### PR TITLE
feat: document quality improvement v5.8.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deep-work",
-  "version": "5.7.0",
+  "version": "5.8.0",
   "description": "Evidence-Driven Development Protocol — auto-flow orchestration with TDD enforcement, slice-based execution, and receipt validation",
   "author": {
     "name": "sungmin"

--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -7,6 +7,32 @@ All notable changes to the Deep Work plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.8.0] - 2026-04-08
+
+### 추가
+- **Completeness Policy** (Section 3.3-1) — plan.md의 명시적 금지 패턴 정의 (TBD, TODO, 모호한 지시, 컨텍스트 없는 교차 참조). Claude 자체 재검토 + structural review `code_completeness` 차원으로 강제.
+- **Code sketch 크기별 완성도** — S: 주석 의사코드, M: 실제 함수 시그니처 + 타입 정의, L: 경계면 완전 코드 (인터페이스, API, 테스트). 기존 "의사코드 또는 실제 코드"를 비례 기준으로 대체.
+- **Slice 필드: `expected_output`, `steps`** — `expected_output`: verification_cmd 성공 시 예상 출력. `steps`: M/L slice 내 실행 가이드 (3-12개 번호 액션). 하위 호환성을 위해 모두 optional.
+- **`failing_test` 크기별 상세도** — S: 파일+설명, M: 함수 시그니처+핵심 assertion, L: 경계면 테스트 완전 본문.
+- **"Boundary: Files NOT to Modify"** 섹션 — plan 템플릿에 추가, 구현 중 scope creep 방지.
+- **Research 추적성 태그** — `[RF-NNN]` (Key Findings), `[RA-NNN]` (인터페이스/시그니처). plan Architecture Decision에서 구체적 연구 근거 참조 가능.
+- **Research 태그 Lifecycle 규칙** — 단조 증가 번호, incremental 보존, plan 참조 태그 삭제 경고.
+- **Research `Testing Patterns` 섹션** — 기존 테스트 프레임워크, assertion 스타일, 파일 명명 규칙 문서화.
+- **Brainstorm 맥락 적응형 질문** — Core 2개 + 맥락별 1-3개 (기능/리팩토링/버그/성능/통합) + 마무리 경계 질문.
+- **Brainstorm `Scope Assessment`** — 분해 점검 + 빠른 코드베이스 확인 후 접근법 비교.
+- **Brainstorm `Boundaries` 섹션** — 변경하지 않는 부분 명시, plan Boundary 섹션으로 전달.
+- **Review gate 차원: `code_completeness`, `buildability`** — 4곳 동기화 (structural 테이블, 하드코딩, cross-model Plan Rubric, JSON 스키마).
+- **Review gate 하위 호환성 fallback** — `expected_output`/`steps` 없는 기존 plan은 차원별 완화 기준으로 평가.
+
+### 변경
+- `deep-implement.md` slice 파서가 `expected_output`, `steps`, `contract`, `acceptance_threshold` 인식 (모두 optional).
+- Step B-1 (RED): `failing_test`에 테스트 코드가 있으면 직접 사용 (M/L).
+- Step B-2 (GREEN): `expected_output`이 있으면 verification_cmd 출력과 비교.
+- `deep-work.md` 인라인 plan: `failing_test` 표현 변경 + Completeness Policy 제외 주석.
+- `research-guide.md` quality criteria 4→8개 확장.
+- `plan-templates.md` API Endpoint 템플릿을 v5.8 exemplar로 업그레이드. 레거시 템플릿에 마이그레이션 가이드 추가.
+- `testability` 차원: `expected_output`은 권장, 필수 아님으로 명확화.
+
 ## [5.7.0] - 2026-04-08
 
 ### 추가

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ All notable changes to the Deep Work plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.8.0] - 2026-04-08
+
+### Added
+- **Completeness Policy** (Section 3.3-1) — explicit banned patterns for plan.md (TBD, TODO, vague directives, cross-references without content). Enforced via Claude self-review + structural review `code_completeness` dimension.
+- **Code sketch tiering** — S: annotated pseudocode, M: actual function signatures + type definitions, L: complete boundary code (interfaces, APIs, tests). Replaces "pseudocode or actual code" with proportional standard.
+- **Slice fields: `expected_output`, `steps`** — `expected_output` defines what `verification_cmd` should print on success. `steps` provides execution guidance within M/L slices (3-12 numbered actions). Both optional for backward compatibility.
+- **`failing_test` detail tiers** — S: file + description, M: function signature + key assertion, L: complete test body for boundary tests.
+- **"Boundary: Files NOT to Modify"** section in plan templates — prevents scope creep during implementation.
+- **Research traceability tags** — `[RF-NNN]` for Key Findings, `[RA-NNN]` for interfaces/signatures. Tags enable plan Architecture Decision to reference specific research evidence.
+- **Research Tag Lifecycle Rules** — monotonic numbering, incremental preservation, deletion warnings for plan-referenced tags.
+- **Research `Testing Patterns` section** — documents existing test framework, assertion style, file naming for plan test specification.
+- **Brainstorm context-adaptive questions** — core 2 + context-adaptive 1-3 (by task type: feature/refactoring/bug/performance/integration) + closing boundary question.
+- **Brainstorm `Scope Assessment`** — decomposition check + quick codebase pulse before approach comparison.
+- **Brainstorm `Boundaries` section** — documents what explicitly stays unchanged, feeds into plan Boundary section.
+- **Review gate dimensions: `code_completeness`, `buildability`** — synchronized across 4 locations (structural table, hardcoded dimensions, cross-model Plan Rubric, JSON schema).
+- **Review gate backward compatibility fallback** — legacy plans without `expected_output`/`steps` evaluated with relaxed criteria per dimension.
+
+### Changed
+- `deep-implement.md` slice parser now recognizes `expected_output`, `steps`, `contract`, `acceptance_threshold` fields (all optional for backward compatibility).
+- Step B-1 (RED) uses test code from `failing_test` field when available (M/L slices).
+- Step B-2 (GREEN) compares `verification_cmd` output against `expected_output` when available.
+- `deep-work.md` inline plan template updated: `failing_test: [to be determined during implementation]` → `[구현 시 결정 — inline mode]` with Completeness Policy exemption comment.
+- `research-guide.md` quality criteria expanded from 4 to 8 items (RF/RA tags, code snippets per section, test patterns).
+- `plan-templates.md` API Endpoint template upgraded to v5.8 exemplar with full slice format. Legacy templates marked with migration guide.
+- `testability` dimension description clarified: `expected_output` is recommended, not required.
+
 ## [5.7.0] - 2026-04-08
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# deep-work v5.7.0
+# deep-work v5.8.0
 
 Evidence-Driven Development Protocol — `/deep-work "task"` 하나로 Brainstorm → Research → Plan → Implement → Test 전체 워크플로우를 자동 진행하는 Claude Code 플러그인.
 

--- a/commands/deep-brainstorm.md
+++ b/commands/deep-brainstorm.md
@@ -56,10 +56,42 @@ Engage the user in a structured design conversation:
 먼저 문제를 정확히 이해하겠습니다.
 ```
 
-Ask the user (one at a time):
+Ask the user 3-5 questions (one at a time). Start with core questions, then add context-appropriate ones:
+
+**Core questions (always ask):**
 1. **이 기능/변경의 핵심 목표는 무엇인가요?** (단순히 "무엇"이 아니라 "왜")
-2. **이 변경이 없으면 어떤 문제가 계속되나요?** (pain point 구체화)
-3. **성공하면 어떻게 보이나요?** (성공 기준)
+2. **성공하면 어떻게 보이나요?** (측정 가능한 성공 기준)
+
+**Context-adaptive questions (choose 1-3 based on the task):**
+- For user-facing features: **누가 이 기능을 사용하나요? 어떤 시나리오에서?**
+- For refactoring: **현재 코드의 가장 큰 문제점은 무엇인가요?**
+- For bug fixes: **이 문제가 발생하는 정확한 조건은? 재현 단계는?**
+- For performance: **현재 성능 수치는? 목표 수치는?**
+- For integration: **연동 대상의 API 문서나 제약사항이 있나요?**
+
+**Always close with:**
+- **이 변경에서 절대 건드리면 안 되는 부분이 있나요?** (Boundaries — feeds into plan's "Files NOT to Modify")
+
+#### 2a-bis. Scope Assessment
+
+Before proposing approaches, evaluate scope:
+
+1. **Decomposition check**: Does this task describe multiple independent subsystems? If so:
+   ```
+   이 작업은 여러 독립적인 하위 시스템을 포함합니다:
+   - [subsystem 1]
+   - [subsystem 2]
+   각각 별도의 deep-work 세션으로 분리하는 것을 권장합니다.
+   먼저 [subsystem]부터 진행할까요?
+   ```
+
+2. **Quick codebase pulse**: Read 2-3 key files related to the task to ground the conversation in reality. This is NOT full research — just enough to avoid proposing approaches that conflict with the existing architecture.
+   ```
+   빠른 코드베이스 확인:
+   - [file1]: [1줄 요약]
+   - [file2]: [1줄 요약]
+   이 컨텍스트를 바탕으로 접근법을 제안합니다.
+   ```
 
 #### 2b. Approach Comparison
 
@@ -126,6 +158,10 @@ Write `$WORK_DIR/brainstorm.md`:
 ## 엣지 케이스 & 리스크
 - [edge case 1]
 - [edge case 2]
+
+## 변경하지 않는 부분 (Boundaries)
+- [기존 기능/파일/인터페이스 that explicitly stays unchanged]
+- [Integration point that must remain backward-compatible]
 
 ## 다음 단계
 Research 단계에서 코드베이스를 분석하여 이 접근 방식의 실현 가능성을 검증합니다.

--- a/commands/deep-implement.md
+++ b/commands/deep-implement.md
@@ -48,11 +48,15 @@ Read `$WORK_DIR/plan.md` and parse the **Slice Checklist** section. Each slice h
   - files: [file1, file2]
   - failing_test: [test file — test description]
   - verification_cmd: [command to verify]
+  - expected_output: [optional — what success looks like]
   - spec_checklist: [req1, req2]
+  - contract: [criterion1, criterion2]
+  - acceptance_threshold: all
   - size: S/M/L
+  - steps: [optional — execution guidance for M/L slices]
 ```
 
-Build a list of slices with their metadata.
+Build a list of slices with their metadata. New fields (`expected_output`, `steps`) are optional for backward compatibility with older plan formats.
 
 **Inline slice handling (v5.1)**: If the plan was generated inline (state file `skipped_phases` includes "plan"):
 - The plan will have a single SLICE-001 with potentially empty `failing_test`
@@ -155,10 +159,11 @@ For each unchecked slice (`- [ ]`), execute the following cycle:
 
 #### B-1. RED: Write Failing Test
 
-1. Read the slice's `failing_test` field
-2. Create or update the test file with a test that should FAIL
-3. Run the test: execute `verification_cmd`
-4. **Verify it fails for the RIGHT reason** (feature missing, not syntax error)
+1. Read the slice's `failing_test` field. If it contains actual test code (M/L slices may include function signatures or complete test bodies), use that code directly instead of writing from scratch.
+2. If the slice has a `steps` field, follow the step sequence — but the TDD state machine (RED→GREEN→REFACTOR) always takes precedence over step ordering.
+3. Create or update the test file with a test that should FAIL
+4. Run the test: execute `verification_cmd`
+5. **Verify it fails for the RIGHT reason** (feature missing, not syntax error)
 5. Capture the failing test output (last 200 lines)
 6. **[필수] State file 업데이트**: `tdd_state: RED_VERIFIED`
    ⚠️ 이 업데이트를 수행하지 않으면 phase guard가 이후 모든 production 코드 편집을 차단한다.
@@ -183,7 +188,7 @@ For each unchecked slice (`- [ ]`), execute the following cycle:
 1. Implement the change — **minimal code to pass the test**
 2. Only modify files listed in the slice's `files` field
 3. Run `verification_cmd` again
-4. **Verify ALL tests pass** (not just the new one)
+4. **Verify ALL tests pass** (not just the new one). If the slice has an `expected_output` field, compare the actual output against it to confirm the tests pass for the right reason (not a false positive).
 5. Capture passing test output
 6. **[필수] State file 업데이트**: `tdd_state: GREEN`
    ⚠️ 이 업데이트를 수행하지 않으면 다음 slice 시작 시 phase guard가 차단한다.

--- a/commands/deep-plan.md
+++ b/commands/deep-plan.md
@@ -388,7 +388,7 @@ The following patterns are **plan failures** — they must never appear in a fin
 - `Add appropriate error handling` / `add validation` / `handle edge cases` (without specifying which cases)
 - `Write tests for the above` (without actual test descriptions or code)
 - `Similar to SLICE-N` (repeat the relevant details — the implementing agent may execute slices out of order or in isolation)
-- Steps that describe *what* to do without showing *how* (code blocks required for any step that changes code, per the Code sketch tiering rules)
+- In **Files to Modify** section: changes that describe *what* to do without showing *how* (code blocks required per the Code sketch tiering rules). Note: this applies to the `Code sketch` field, NOT to slice `steps` — steps are concise execution guidance and do not require inline code blocks.
 - Empty sections or sections containing only headers
 - `...` or `[etc.]` as substitutes for actual content
 - References to types, functions, or methods not defined elsewhere in the plan or existing codebase

--- a/commands/deep-plan.md
+++ b/commands/deep-plan.md
@@ -177,22 +177,46 @@ The slice format replaces the previous `- [ ] Task N:` checklist format.
 Brief description of what will be implemented and the approach chosen.
 
 ## Architecture Decision
-Why this approach was chosen over alternatives. Reference research findings.
+Why this approach was chosen over alternatives.
+**Research 근거:** [RF-NNN], [RA-NNN] 태그로 연결. 근거 없는 결정은 assumption으로 표기.
 
 ## Files to Modify
 
 ### [File path 1]
 - **Action**: Create / Modify / Delete
 - **Changes**: Detailed description
-- **Code sketch**:
+- **Code sketch** (completeness tiered by slice size):
+  - **S slices**: Annotated pseudocode — describe the change with enough detail that the approach is unambiguous.
+  - **M slices**: Key function signatures and type definitions must be actual code. Logic flow can be pseudocode with inline comments.
+  - **L slices**: Boundary code (interfaces, public API, type definitions, tests) must be complete, copy-pasteable code. Repetitive internal implementations can use annotated diff/skeleton. For modifications, show before/after diff with line references.
   ```language
-  // Pseudocode or actual code snippet showing the change
+  // Example for M slice:
+  // ACTUAL — function signature and types
+  export async function authenticate(credentials: LoginCredentials): Promise<AuthResult> {
+    // PSEUDOCODE — logic flow
+    // 1. Validate input (email format, password non-empty)
+    // 2. Query user by email from UserRepository
+    // 3. Compare password hash using bcrypt
+    // 4. If match: generate JWT token, return { token, user }
+    // 5. If no match: throw AuthenticationError("invalid_credentials")
+  }
   ```
+- **Line references** (for Modify actions): Specify as `filename:startLine-endLine` or anchor to a named function/class.
 - **Reason**: Why this change is needed
 - **Risk**: Low / Medium / High — explanation
 
 ### [File path 2]
 ...
+
+## Boundary: Files NOT to Modify
+
+List files that might seem related but must NOT be changed in this task.
+
+| File | Reason to leave unchanged |
+|------|--------------------------|
+| [file] | [reason] |
+
+> If you discover during implementation that one of these files must change, STOP and document it as an Open Question. Do not modify without plan amendment.
 
 ## Execution Order
 1. First: [file/change] — because [reason]
@@ -222,25 +246,54 @@ Each slice is a self-contained unit of work with its own TDD cycle and receipt.
   - files: [file1, file2]
   - failing_test: [test file — test description]
   - verification_cmd: [command to verify]
+  - expected_output: [what success looks like, e.g., "Tests: 5 passed, 0 failed"]
   - spec_checklist: [requirement 1, requirement 2]
   - contract: [testable criterion 1, testable criterion 2]
   - acceptance_threshold: all
   - size: S/M/L
+  - steps: (required for M/L, optional for S)
+    1. [Write failing test: test_name in test_file — assert specific_behavior]
+    2. [Verify RED: run verification_cmd, expect failure message]
+    3. [Implement: create/modify file — specific change with code reference]
+    4. [Verify GREEN: run verification_cmd, expect all pass]
+    5. [Commit: descriptive message]
 
 - [ ] SLICE-002: [Goal]
   - files: [file1, file2]
   - failing_test: [test file — test description]
   - verification_cmd: [command to verify]
+  - expected_output: [성공 시 예상 출력]
   - spec_checklist: [requirement 1, requirement 2]
   - contract: [testable criterion 1, testable criterion 2]
   - acceptance_threshold: all
   - size: S/M/L
+  - steps: (required for M/L, optional for S)
+    1. ...
 
 ...
 
 ## Open Questions
 - Any unresolved decisions for the user to weigh in on
 ```
+
+**Slice field guidelines:**
+
+`expected_output`: What the `verification_cmd` should print when passing. Without this, the implementing agent cannot distinguish "tests pass" from "tests pass for the wrong reason."
+
+`steps`: Each step is one action. Steps are execution guidance, NOT receipt/TDD tracking units — the slice remains the atomic unit. Steps are required for M/L slices, optional for S.
+- **S slices**: Steps optional. Goal + files + failing_test provide enough direction.
+- **M slices**: 3-7 steps recommended. Each step completable in 2-10 minutes.
+- **L slices**: 5-12 steps required. Consider splitting into smaller slices if steps exceed 12.
+
+`failing_test` detail by slice size:
+- **S**: `failing_test: tests/auth.test.ts — "rejects empty email"` (file + description)
+- **M**: Include test function signature and key assertion:
+  ```
+  failing_test: tests/auth.test.ts — test('rejects empty email', () => {
+    expect(submitForm({email: ''})).toHaveProperty('error', 'Email required')
+  })
+  ```
+- **L**: Boundary tests include complete function body; repetitive internal tests use signature + assertion.
 
 **For zero-base projects (`project_type: zero-base`):**
 
@@ -260,6 +313,7 @@ Each slice is a self-contained unit of work with its own TDD cycle and receipt.
 
 ## Architecture Decision
 [Why this stack and architecture]
+**Research 근거:** [RF-NNN], [RA-NNN] 태그로 연결. 근거 없는 결정은 assumption으로 표기.
 
 ## Project Structure
 [전체 디렉토리 구조 트리]
@@ -269,8 +323,16 @@ Each slice is a self-contained unit of work with its own TDD cycle and receipt.
 ### [File path]
 - **Action**: Create
 - **Purpose**: [이 파일의 역할]
-- **Code sketch**: [코드 스니펫]
+- **Code sketch** (completeness tiered by slice size — same rules as existing codebase template):
+  - S: annotated pseudocode, M: actual signatures + pseudocode logic, L: boundary code complete
+  [코드 스니펫]
 - **Dependencies**: [이 파일이 의존하는 다른 파일]
+
+## Boundary: Files NOT to Modify
+
+| File | Reason to leave unchanged |
+|------|--------------------------|
+| [file] | [reason] |
 
 ## Setup Instructions
 [프로젝트 초기화 명령어 목록]
@@ -284,10 +346,13 @@ Each slice is a self-contained unit of work with its own TDD cycle and receipt.
   - files: [file1, file2]
   - failing_test: [test file — test description]
   - verification_cmd: [command to verify]
+  - expected_output: [성공 시 예상 출력]
   - spec_checklist: [requirement 1]
   - contract: [testable criterion 1, testable criterion 2]
   - acceptance_threshold: all
   - size: S/M/L
+  - steps: (required for M/L, optional for S)
+    1. ...
 
 ...
 
@@ -313,6 +378,22 @@ Each slice is a self-contained unit of work with its own TDD cycle and receipt.
 - `contract`: Testable input→output pairs defining "done" precisely. Each item should be verifiable (e.g., "POST /login → 200 + { token: string }"). Required for M/L/XL slices. Optional for S-size slices.
 - `acceptance_threshold`: `all` (every contract item must pass, default) or `majority` (for exploratory work).
 - `spec_checklist` remains for high-level requirements. `contract` supplements it with precise verification criteria.
+
+### 3.3-1. Completeness Policy (v5.8)
+
+The following patterns are **plan failures** — they must never appear in a finalized plan.md:
+
+**Banned patterns:**
+- `TBD`, `TODO`, `FIXME`, `PLACEHOLDER`, `implement later`, `fill in details`
+- `Add appropriate error handling` / `add validation` / `handle edge cases` (without specifying which cases)
+- `Write tests for the above` (without actual test descriptions or code)
+- `Similar to SLICE-N` (repeat the relevant details — the implementing agent may execute slices out of order or in isolation)
+- Steps that describe *what* to do without showing *how* (code blocks required for any step that changes code, per the Code sketch tiering rules)
+- Empty sections or sections containing only headers
+- `...` or `[etc.]` as substitutes for actual content
+- References to types, functions, or methods not defined elsewhere in the plan or existing codebase
+
+**Enforcement:** The Claude self-review step (Section 3.4.5) scans for these patterns and auto-fixes them before structural review. The structural review dimension `code_completeness` penalizes remaining placeholders. If a placeholder cannot be filled due to insufficient information, move the item to **Open Questions** rather than leaving a banned pattern.
 
 ### 3.4. Contract Negotiation (v5.1)
 
@@ -349,7 +430,14 @@ plan.md 작성 및 contract negotiation 완료 직후, subagent에게 넘기기 
 
 **점검 항목:**
 
-1. **Placeholder 스캔**: plan.md에서 "TBD", "TODO", 빈 섹션, 미완성 코드 스케치를 탐색. 발견 시 해당 내용을 구체적으로 채운다.
+1. **Placeholder 스캔**: plan.md에서 Completeness Policy (Section 3.3-1)의 전체 banned pattern 목록을 탐색:
+   - `TBD`, `TODO`, `FIXME`, `PLACEHOLDER`, `implement later`, `fill in details`
+   - Vague directives: `Add appropriate...`, `handle edge cases`, `Write tests for the above`
+   - Cross-references without content: `Similar to SLICE-N`
+   - Empty sections, sections with only headers, `...` or `[etc.]`
+   - Code steps without code blocks (for M/L slices per Code sketch tiering)
+   - References to undefined types/functions
+   발견 시 해당 내용을 구체적으로 채운다. 채울 수 없는 경우 (정보 부족), 해당 항목을 Open Questions로 이동하고 사용자에게 알린다.
 
 2. **내부 일관성**: Slice Checklist의 `files` 목록과 "Files to Modify" 섹션의 파일 목록을 비교. 불일치 시 수정. Execution Order와 Slice 순서가 충돌하는지 확인.
 
@@ -401,7 +489,7 @@ Read `evaluator_model` from state file (default: "sonnet").
 Follow the **Structural Review Protocol** with these settings:
 - **Phase**: plan
 - **Document**: `$WORK_DIR/plan.md`
-- **Dimensions**: architecture_fit, slice_executability, testability, rollback_completeness, risk_coverage
+- **Dimensions**: architecture_fit, slice_executability, testability, code_completeness, buildability, rollback_completeness, risk_coverage
 - **Output**: `$WORK_DIR/plan-review.json` + `$WORK_DIR/plan-review.md`
 - **Model**: evaluator_model from state (default: "sonnet")
 - **Max iterations**: 2

--- a/commands/deep-research.md
+++ b/commands/deep-research.md
@@ -216,6 +216,10 @@ Write all findings to `$WORK_DIR/research.md` with the following structure:
 ## 1. Technology Stack & Architecture
 [Detailed analysis, with at least one code snippet or reference example]
 
+### Key Interfaces & Signatures (for Plan reference)
+<!-- Plan이 참조할 핵심 아티팩트에 [RA-NNN] 태그 부여 — zero-base에서는 선택한 프레임워크/라이브러리의 핵심 API -->
+- [RA-001] `[Framework/Library core API]` — [documentation reference]
+
 ## 2. Coding Conventions & Standards
 [Detailed analysis]
 

--- a/commands/deep-research.md
+++ b/commands/deep-research.md
@@ -203,10 +203,10 @@ Write all findings to `$WORK_DIR/research.md` with the following structure:
      알아야 할 가장 중요한 사항을 먼저 기술한다. -->
 
 ## Key Findings
-<!-- 불릿 리스트로 주요 발견사항 나열. 각 항목은 한 줄로. -->
-- [발견 1]: [한 줄 요약]
-- [발견 2]: [한 줄 요약]
-- [발견 3]: [한 줄 요약]
+<!-- 불릿 리스트로 주요 발견사항 나열. 각 항목은 [RF-NNN] 태그 포함. -->
+- [RF-001] [발견 1]: [한 줄 요약]
+- [RF-002] [발견 2]: [한 줄 요약]
+- [RF-003] [발견 3]: [한 줄 요약]
 
 ## Risk & Blockers
 <!-- 구현을 가로막을 수 있는 위험 요소. 없으면 "없음"으로 기재. -->
@@ -214,16 +214,16 @@ Write all findings to `$WORK_DIR/research.md` with the following structure:
 ---
 
 ## 1. Technology Stack & Architecture
-[Detailed analysis]
+[Detailed analysis, with at least one code snippet or reference example]
 
 ## 2. Coding Conventions & Standards
 [Detailed analysis]
 
 ## 3. Data Model & Storage
-[Detailed analysis]
+[Detailed analysis, with at least one schema draft]
 
 ## 4. API Design & External Services
-[Detailed analysis]
+[Detailed analysis, with at least one API contract example]
 
 ## 5. Project Scaffolding & Build/CI
 [Detailed analysis]
@@ -306,10 +306,10 @@ Write all findings to `$WORK_DIR/research.md` in a structured format. The docume
      알아야 할 가장 중요한 사항을 먼저 기술한다. -->
 
 ## Key Findings
-<!-- 불릿 리스트로 주요 발견사항 나열. 각 항목은 한 줄로. -->
-- [발견 1]: [한 줄 요약]
-- [발견 2]: [한 줄 요약]
-- [발견 3]: [한 줄 요약]
+<!-- 불릿 리스트로 주요 발견사항 나열. 각 항목은 [RF-NNN] 태그 포함. -->
+- [RF-001] [발견 1]: [한 줄 요약]
+- [RF-002] [발견 2]: [한 줄 요약]
+- [RF-003] [발견 3]: [한 줄 요약]
 
 ## Risk & Blockers
 <!-- 구현을 가로막을 수 있는 위험 요소. 없으면 "없음"으로 기재. -->
@@ -319,14 +319,18 @@ Write all findings to `$WORK_DIR/research.md` in a structured format. The docume
 ## 1. Architecture & Structure
 [Detailed breakdown with file paths and code references]
 
+### Key Interfaces & Signatures
+<!-- Plan이 참조할 핵심 아티팩트에 [RA-NNN] 태그 부여 -->
+- [RA-001] `[FunctionName](params): ReturnType` — `src/path/file.ts:line`
+
 ## 2. Relevant Patterns
-[Every pattern the implementation must follow]
+[Every pattern the implementation must follow, with at least one code snippet]
 
 ## 3. Data Layer
-[Data models, migrations, validation]
+[Data models, migrations, validation, with at least one code snippet]
 
 ## 4. API & Integration
-[API structure, auth, external services]
+[API structure, auth, external services, with at least one code snippet]
 
 ## 5. Shared Infrastructure
 [Utilities, config, build setup]
@@ -344,9 +348,18 @@ Write all findings to `$WORK_DIR/research.md` in a structured format. The docume
 ## Constraints
 - [Technical limitation 1]
 - [Convention requirement 2]
+
+## Testing Patterns
+[Existing test framework, assertion style, file naming convention — so plan can specify tests in the project's idiom]
 ```
 
 Then continue to [Step 4: Update state file](#4-update-state-file).
+
+**Research Tag Lifecycle Rules (v5.8):**
+- Tag numbers are monotonically increasing within a document (RF-001, RF-002, ...; RA-001, RA-002, ...)
+- **Incremental research** (`--scope`, `--incremental`): Preserve existing tags, add new ones starting after the highest existing number
+- **Tag deletion**: Before removing a tagged finding, check if `plan.md` references it. If referenced, display a warning before removal.
+- **Merge/dedup**: When merging duplicate findings, keep the representative tag and add a redirect comment to the merged one: `<!-- → RF-NNN 통합 -->`
 
 ---
 
@@ -421,9 +434,10 @@ Read all 3 partial result files and synthesize into a single `$WORK_DIR/research
 <!-- 3-5줄. 세 분석가의 결과를 종합한 핵심 결론. -->
 
 ## Key Findings
-- [발견 1]: [한 줄 요약]
-- [발견 2]: [한 줄 요약]
-- [발견 3]: [한 줄 요약]
+<!-- [RF-NNN] 태그 포함. 세 분석가의 결과 종합. -->
+- [RF-001] [발견 1]: [한 줄 요약]
+- [RF-002] [발견 2]: [한 줄 요약]
+- [RF-003] [발견 3]: [한 줄 요약]
 
 ## Risk & Blockers
 <!-- 종합된 위험 요소. -->
@@ -607,3 +621,7 @@ Before marking research as complete, verify:
 - [ ] Potential conflicts and risks are identified
 - [ ] The document is detailed enough for someone unfamiliar with the codebase to understand the relevant parts
 - [ ] Executive Summary and Key Findings are at the top of the document
+- [ ] Key findings have [RF-NNN] tags for plan traceability
+- [ ] Function signatures and type definitions for plan-relevant interfaces are captured with [RA-NNN] tags
+- [ ] Each detailed analysis section (1-6) includes at least one code snippet
+- [ ] Existing test patterns (framework, assertion style, file naming) are documented

--- a/commands/deep-work.md
+++ b/commands/deep-work.md
@@ -724,12 +724,13 @@ slices:
 4. Write the inline slice to `$WORK_DIR/plan.md` as a minimal plan:
    ```markdown
    # Implementation Plan: $ARGUMENTS (Inline)
+   <!-- inline mode: Completeness Policy 적용 제외. 상세 plan은 /deep-plan 사용 -->
 
    ## Slice Checklist
 
    - [ ] SLICE-001: $ARGUMENTS
      - files: [user-provided files]
-     - failing_test: [to be determined during implementation]
+     - failing_test: [구현 시 결정 — inline mode]
      - verification_cmd: [user-provided command]
      - spec_checklist: [$ARGUMENTS]
      - contract: []

--- a/skills/deep-work-workflow/SKILL.md
+++ b/skills/deep-work-workflow/SKILL.md
@@ -142,6 +142,9 @@ For detailed guidance, see [Research Guide](references/research-guide.md) or [Ze
 - Transform research findings into a concrete action plan
 - **Plan Summary at the top** with approach, scope, risk level, and key decisions
 - Define exact files to modify, code snippets, execution order
+- **Code completeness tiered by slice size**: S=pseudocode OK, M=signatures+types actual code, L=boundary code complete (interfaces, APIs, tests)
+- **No placeholders**: Plan must pass the Completeness Policy — no TBD, TODO, or vague directives
+- **Research traceability**: Architecture decisions reference tagged research findings [RF-NNN], [RA-NNN]
 - Create a checklist-style task list in `$WORK_DIR/plan.md`
 
 **What's blocked**: All code file modifications (enforced by hook)

--- a/skills/deep-work-workflow/SKILL.md
+++ b/skills/deep-work-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deep-work-workflow
-version: "5.6.0"
+version: "5.8.0"
 description: |
   Evidence-driven development protocol with auto-flow orchestration.
   Use when: "deep work", "plan before code", "TDD", "evidence-driven",

--- a/skills/deep-work-workflow/references/plan-templates.md
+++ b/skills/deep-work-workflow/references/plan-templates.md
@@ -21,7 +21,7 @@ When using a template:
   - files: [src/routes/resource.ts, src/types/resource.ts]
   - failing_test: tests/routes/resource.test.ts — "POST /resource returns 201 with valid input"
   - verification_cmd: npm test -- --grep "resource"
-  - expected_output: "Tests: N passed, 0 failed"
+  - expected_output: "all tests passed, 0 failed"
   - spec_checklist: [Route registered, DTO types defined, validation schema created]
   - contract: [POST /resource with valid body → 201 + {id: string}, POST /resource with missing field → 400 + {error: string}]
   - acceptance_threshold: all
@@ -37,7 +37,7 @@ When using a template:
   - files: [src/services/resource.ts, src/repositories/resource.ts]
   - failing_test: tests/services/resource.test.ts — "creates resource with valid data"
   - verification_cmd: npm test -- --grep "resource"
-  - expected_output: "Tests: N passed, 0 failed"
+  - expected_output: "all tests passed, 0 failed"
   - spec_checklist: [Service method exists, Repository query works, Error cases handled]
   - contract: [createResource(validData) → {id, ...data}, createResource(duplicateKey) → throws ConflictError]
   - acceptance_threshold: all
@@ -50,6 +50,10 @@ When using a template:
   - spec_checklist: [Auth required on route, 401 for missing token, 403 for insufficient role]
   - size: S
 ```
+
+---
+
+> **Legacy templates below**: The following templates use the old `Task Checklist` format. When using them, convert each `Task N:` into a `SLICE-NNN:` entry with `files`, `failing_test`, `verification_cmd`, `expected_output`, `spec_checklist`, `contract`, `size`, and `steps` (for M/L). See the API Endpoint exemplar above for the target format.
 
 ## UI Component Addition
 

--- a/skills/deep-work-workflow/references/plan-templates.md
+++ b/skills/deep-work-workflow/references/plan-templates.md
@@ -2,17 +2,53 @@
 
 Pre-defined plan structures for common task types. These serve as starting skeletons — adapt and expand as needed.
 
+## Template Usage
+
+When using a template:
+1. Replace each task with a `SLICE-NNN:` entry in slice format (files, failing_test, verification_cmd, expected_output, steps, etc.)
+2. Add concrete file paths, code sketches, and failing_test specifications per slice
+3. Follow the Completeness Policy (Section 3.3-1 of deep-plan.md) — no placeholders
+4. Templates are starting points, not ceilings — add or remove slices as needed
+
 ## API Endpoint Addition
 
+**Exemplar** (showing full slice format):
+
 ```markdown
-## Task Checklist
-- [ ] Task 1: Route definition — Add route in router/controller
-- [ ] Task 2: Controller/Handler — Implement request handling logic
-- [ ] Task 3: Request/Response DTO — Define input/output types
-- [ ] Task 4: Validation rules — Add input validation
-- [ ] Task 5: Middleware setup — Configure auth, rate limiting, etc.
-- [ ] Task 6: Unit tests — Test handler logic in isolation
-- [ ] Task 7: Integration tests — Test full request/response cycle
+## Slice Checklist
+
+- [ ] SLICE-001: Route definition and request/response types
+  - files: [src/routes/resource.ts, src/types/resource.ts]
+  - failing_test: tests/routes/resource.test.ts — "POST /resource returns 201 with valid input"
+  - verification_cmd: npm test -- --grep "resource"
+  - expected_output: "Tests: N passed, 0 failed"
+  - spec_checklist: [Route registered, DTO types defined, validation schema created]
+  - contract: [POST /resource with valid body → 201 + {id: string}, POST /resource with missing field → 400 + {error: string}]
+  - acceptance_threshold: all
+  - size: M
+  - steps:
+    1. Define request/response DTOs in types file
+    2. Write failing integration test for the happy path
+    3. Register route in router with handler stub
+    4. Implement handler with validation
+    5. Verify GREEN
+
+- [ ] SLICE-002: Business logic and data access
+  - files: [src/services/resource.ts, src/repositories/resource.ts]
+  - failing_test: tests/services/resource.test.ts — "creates resource with valid data"
+  - verification_cmd: npm test -- --grep "resource"
+  - expected_output: "Tests: N passed, 0 failed"
+  - spec_checklist: [Service method exists, Repository query works, Error cases handled]
+  - contract: [createResource(validData) → {id, ...data}, createResource(duplicateKey) → throws ConflictError]
+  - acceptance_threshold: all
+  - size: M
+
+- [ ] SLICE-003: Auth middleware and error integration
+  - files: [src/routes/resource.ts]
+  - failing_test: tests/routes/resource.test.ts — "rejects unauthenticated request with 401"
+  - verification_cmd: npm test -- --grep "resource"
+  - spec_checklist: [Auth required on route, 401 for missing token, 403 for insufficient role]
+  - size: S
 ```
 
 ## UI Component Addition

--- a/skills/deep-work-workflow/references/research-guide.md
+++ b/skills/deep-work-workflow/references/research-guide.md
@@ -116,8 +116,12 @@ For zero-base projects, see [Zero-Base Guide](zero-base-guide.md).
 A good research document:
 - Contains specific file paths, not vague descriptions
 - Shows concrete code examples, not abstract patterns
-- Identifies non-obvious constraints
+- Captures function signatures and type definitions for all interfaces the plan will touch (tagged as [RA-NNN])
+- Tags key findings with [RF-NNN] identifiers for plan cross-reference
+- Identifies non-obvious constraints with specific evidence (file path + line number)
+- Includes at least one code snippet per detailed analysis section (Sections 1-6)
 - Is detailed enough for the planning phase to be purely synthetic (no new research needed)
+- Documents existing test patterns (test framework, assertion style, file naming convention) so plan can specify tests in the project's idiom
 
 ## Incremental Research (v3.1.0)
 

--- a/skills/deep-work-workflow/references/review-gate.md
+++ b/skills/deep-work-workflow/references/review-gate.md
@@ -128,13 +128,17 @@ Auto-fix 루프에서 문서를 수정할 때 반드시 따라야 하는 안전 
 |-----------|------|
 | `architecture_fit` | 기존 코드베이스의 아키텍처/패턴과 일관성 있는가? |
 | `slice_executability` | 각 slice가 독립적으로 실행 가능하고 구체적인가? |
-| `testability` | 각 slice에 failing_test와 verification_cmd(+expected_output)가 있는가? |
+| `testability` | 각 slice에 failing_test와 verification_cmd가 있는가? (expected_output은 권장) |
 | `code_completeness` | Code sketch가 Completeness Policy를 충족하는가? (placeholder 부재, 크기별 코드 완성도) |
 | `buildability` | 코드베이스에 익숙하지 않은 엔지니어가 이 plan만 보고 구현할 수 있는가? |
 | `rollback_completeness` | 롤백 전략이 구체적이고 실행 가능한가? |
 | `risk_coverage` | 리스크가 식별되고 완화 방안이 있는가? |
 
-**하위 호환성 (v5.8)**: plan.md에 `steps` 또는 `expected_output` 필드가 없는 경우 (기존 형식), `code_completeness`는 기존 기준(Code sketch 존재 여부 + placeholder 부재)으로 평가하고, `buildability`는 기존 `slice_executability`와 동일 기준으로 fallback한다. 인라인 plan(`skipped_phases` includes "plan")은 structural review 자체를 skip한다.
+**하위 호환성 (v5.8)**: plan.md에 `steps` 또는 `expected_output` 필드가 없는 경우 (기존 형식):
+- `code_completeness`는 기존 기준(Code sketch 존재 여부 + placeholder 부재)으로 평가
+- `buildability`는 기존 `slice_executability`와 동일 기준으로 fallback
+- `testability`는 `failing_test` + `verification_cmd` 존재만으로 평가 (`expected_output` 부재는 감점하지 않음)
+- 인라인 plan(`skipped_phases` includes "plan")은 structural review 자체를 skip
 
 ---
 

--- a/skills/deep-work-workflow/references/review-gate.md
+++ b/skills/deep-work-workflow/references/review-gate.md
@@ -128,9 +128,13 @@ Auto-fix 루프에서 문서를 수정할 때 반드시 따라야 하는 안전 
 |-----------|------|
 | `architecture_fit` | 기존 코드베이스의 아키텍처/패턴과 일관성 있는가? |
 | `slice_executability` | 각 slice가 독립적으로 실행 가능하고 구체적인가? |
-| `testability` | 각 slice에 failing_test와 verification_cmd가 있는가? |
+| `testability` | 각 slice에 failing_test와 verification_cmd(+expected_output)가 있는가? |
+| `code_completeness` | Code sketch가 Completeness Policy를 충족하는가? (placeholder 부재, 크기별 코드 완성도) |
+| `buildability` | 코드베이스에 익숙하지 않은 엔지니어가 이 plan만 보고 구현할 수 있는가? |
 | `rollback_completeness` | 롤백 전략이 구체적이고 실행 가능한가? |
 | `risk_coverage` | 리스크가 식별되고 완화 방안이 있는가? |
+
+**하위 호환성 (v5.8)**: plan.md에 `steps` 또는 `expected_output` 필드가 없는 경우 (기존 형식), `code_completeness`는 기존 기준(Code sketch 존재 여부 + placeholder 부재)으로 평가하고, `buildability`는 기존 `slice_executability`와 동일 기준으로 fallback한다. 인라인 plan(`skipped_phases` includes "plan")은 structural review 자체를 skip한다.
 
 ---
 
@@ -184,6 +188,8 @@ Plan phase에서 각 모델에 제공하는 rubric:
 | `architecture_fit` | 기존 아키텍처/패턴과의 일관성 |
 | `assumption_validity` | plan의 가정이 유효한가 |
 | `slice_executability` | 각 slice가 독립 실행 가능한가 |
+| `code_completeness` | Code sketch가 Completeness Policy를 충족하는가 |
+| `buildability` | 이 plan만으로 구현이 가능한가 (막히는 부분 없이) |
 | `risk_coverage` | 리스크와 완화 방안이 충분한가 |
 | `alternative_consideration` | 대안이 충분히 검토되었는가 |
 
@@ -208,7 +214,7 @@ Phase에 따라 적절한 rubric의 dimensions를 사용한다:
 - `research` → Research Rubric의 5개 dimension
 
 **Note:** `dimensions` 객체의 키는 현재 phase의 rubric에 맞춰야 한다.
-- Plan: `architecture_fit`, `assumption_validity`, `slice_executability`, `risk_coverage`, `alternative_consideration`
+- Plan: `architecture_fit`, `assumption_validity`, `slice_executability`, `code_completeness`, `buildability`, `risk_coverage`, `alternative_consideration`
 - Research: `completeness`, `accuracy`, `relevance`, `risk_identification`, `actionability`
 
 각 모델에 다음을 지시한다:
@@ -222,6 +228,8 @@ Output ONLY valid JSON in this schema:
     "architecture_fit": <score>,
     "assumption_validity": <score>,
     "slice_executability": <score>,
+    "code_completeness": <score>,
+    "buildability": <score>,
     "risk_coverage": <score>,
     "alternative_consideration": <score>
   },


### PR DESCRIPTION
## Summary

superpowers 플러그인과의 비교 분석을 기반으로 deep-work의 전 Phase 문서 품질을 개선합니다. 핵심 문제: deep-work은 "무엇을(What)" 잘 정의하지만, "어떻게(How)"의 정밀도가 부족 → 구현 에이전트가 코드를 재해석해야 하는 상황 해소.

### Phase 1: Plan 코드 완성도
- **Completeness Policy** (Section 3.3-1) — TBD/TODO/vague 패턴 명시적 금지
- **Code sketch tiering** — S: 의사코드, M: 시그니처+타입, L: 경계면 완전 코드
- **Slice 확장** — `expected_output`, `steps` 필드 추가 (기존+zero-base 양쪽)
- **`deep-implement.md`** slice 파서 동기화 + B-1/B-2 안내 강화
- **`deep-work.md`** 인라인 plan Completeness Policy 제외 처리

### Phase 2: Research → Plan 추적성
- **[RF-NNN] / [RA-NNN] 태그** — Solo/Zero-base/Team 3곳 + lifecycle 규칙
- **Quality criteria** 4→8개 확장 (research-guide.md + 인라인 체크리스트)

### Phase 3: Brainstorm 유연성
- **맥락 적응형 질문** — Core 2 + 맥락별 1-3 + 마무리 경계 질문
- **Scope Assessment** + **Boundaries** 섹션

### Phase 4: Review Gate 강화
- **code_completeness + buildability** — 4곳 원자적 동기화 + fallback 규칙
- **plan-templates.md** API exemplar + 레거시 마이그레이션 가이드

### 리뷰 피드백 반영
Opus, Codex Rescue, Codex Adversarial 3회 리뷰를 거쳐 다음 이슈 해결:
- `deep-implement.md` 누락 → 소비자 동기화
- Zero-base 템플릿 미반영 → 양쪽 동일 적용
- Review dimension 미연결 → 4곳 원자적 수정
- testability fallback 누락 → expected_output 부재 시 감점하지 않음
- steps vs Completeness Policy 충돌 → 역할 분리 명확화

## Test plan

- [x] 252개 기존 테스트 전체 통과 (`node --test hooks/scripts/*.test.js`)
- [x] Slice 스키마 생산자-소비자 동기화 검증
- [x] Review dimension 4곳 일치 검증
- [x] RF/RA 태그 3곳 적용 검증
- [ ] 수정된 `/deep-plan`으로 실제 plan 생성하여 새 필드 포함 확인
- [ ] 기존 형식 plan.md로 structural review 실행하여 fallback 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)