### PR TITLE
feat(artifact): adopt M3 cross-plugin envelope for session-receipt + slice-receipt

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deep-work",
-  "version": "6.4.2",
+  "version": "6.5.0",
   "description": "Evidence-Driven Development Protocol — 3-layer architecture with Skill-based phase dispatch, computational enforcement (worktree guard + phase transition injection), TDD enforcement, and receipt validation",
   "author": {
     "name": "sungmin"

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,10 @@ TODOS.md
 docs/
 specs/
 plans/
+
+# Dev tooling caches and local-only artifacts (never committed)
+.claude/
+.deep-review/
+.deep-docs/
+.serena/
+--help

--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.5.0] - 2026-05-07
+
+### Added
+- **M3 cross-plugin envelope 채택** — `session-receipt.json` 와 `receipts/SLICE-*.json` 양쪽 (claude-deep-suite Phase 2 priority #3; cf. `claude-deep-suite/docs/envelope-migration.md` §1). 두 artifact 모두 `{ schema_version: "1.0", envelope: { producer, producer_version, artifact_kind, run_id, generated_at, schema, git, provenance, [parent_run_id], [session_id] }, payload: { ... legacy receipt body ... } }` 형식으로 emit.
+- **`hooks/scripts/envelope.js`** — 공유 zero-dep envelope 라이브러리: MSB-first ULID 생성기 (Crockford Base32, 26-char), `detectGit()` head/branch/dirty 감지 + safe `0000000` fallback, `loadProducerVersion()` 모듈 path 기준 resolve (handoff §4 literal-cwd-resolve), `wrapEnvelope()` builder, `unwrapEnvelope()` reader 와 full identity guard (producer / artifact_kind / schema.name) + corrupt-payload defense.
+- **`hooks/scripts/wrap-receipt-envelope.js`** — markdown agent prompt (`agents/implement-slice-worker.md`, `commands/deep-finish.md`) 에서 호출하는 CLI 헬퍼. `--source-evolve-insights`, `--source-harnessability`, `--source-artifacts-glob` 으로 cross-plugin / intra-plugin chain 추출 (envelope 인 evolve-insights 의 `run_id` 를 `parent_run_id` 로 자동 채우고, slice receipt 와 harnessability `run_id` 를 `provenance.source_artifacts[]` 에 누적).
+- **`scripts/validate-envelope-emit.js`** — suite envelope schema 를 미러링한 zero-dep self-test validator. root / envelope / git / schema / provenance / source_artifacts 모든 nested object 에 `additionalProperties: false`, ULID Crockford alphabet 강제 (I/L/O/U 거부), SemVer 2.0.0 strict, RFC 3339, kebab-case, `schema.name === artifact_kind` identity, payload non-null/non-array object 에 `schema_version: "1.0"` 보존.
+- **`tests/envelope-emit.test.js`** + **`tests/envelope-chain.test.js`** + **fixtures (`sample-session-receipt.json`, `sample-slice-receipt.json`)** — ULID/SemVer/RFC3339 패턴, identity guard, corrupt-payload defense, `parent_run_id` cross-plugin chain (session-receipt.envelope.parent_run_id === consumed evolve-insights.envelope.run_id), intra-plugin chain (session-receipt 의 `provenance.source_artifacts[]` 가 모든 SLICE-*.json `run_id` 를 aggregate) 50+ assertion.
+
+### Changed
+- **`agents/implement-slice-worker.md`** — slice receipt 생성 프로토콜이 legacy body 를 `$WORK_DIR/receipts/.SLICE-NNN.payload.json` 에 먼저 쓰고, `node ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/wrap-receipt-envelope.js --artifact-kind slice-receipt ...` 로 final envelope-wrapped `SLICE-NNN.json` 을 emit. Payload 의 `schema_version` 은 literal string `"1.0"` 이어야 한다.
+- **`commands/deep-finish.md`** — Section 2 가 session-receipt body 를 `$WORK_DIR/.session-receipt.payload.json` 에 쓴다. Section 2-1 (quality fields) 과 Section 7 (outcome/outcome_ref) 가 같은 temp file 을 갱신. 새 Section 7-Z 가 outcome 결정 후 정확히 한 번 envelope wrap 을 수행하므로 `envelope.run_id` 가 세션당 한 번만 생성된다. Cross-plugin chain 은 `.deep-evolve/<session>/evolve-insights.json` 과 `.deep-dashboard/harnessability-report.json` 에서 auto-detect.
+- **`hooks/scripts/verify-delegated-receipt-runner.js`** — slice receipt loader 가 `unwrapEnvelope()` 를 호출하므로 verify-receipt-core 는 envelope 여부와 관계없이 legacy body 를 본다. Identity mismatch 는 descriptive error 로 throw.
+- **`hooks/scripts/validate-receipt.sh`** — `json_field` 헬퍼가 M3 envelope 감지 후 `.payload` 에서 읽고, full identity guard 를 unwrap 전에 적용. Legacy receipt 는 top-level pass-through.
+- **`hooks/scripts/session-end.sh`** — slice receipt aggregation loop 가 foreign envelope (producer/artifact_kind/schema.name mismatch) 를 `slices_total` 카운트 전에 skip.
+- **`hooks/scripts/receipt-migration.js`** — envelope-wrapped receipt 를 already-migrated 로 인식 (no-op). Legacy v0 → v1.0 lift 는 top-level legacy receipt 에만 적용.
+- **`skills/deep-integrate/gather-signals.sh`** — `read_json_safe` 가 optional `expected_producer` / `expected_artifact_kind` 를 받아 matching envelope 는 `.payload` 를 반환, foreign envelope 는 `null` (handoff §4 round-4 defense-in-depth). deep-work session-receipt, deep-docs last-scan, deep-dashboard harnessability-report, deep-evolve evolve-insights, deep-wiki index 모두 적용. deep-review/deep-evolve/deep-wiki Phase 2 priority #4–#6 forward-compat.
+- **`skills/deep-research/SKILL.md`** — Cross-Plugin Context (Harnessability + Evolve Insights) 가 envelope 감지 + identity guard 절차를 명시. legacy fallback 으로 forward-compat 유지.
+- **`commands/deep-receipt.md`** / **`commands/deep-status.md`** / **`commands/deep-report.md`** — receipt read 지침에 envelope-aware unwrap 규칙 (identity guard + payload extraction; legacy pass-through 유지) 명시.
+
+### Notes
+- Suite-side 갱신 (claude-deep-suite `marketplace.json` SHA bump, `payload-registry/deep-work/{session,slice}-receipt/v1.0.schema.json` placeholder → authoritative shape, adoption ledger 갱신) 은 본 PR 범위 밖. claude-deep-suite handoff §1 에 따라 Phase 2 plugin PR 은 plugin repo 만 수정하고, suite-side 작업은 Phase 3 에서 일괄 처리.
+
 ## [6.4.2] — 2026-04-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.5.0] - 2026-05-07
+
+### Added
+- **M3 cross-plugin envelope adoption** for `session-receipt.json` and `receipts/SLICE-*.json` (claude-deep-suite Phase 2 priority #3; cf. `claude-deep-suite/docs/envelope-migration.md` §1). Both artifacts now ship as `{ schema_version: "1.0", envelope: { producer, producer_version, artifact_kind, run_id, generated_at, schema, git, provenance, [parent_run_id], [session_id] }, payload: { ... legacy receipt body ... } }`.
+- **`hooks/scripts/envelope.js`** — shared zero-dep envelope library: MSB-first ULID generator (Crockford Base32, 26-char), `detectGit()` head/branch/dirty trio with safe `0000000` fallback, `loadProducerVersion()` resolved relative to module path (handoff §4 literal-cwd-resolve), `wrapEnvelope()` builder, `unwrapEnvelope()` reader with full identity guards (producer / artifact_kind / schema.name) and corrupt-payload defense.
+- **`hooks/scripts/wrap-receipt-envelope.js`** — CLI helper invoked by markdown agent prompts (`agents/implement-slice-worker.md`, `commands/deep-finish.md`) to wrap a payload temp file. Supports `--source-evolve-insights`, `--source-harnessability`, `--source-artifacts-glob` for cross-plugin / intra-plugin chain extraction (writes `parent_run_id` from evolve-insights envelope and aggregates slice receipt + harnessability `run_id` into `provenance.source_artifacts[]`).
+- **`scripts/validate-envelope-emit.js`** — zero-dep self-test validator mirroring suite envelope schema. Enforces `additionalProperties: false` on root / envelope / git / schema / provenance / source_artifacts items, ULID Crockford alphabet (rejects I/L/O/U), SemVer 2.0.0 strict, RFC 3339, kebab-case, `schema.name === artifact_kind` identity, payload non-null/non-array object with `schema_version: "1.0"` preserved.
+- **`tests/envelope-emit.test.js`** + **`tests/envelope-chain.test.js`** + **fixtures (`sample-session-receipt.json`, `sample-slice-receipt.json`)** — 50+ assertions covering ULID/SemVer/RFC3339 patterns, identity guards, corrupt-payload defense, `parent_run_id` cross-plugin chain (session-receipt.envelope.parent_run_id === consumed evolve-insights.envelope.run_id), and intra-plugin chain (session-receipt's `provenance.source_artifacts[]` aggregates all SLICE-*.json `run_id`s).
+
+### Changed
+- **`agents/implement-slice-worker.md`** — slice receipt emission protocol now writes the legacy body to `$WORK_DIR/receipts/.SLICE-NNN.payload.json` first, then invokes `node ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/wrap-receipt-envelope.js --artifact-kind slice-receipt ...` to produce the final envelope-wrapped `SLICE-NNN.json`. Payload `schema_version` must be the literal string `"1.0"`.
+- **`commands/deep-finish.md`** — Section 2 now writes the session-receipt body to `$WORK_DIR/.session-receipt.payload.json`. Sections 2-1 (quality fields) and 7 (outcome/outcome_ref) update the same temp file. New Section 7-Z performs the envelope wrap exactly once, after the outcome is decided, so `envelope.run_id` is generated only once per session. Cross-plugin chain is auto-detected from `.deep-evolve/<session>/evolve-insights.json` and `.deep-dashboard/harnessability-report.json`.
+- **`hooks/scripts/verify-delegated-receipt-runner.js`** — slice receipt loader invokes `unwrapEnvelope()` so verify-receipt-core sees the legacy body whether the file is envelope-wrapped or legacy. Identity-mismatched envelopes throw with a descriptive error.
+- **`hooks/scripts/validate-receipt.sh`** — `json_field` helper detects M3 envelope and reads from `.payload`, with full identity guard before unwrap. Falls through to top-level read for legacy receipts.
+- **`hooks/scripts/session-end.sh`** — slice receipt aggregation loop skips foreign envelopes (producer/artifact_kind/schema.name mismatch) before counting toward `slices_total`.
+- **`hooks/scripts/receipt-migration.js`** — envelope-wrapped receipts are recognized as already-migrated (no-op); the legacy v0 → v1.0 lift only applies to top-level legacy receipts.
+- **`skills/deep-integrate/gather-signals.sh`** — `read_json_safe` accepts optional `expected_producer` / `expected_artifact_kind` arguments and returns `.payload` for matching envelopes, `null` for foreign envelopes (defense-in-depth, handoff §4 round-4 lesson). Applied to deep-work session-receipt, deep-docs last-scan, deep-dashboard harnessability-report, deep-evolve evolve-insights, deep-wiki index. Forward-compat for deep-review/deep-evolve/deep-wiki Phase 2 priority #4–#6.
+- **`skills/deep-research/SKILL.md`** — Cross-Plugin Context section (Harnessability + Evolve Insights) documents envelope detection + identity guard procedure, with legacy fallback for forward-compat.
+- **`commands/deep-receipt.md`** / **`commands/deep-status.md`** / **`commands/deep-report.md`** — receipt read instructions document the envelope-aware unwrap rule (identity guard + payload extraction; legacy pass-through preserved).
+
+### Notes
+- Suite-side updates (claude-deep-suite `marketplace.json` SHA bump, `payload-registry/deep-work/{session,slice}-receipt/v1.0.schema.json` placeholder → authoritative shape, adoption ledger update) are out of scope for this PR per claude-deep-suite handoff §1: M3 Phase 2 plugin PRs touch the plugin repo only; suite-side updates are batched in Phase 3.
+
 ## [6.4.2] — 2026-04-29
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,40 @@
-# deep-work v6.4.2
+# deep-work v6.5.0
 
-Evidence-Driven Development Protocol — `/deep-work "task"` 하나로 Brainstorm → Research → Plan → Implement → Test 전체 워크플로우를 자동 진행하는 Claude Code 플러그인. v6.4.2에서는 세션 초기화 흐름이 LLM 추천 기반 항목별 ask로 전환되었으며, profile v2→v3 자동 마이그레이션과 알림 시스템 전면 제거가 포함됩니다.
+Evidence-Driven Development Protocol — `/deep-work "task"` 하나로 Brainstorm → Research → Plan → Implement → Test 전체 워크플로우를 자동 진행하는 Claude Code 플러그인. v6.5.0에서는 `session-receipt.json`과 `receipts/SLICE-*.json`이 claude-deep-suite M3 cross-plugin envelope으로 전환되어 cross-plugin run_id chain trace가 가능해집니다. v6.4.2에서는 세션 초기화 흐름이 LLM 추천 기반 항목별 ask로 전환되었으며, profile v2→v3 자동 마이그레이션과 알림 시스템 전면 제거가 포함되었습니다.
+
+## v6.5.0 — M3 Envelope Adoption (claude-deep-suite Phase 2 #3)
+
+`session-receipt.json` 및 `receipts/SLICE-*.json` 모두 다음 형식으로 emit:
+
+```
+{
+  "schema_version": "1.0",
+  "envelope": {
+    "producer": "deep-work",
+    "producer_version": "6.5.0",
+    "artifact_kind": "session-receipt|slice-receipt",
+    "run_id": "<ULID>",
+    "session_id": "<dw-session-id>",
+    "parent_run_id": "<consumed evolve-insights run_id, optional>",
+    "generated_at": "<RFC 3339>",
+    "schema": { "name": "<same as artifact_kind>", "version": "1.0" },
+    "git": { "head": "<sha>", "branch": "<name>", "dirty": false },
+    "provenance": {
+      "source_artifacts": [{ "path": "...", "run_id": "..." }],
+      "tool_versions": { "node": "v20.x" }
+    }
+  },
+  "payload": { /* legacy session/slice receipt body — schema_version: "1.0" preserved */ }
+}
+```
+
+**Writer**: `hooks/scripts/wrap-receipt-envelope.js`(markdown agent prompt에서 호출하는 CLI helper). `agents/implement-slice-worker.md`(slice receipts)와 `commands/deep-finish.md`(session receipt, Section 7-Z) 양쪽이 이 helper를 사용. helper는 자기 모듈 path 기준으로 plugin의 `.claude-plugin/plugin.json`에서 `producer_version`을 읽는다 (handoff §4 literal-cwd-resolve 회피).
+
+**Reader**: 모든 internal reader(`hooks/scripts/verify-delegated-receipt-runner.js`, `validate-receipt.sh`, `session-end.sh`, `receipt-migration.js`)와 cross-plugin consumer(`skills/deep-integrate/gather-signals.sh`, `skills/deep-research/SKILL.md`)가 M3 envelope 형태를 감지하고 identity guard(`producer === "deep-work"` + `artifact_kind` + `schema.name === artifact_kind`)를 검증한 뒤 `.payload`로 unwrap하고 legacy 필드를 읽는다. Legacy non-envelope receipt는 그대로 통과 (forward-compat).
+
+**Self-test**: `scripts/validate-envelope-emit.js`가 suite envelope schema를 미러링한 zero-dep release-lint. `tests/envelope-emit.test.js` + `tests/envelope-chain.test.js`가 identity guard, corrupt-payload defense, ULID Crockford alphabet (I/L/O/U 거부), SemVer 2.0.0 strict, cross-plugin chain assertion (session-receipt.parent_run_id === consumed evolve-insights.run_id)를 cover.
+
+> **Suite-side 갱신**(marketplace.json SHA bump, payload-registry placeholder → authoritative, adoption ledger T+0 line)은 claude-deep-suite Phase 3 batch에서 일괄 처리 (handoff §1 정책). Phase 2 plugin PR은 plugin repo만 수정한다.
 
 ## Structure
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -21,6 +21,33 @@ deep-work는 [Deep Suite](https://github.com/Sungmin-Cho/claude-deep-suite) 생�
 
 deep-work는 [deep-review](https://github.com/Sungmin-Cho/claude-deep-review)와 [deep-dashboard](https://github.com/Sungmin-Cho/claude-deep-dashboard)가 소비하는 receipt과 health report를 생성합니다.
 
+## v6.5.0 새 기능
+
+### M3 Cross-Plugin Envelope 채택 (claude-deep-suite Phase 2 #3)
+
+`session-receipt.json` 과 `receipts/SLICE-*.json` 이 M3 envelope-wrapped artifact 로 emit 됩니다 (cf. `claude-deep-suite/docs/envelope-migration.md` §1):
+
+```
+{
+  "schema_version": "1.0",
+  "envelope": {
+    "producer": "deep-work",
+    "producer_version": "6.5.0",
+    "artifact_kind": "session-receipt|slice-receipt",
+    "run_id": "<ULID>",
+    "session_id": "<dw-session-id>",
+    "parent_run_id": "<consumed evolve-insights run_id, optional>",
+    "generated_at": "<RFC 3339>",
+    "schema": { "name": "<same as artifact_kind>", "version": "1.0" },
+    "git": { ... },
+    "provenance": { "source_artifacts": [...], "tool_versions": {...} }
+  },
+  "payload": { /* legacy receipt body */ }
+}
+```
+
+session-receipt 의 `envelope.parent_run_id` 가 consumed `evolve-insights.json` envelope 으로 chain (handoff §3.3 cross-plugin trace), `provenance.source_artifacts[]` 가 모든 slice receipt run_id 를 aggregate (intra-plugin chain). Internal reader (`hooks/scripts/*`) 와 cross-plugin consumer (`gather-signals.sh`, `deep-research/SKILL.md`) 는 envelope 을 감지하고 identity guard 를 적용한 뒤 `.payload` 로 unwrap 후 legacy field 를 읽습니다. Legacy non-envelope receipt 는 forward-compat.
+
 ## v6.4.2 새 기능
 
 ### 유연한 세션 초기화

--- a/README.md
+++ b/README.md
@@ -21,6 +21,33 @@ In the 2×2 matrix (Guide/Sensor × Computational/Inferential), deep-work covers
 
 deep-work also produces receipts and health reports consumed by [deep-review](https://github.com/Sungmin-Cho/claude-deep-review) and [deep-dashboard](https://github.com/Sungmin-Cho/claude-deep-dashboard).
 
+## What's New in v6.5.0
+
+### M3 Cross-Plugin Envelope Adoption (claude-deep-suite Phase 2 #3)
+
+`session-receipt.json` and `receipts/SLICE-*.json` are now emitted as M3 envelope-wrapped artifacts (cf. `claude-deep-suite/docs/envelope-migration.md` §1):
+
+```
+{
+  "schema_version": "1.0",
+  "envelope": {
+    "producer": "deep-work",
+    "producer_version": "6.5.0",
+    "artifact_kind": "session-receipt|slice-receipt",
+    "run_id": "<ULID>",
+    "session_id": "<dw-session-id>",
+    "parent_run_id": "<consumed evolve-insights run_id, optional>",
+    "generated_at": "<RFC 3339>",
+    "schema": { "name": "<same as artifact_kind>", "version": "1.0" },
+    "git": { ... },
+    "provenance": { "source_artifacts": [...], "tool_versions": {...} }
+  },
+  "payload": { /* legacy receipt body */ }
+}
+```
+
+The session-receipt's `envelope.parent_run_id` chains to the consumed `evolve-insights.json` envelope (handoff §3.3 cross-plugin trace), and `provenance.source_artifacts[]` aggregates all slice receipt run_ids (intra-plugin chain). Internal readers (`hooks/scripts/*`) and cross-plugin consumers (`gather-signals.sh`, `deep-research/SKILL.md`) detect the envelope, enforce identity guard, and unwrap to `.payload` before reading legacy fields. Legacy non-envelope receipts are forward-compatible.
+
 ## What's New in v6.4.2
 
 ### Flexible Session Init

--- a/agents/implement-slice-worker.md
+++ b/agents/implement-slice-worker.md
@@ -52,23 +52,37 @@ Before each slice: record `git_before_slice = git rev-parse HEAD`.
 After each slice (tdd cycle + sensor + review complete):
 record `git_after_slice = git rev-parse HEAD`.
 
-## Receipt file creation — EXPLICIT PROTOCOL
+## Receipt file creation — EXPLICIT PROTOCOL (v6.5.0 envelope adoption)
 
-At the end of each slice you **MUST** write the receipt file. Use your `Write` tool
-with the exact shape below. Do NOT skip this step — the parent's verify-receipt
-gate will hard-fail if the receipt is missing or incomplete.
+At the end of each slice you **MUST** write an envelope-wrapped receipt file.
+The parent's verify-receipt gate will hard-fail if the receipt is missing or
+incomplete.
+
+Starting in deep-work v6.5.0 the receipt file at
+`$WORK_DIR/receipts/SLICE-NNN.json` is wrapped in the M3 cross-plugin envelope
+(cf. `claude-deep-suite/docs/envelope-migration.md` §1). The legacy receipt
+fields move under `payload`; the producer / artifact_kind / run_id / git
+metadata are emitted by the wrap helper. Do NOT hand-author the envelope —
+use the helper script so ULID, RFC 3339 timestamp, and SemVer producer_version
+are produced consistently.
+
+### Step 1 — write the payload JSON to a temp file
+
+Use your `Write` tool to emit the payload (legacy receipt body) to a temp
+path inside the work_dir, e.g. `$WORK_DIR/receipts/.SLICE-NNN.payload.json`:
 
 ```
 Write(
-  file_path="$WORK_DIR/receipts/SLICE-NNN.json",
-  content=<JSON string shown below>
+  file_path="$WORK_DIR/receipts/.SLICE-NNN.payload.json",
+  content=<payload JSON string shown below>
 )
 ```
 
-Required JSON structure (all fields mandatory except where noted):
+Required payload JSON structure (all fields mandatory except where noted):
 
 ```json
 {
+  "schema_version": "1.0",
   "slice_id": "SLICE-NNN",
   "cluster_id": "<cluster id from prompt input — e.g. 'C1'. Used by parent's verify-receipt item 6 for per-cluster baseline chain validation in team parallel mode. Solo mode may omit (defaults to '_default').>",
   "status": "complete",
@@ -104,10 +118,37 @@ Required JSON structure (all fields mandatory except where noted):
 }
 ```
 
+`schema_version` MUST be the literal string `"1.0"` (not numeric `1.0`). The
+envelope validator rejects payload without `schema_version: "1.0"`.
+
+### Step 2 — wrap the payload via the envelope helper
+
+Run via the `Bash` tool:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/wrap-receipt-envelope.js" \
+  --artifact-kind slice-receipt \
+  --payload-file "$WORK_DIR/receipts/.SLICE-NNN.payload.json" \
+  --output "$WORK_DIR/receipts/SLICE-NNN.json"
+
+rm -f "$WORK_DIR/receipts/.SLICE-NNN.payload.json"
+```
+
+The helper:
+- Generates an MSB-first Crockford Base32 ULID into `envelope.run_id`.
+- Reads `producer_version` from the plugin's `.claude-plugin/plugin.json`
+  (resolved relative to the helper's module path — handoff §4
+  literal-cwd-resolve).
+- Detects `git.head` / `git.branch` / `git.dirty` from the current worktree.
+- Emits `envelope.producer = "deep-work"`, `envelope.artifact_kind =
+  "slice-receipt"`, `envelope.schema.name = "slice-receipt"` (identity
+  contract, round-4 lesson).
+
 If status="blocked" (slice failed after 3 attempts):
-- Include `"debug": {"root_cause_note": "<description>"}`.
+- Include `"debug": {"root_cause_note": "<description>"}` inside the payload.
 - Mark subsequent not-yet-started slices with `"status": "blocked-upstream"`
-  in their placeholder receipts and return immediately.
+  in their placeholder receipts (still wrapped via the same helper) and
+  return immediately.
 
 # TDD Protocol (prompt-embedded — hook not applied)
 - RED first: write failing test, verify FAIL with correct reason

--- a/commands/deep-finish.md
+++ b/commands/deep-finish.md
@@ -108,7 +108,21 @@ Scan `$WORK_DIR/receipts/` for all `SLICE-*.json` files. For each:
 - Aggregate model usage (haiku/sonnet/opus counts)
 - Sum estimated_cost across slices
 
-**Generate `$WORK_DIR/session-receipt.json`** (derived cache — canonical source is slice receipts):
+**Generate `$WORK_DIR/session-receipt.json`** (derived cache — canonical source
+is slice receipts) **wrapped in the M3 cross-plugin envelope** (deep-work
+v6.5.0; cf. `claude-deep-suite/docs/envelope-migration.md` §1).
+
+> **Two-step protocol (v6.5.0)**: the legacy session-receipt body ("payload")
+> is built first into a temp file; quality fields (Section 2-1) and
+> outcome/outcome_ref (Section 7) are appended to that **same payload temp
+> file**; only at the end of Section 7 does the wrap helper produce the final
+> envelope-wrapped `session-receipt.json` with a single `run_id`. This avoids
+> re-generating ULIDs as outcome data lands.
+
+#### Step 2.1 — write the session-receipt payload to a temp file
+
+Use the `Write` tool to emit the **payload** (legacy session-receipt body) to a
+temp path, e.g. `$WORK_DIR/.session-receipt.payload.json`:
 
 ```json
 {
@@ -152,9 +166,15 @@ Scan `$WORK_DIR/receipts/` for all `SLICE-*.json` files. For each:
     "total_contracts": 0,
     "contracts_met": 0
   },
-  "deep_work_version": "6.4.1"
+  "deep_work_version": "6.5.0"
 }
 ```
+
+`schema_version` MUST be the literal string `"1.0"`. Section 2-1 will add
+`quality_score`, `quality_breakdown`, and `quality_diagnostics` to this same
+payload temp file. Section 7's option-specific blocks update
+`outcome`/`outcome_ref` on the same temp file. The final envelope wrap is
+performed by Section 7-Z below — exactly once per session.
 
 ### 2-1. Calculate Session Quality Score (v5.8 — 5-component system)
 
@@ -199,7 +219,12 @@ Examples:
      Phase Balance:   [N]/100 ([detail])
 ```
 
-**Persist to session receipt**: Add `quality_score`, `quality_breakdown` (object with all 5 component scores + not_applicable flags), and `quality_diagnostics` (the 2 diagnostic metrics) to the `session-receipt.json` generated in Section 2.
+**Persist to session receipt**: Add `quality_score`, `quality_breakdown`
+(object with all 5 component scores + not_applicable flags), and
+`quality_diagnostics` (the 2 diagnostic metrics) to the
+**`$WORK_DIR/.session-receipt.payload.json` temp file** generated in Step 2.1.
+The final envelope wrap (Section 7-Z) consumes this payload as-is, so any
+field placed here ends up under `envelope.payload` in the wrapped receipt.
 
 **Authoritative JSONL write**: After calculating the quality score, write the finalized session record to `harness-sessions.jsonl`. This is the authoritative write — it includes the `quality_score` field and `status: "finalized"`.
 
@@ -338,7 +363,9 @@ Use AskUserQuestion:
    ```
    Abort: `git merge --abort`. Stop here.
 5. On success: `git worktree remove [worktree_path]` + `git branch -d [worktree_branch]`
-6. Update session receipt: `outcome: "merge"`
+6. Update session-receipt **payload**: set `outcome: "merge"` in
+   `$WORK_DIR/.session-receipt.payload.json` (Edit tool — preserve existing
+   fields). The envelope wrap happens in Section 7-Z.
 
 #### Option: PR
 
@@ -374,11 +401,15 @@ Use AskUserQuestion:
    )"
    ```
 5. Worktree is **NOT** removed (PR review 중 추가 작업 가능)
-6. Update session receipt: `outcome: "pr"`, `outcome_ref: [PR URL]`
+6. Update session-receipt **payload**: set `outcome: "pr"`,
+   `outcome_ref: [PR URL]` in `$WORK_DIR/.session-receipt.payload.json` (Edit
+   tool — preserve existing fields). The envelope wrap happens in Section 7-Z.
 
 #### Option: Keep
 
-1. Update session receipt: `outcome: "keep"`
+1. Update session-receipt **payload**: set `outcome: "keep"` in
+   `$WORK_DIR/.session-receipt.payload.json`. The envelope wrap happens in
+   Section 7-Z.
 2. Display:
    ```
    브랜치가 유지됩니다: [worktree_branch]
@@ -403,7 +434,56 @@ Use AskUserQuestion:
    2. 취소
    ```
 3. On confirm: `git worktree remove --force [worktree_path]` + `git branch -D [worktree_branch]`
-4. Update session receipt: `outcome: "discard"`
+4. Update session-receipt **payload**: set `outcome: "discard"` in
+   `$WORK_DIR/.session-receipt.payload.json`. The envelope wrap happens in
+   Section 7-Z.
+
+### 7-Z. Envelope wrap (v6.5.0 — runs once, after outcome is decided)
+
+Now that the payload temp file has all fields (Section 2 base + Section 2-1
+quality + Section 7 outcome), wrap it in the M3 envelope and write the final
+`session-receipt.json`. Use the `Bash` tool with the helper script:
+
+```bash
+EVOLVE_PATH=""
+if [ -f "$PROJECT_ROOT/.deep-evolve/current.json" ]; then
+  EVOLVE_SID=$(node -e "
+    try { console.log(JSON.parse(require('fs').readFileSync(process.argv[1],'utf8')).session_id||''); }
+    catch (_) { console.log(''); }
+  " "$PROJECT_ROOT/.deep-evolve/current.json")
+  if [ -n "$EVOLVE_SID" ] && [ -f "$PROJECT_ROOT/.deep-evolve/$EVOLVE_SID/evolve-insights.json" ]; then
+    EVOLVE_PATH="$PROJECT_ROOT/.deep-evolve/$EVOLVE_SID/evolve-insights.json"
+  fi
+fi
+
+HARN_PATH=""
+if [ -f "$PROJECT_ROOT/.deep-dashboard/harnessability-report.json" ]; then
+  HARN_PATH="$PROJECT_ROOT/.deep-dashboard/harnessability-report.json"
+fi
+
+WRAP_ARGS=(
+  --artifact-kind session-receipt
+  --payload-file "$WORK_DIR/.session-receipt.payload.json"
+  --output "$WORK_DIR/session-receipt.json"
+  --session-id "$DEEP_WORK_SESSION_ID"
+  --source-artifacts-glob "$WORK_DIR/receipts/SLICE-*.json"
+)
+[ -n "$EVOLVE_PATH" ] && WRAP_ARGS+=(--source-evolve-insights "$EVOLVE_PATH")
+[ -n "$HARN_PATH" ] && WRAP_ARGS+=(--source-harnessability "$HARN_PATH")
+
+node "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/wrap-receipt-envelope.js" "${WRAP_ARGS[@]}"
+rm -f "$WORK_DIR/.session-receipt.payload.json"
+```
+
+The helper:
+- Generates `envelope.run_id` (ULID), sets `producer = "deep-work"`,
+  `artifact_kind = "session-receipt"`, `schema.name = "session-receipt"`.
+- Sets `envelope.parent_run_id` from the consumed evolve-insights envelope's
+  `run_id` (handoff §3.3 cross-plugin chain) when `--source-evolve-insights`
+  is passed and the file is itself an envelope.
+- Adds slice receipts' `run_id` (when envelope-wrapped) plus
+  `harnessability-report.json`'s `run_id` to `provenance.source_artifacts[]`
+  (intra-plugin chain + multi-source aggregation).
 
 ### 8. Finalize state
 

--- a/commands/deep-finish.md
+++ b/commands/deep-finish.md
@@ -446,7 +446,8 @@ quality + Section 7 outcome), wrap it in the M3 envelope and write the final
 
 > **Important — failure semantics**: the snippet uses `set -euo pipefail` so
 > that any sub-command failure aborts before `rm -f` runs. The cleanup is
-> gated with `&&` so that on helper failure the payload temp file is
+> gated with an `if/then/else` block (equivalent to `&&` for our purposes
+> under `set -e`) so that on helper failure the payload temp file is
 > **preserved** for retry. To re-attempt a failed wrap, simply re-execute
 > Section 7-Z (Section 2/2-1/7 do not re-run; the same payload is used).
 

--- a/commands/deep-finish.md
+++ b/commands/deep-finish.md
@@ -444,13 +444,34 @@ Now that the payload temp file has all fields (Section 2 base + Section 2-1
 quality + Section 7 outcome), wrap it in the M3 envelope and write the final
 `session-receipt.json`. Use the `Bash` tool with the helper script:
 
+> **Important — failure semantics**: the snippet uses `set -euo pipefail` so
+> that any sub-command failure aborts before `rm -f` runs. The cleanup is
+> gated with `&&` so that on helper failure the payload temp file is
+> **preserved** for retry. To re-attempt a failed wrap, simply re-execute
+> Section 7-Z (Section 2/2-1/7 do not re-run; the same payload is used).
+
 ```bash
+set -euo pipefail
+
+# Resolve session_id with the same fallback chain as Section 1: env var →
+# .claude/deep-work-current-session pointer file (omit flag if neither
+# resolves rather than passing the empty string — handoff §4 W2).
+SESSION_ID="${DEEP_WORK_SESSION_ID:-}"
+if [ -z "$SESSION_ID" ] && [ -f "$PROJECT_ROOT/.claude/deep-work-current-session" ]; then
+  SESSION_ID="$(tr -d '\n\r' < "$PROJECT_ROOT/.claude/deep-work-current-session" || true)"
+fi
+
 EVOLVE_PATH=""
 if [ -f "$PROJECT_ROOT/.deep-evolve/current.json" ]; then
-  EVOLVE_SID=$(node -e "
-    try { console.log(JSON.parse(require('fs').readFileSync(process.argv[1],'utf8')).session_id||''); }
-    catch (_) { console.log(''); }
-  " "$PROJECT_ROOT/.deep-evolve/current.json")
+  EVOLVE_SID=$(node -e '
+    try {
+      const raw = require("fs").readFileSync(process.argv[1], "utf8");
+      const obj = JSON.parse(raw);
+      const v = (obj && typeof obj === "object" && typeof obj.session_id === "string")
+        ? obj.session_id : "";
+      console.log(v);
+    } catch (_) { console.log(""); }
+  ' "$PROJECT_ROOT/.deep-evolve/current.json" || true)
   if [ -n "$EVOLVE_SID" ] && [ -f "$PROJECT_ROOT/.deep-evolve/$EVOLVE_SID/evolve-insights.json" ]; then
     EVOLVE_PATH="$PROJECT_ROOT/.deep-evolve/$EVOLVE_SID/evolve-insights.json"
   fi
@@ -465,14 +486,21 @@ WRAP_ARGS=(
   --artifact-kind session-receipt
   --payload-file "$WORK_DIR/.session-receipt.payload.json"
   --output "$WORK_DIR/session-receipt.json"
-  --session-id "$DEEP_WORK_SESSION_ID"
   --source-artifacts-glob "$WORK_DIR/receipts/SLICE-*.json"
 )
+[ -n "$SESSION_ID" ] && WRAP_ARGS+=(--session-id "$SESSION_ID")
 [ -n "$EVOLVE_PATH" ] && WRAP_ARGS+=(--source-evolve-insights "$EVOLVE_PATH")
 [ -n "$HARN_PATH" ] && WRAP_ARGS+=(--source-harnessability "$HARN_PATH")
 
-node "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/wrap-receipt-envelope.js" "${WRAP_ARGS[@]}"
-rm -f "$WORK_DIR/.session-receipt.payload.json"
+# Cleanup payload temp file ONLY on helper success — preserve on failure for
+# retry (round-1 deep-review C2 lesson). The `set -e` guarantees abort if the
+# helper exits non-zero before this line runs.
+if node "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/wrap-receipt-envelope.js" "${WRAP_ARGS[@]}"; then
+  rm -f "$WORK_DIR/.session-receipt.payload.json"
+else
+  echo "wrap helper failed — preserving $WORK_DIR/.session-receipt.payload.json for retry; re-run Section 7-Z to retry." >&2
+  exit 1
+fi
 ```
 
 The helper:

--- a/commands/deep-receipt.md
+++ b/commands/deep-receipt.md
@@ -35,6 +35,25 @@ Set `$STATE_FILE` to the resolved path.
 Read `$STATE_FILE` and extract `work_dir`.
 Receipts are stored in `$WORK_DIR/receipts/SLICE-NNN.json`.
 
+**Envelope-aware reads (v6.5.0)**: deep-work 6.5.0 부터 SLICE-*.json 과
+`session-receipt.json` 는 M3 cross-plugin envelope (`{schema_version: "1.0",
+envelope: {...}, payload: {...}}`) 로 emit 된다 (cf.
+`claude-deep-suite/docs/envelope-migration.md` §1). 본 명령의 모든 receipt
+read 단계에서 다음 unwrap 규칙을 적용한다:
+
+1. JSON 파싱 후 root 가 envelope 형태이면 (`schema_version === "1.0"`,
+   `envelope` 객체, `payload` 키 모두 존재) identity guard 검증:
+   `envelope.producer === "deep-work"` ∧
+   `envelope.artifact_kind ∈ {slice-receipt, session-receipt}` ∧
+   `envelope.schema.name === envelope.artifact_kind`. 위 조건을 모두 통과하면
+   `payload` 객체를 사용 (legacy receipt body). 한 항목이라도 어긋나면
+   "foreign envelope at <path>" 경고 후 receipt 무시 (handoff §4 round-4
+   identity guard).
+2. Legacy(non-envelope) JSON 이면 그대로 사용 (forward-compat).
+3. `/deep-receipt export --format=ci` 같은 bundle export 는 envelope wrapping
+   을 그대로 유지한 채 묶어 외부 CI 에 전달한다 (envelope 의 run_id chain 이
+   audit 용).
+
 ## Dashboard
 
 Scan `$WORK_DIR/receipts/` directory for all receipt JSON files. For each receipt, display:

--- a/commands/deep-report.md
+++ b/commands/deep-report.md
@@ -235,7 +235,15 @@ Where `<PLUGIN_DIR>` is the plugin's install path (directory containing `assumpt
 - Research references used: [count]
 - Cross-model unique findings: [count]
 
-[Aggregate harness_metadata from $WORK_DIR/receipts/SLICE-*.json for the current session.]
+[Aggregate harness_metadata from $WORK_DIR/receipts/SLICE-*.json for the
+current session. **Envelope-aware unwrap (v6.5.0)**: receipts 는 M3 envelope
+(`{schema_version: "1.0", envelope: {...}, payload: {...}}`) 로 emit 된다.
+각 파일을 읽을 때 envelope 형태이면 identity guard
+(`envelope.producer === "deep-work"` ∧
+`envelope.artifact_kind === "slice-receipt"` ∧
+`envelope.schema.name === envelope.artifact_kind`) 검증 후 `payload` 를
+receipt body 로 사용. mismatch 는 skip + 경고. legacy 는 root 그대로 사용.
+`harness_metadata` 는 payload root 에 있다.]
 
 [If harness-sessions.jsonl does not exist: "Assumption 엔진 기록 없음 — 세션 완료 후 자동 수집됩니다."]
 

--- a/commands/deep-status.md
+++ b/commands/deep-status.md
@@ -130,7 +130,14 @@ Read the following files if they exist:
 
 If receipts directory exists (`$WORK_DIR/receipts/`):
 - Read all `SLICE-NNN.json` receipt files
-- For each receipt, extract `sensor_results` if present
+- **Envelope-aware unwrap (v6.5.0)**: 각 receipt 의 root 가 M3 envelope
+  형태(`schema_version === "1.0"` + `envelope` 객체 + `payload` 키)이면
+  identity guard 검증 (`envelope.producer === "deep-work"` ∧
+  `envelope.artifact_kind === "slice-receipt"` ∧
+  `envelope.schema.name === "slice-receipt"`) 후 `payload` 를 receipt body
+  로 사용. mismatch / corrupt payload 는 "foreign envelope" 경고 후 무시.
+  Legacy(non-envelope) receipt 는 root 객체를 그대로 사용 (forward-compat).
+- For each receipt body, extract `sensor_results` if present
 - Count slices where all sensor statuses are `pass` or `not_applicable` → Sensor Clean Rate numerator
 - Count total slices with sensor data → Sensor Clean Rate denominator
 - Read `mutation_testing` from the state file for mutation score

--- a/hooks/scripts/envelope.js
+++ b/hooks/scripts/envelope.js
@@ -189,14 +189,20 @@ function wrapEnvelope(opts) {
 }
 
 /**
- * Strict M3 envelope shape detector.
+ * M3 envelope shape detector (loose).
  *
- * Returns true ONLY for {schema_version: "1.0", envelope: {...}, payload: {...}}.
- * Does not validate envelope contents — use unwrapEnvelope() for identity check.
+ * Returns true for {schema_version: "1.0", envelope: {...}, payload: <any>} —
+ * structural detection only. Does NOT validate envelope contents OR payload
+ * shape. Use `unwrapEnvelope()` for full identity + corrupt-payload checks,
+ * or use the stricter `isValidEnvelope()` when consumers also need payload
+ * to be a non-null/non-array object.
  *
  * Defends against legacy v1.0 receipts whose top-level `schema_version: "1.0"`
  * collides with envelope's `schema_version: "1.0"`: the legacy form lacks
- * `envelope` + `payload` keys, so this returns false.
+ * `envelope` + `payload` keys, so this returns false. unwrapEnvelope()
+ * preserves this same loose-detection contract — an envelope-shaped object
+ * with corrupt payload is detected here, then rejected (null) by the
+ * unwrapper rather than mis-classified as legacy.
  */
 function isEnvelope(obj) {
   if (!obj || typeof obj !== 'object' || Array.isArray(obj)) return false;
@@ -204,6 +210,18 @@ function isEnvelope(obj) {
   if (!obj.envelope || typeof obj.envelope !== 'object' || Array.isArray(obj.envelope)) return false;
   if (obj.payload === undefined) return false;
   return true;
+}
+
+/**
+ * Strict M3 envelope detector — adds the payload-shape gate on top of
+ * `isEnvelope`. Returns true only when payload is itself a non-null,
+ * non-array object (round-1 deep-review W4 lesson). Use this when extracting
+ * sub-fields like `envelope.run_id` from a chain-source artifact, where a
+ * corrupt envelope must not contribute trace data downstream.
+ */
+function isValidEnvelope(obj) {
+  if (!isEnvelope(obj)) return false;
+  return obj.payload !== null && typeof obj.payload === 'object' && !Array.isArray(obj.payload);
 }
 
 /**
@@ -263,5 +281,6 @@ module.exports = {
   loadProducerVersion,
   wrapEnvelope,
   isEnvelope,
+  isValidEnvelope,
   unwrapEnvelope,
 };

--- a/hooks/scripts/envelope.js
+++ b/hooks/scripts/envelope.js
@@ -1,0 +1,267 @@
+'use strict';
+
+/**
+ * envelope.js — Shared utilities for the M3 cross-plugin envelope
+ * (cf. claude-deep-suite/docs/envelope-migration.md §1).
+ *
+ * Zero-dep, CommonJS, runs from any cwd. All paths that reference plugin
+ * assets (e.g. plugin.json) resolve relative to this module's __dirname,
+ * NOT the caller's process.cwd() — see handoff §4 "literal-cwd-resolve".
+ *
+ * Exports:
+ *   generateUlid(now?)              MSB-first Crockford Base32 26-char ULID
+ *   detectGit(cwd?)                 git head/branch/dirty trio with safe fallback
+ *   loadProducerVersion()           reads .claude-plugin/plugin.json relative to module
+ *   wrapEnvelope(opts)              builds an envelope object (does not write)
+ *   unwrapEnvelope(obj, p, kind)    returns payload (or input as-is for legacy);
+ *                                   null if envelope-shaped but identity mismatches.
+ *   isEnvelope(obj)                 boolean — strict M3 envelope shape detector
+ *
+ * Identity contract: producer === 'deep-work', artifact_kind ∈ {session-receipt,
+ * slice-receipt}, schema.name === artifact_kind. unwrapEnvelope() enforces all
+ * three (handoff §4 round-4 "envelope identity guards").
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const { randomBytes } = require('node:crypto');
+
+const PLUGIN_NAME = 'deep-work';
+const ALLOWED_ARTIFACT_KINDS = Object.freeze(new Set(['session-receipt', 'slice-receipt']));
+
+// Crockford's Base32 alphabet (per ULID spec) — excludes I/L/O/U.
+const CROCKFORD = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+const ULID_RE = /^[0-9A-HJKMNP-TV-Z]{26}$/;
+
+function generateUlid(now) {
+  if (now === undefined) now = Date.now();
+  // 48-bit timestamp ms (10 base32 chars) MSB-first + 80-bit randomness (16 base32 chars).
+  let ts = now;
+  const tsChars = new Array(10);
+  for (let i = 9; i >= 0; i--) {
+    tsChars[i] = CROCKFORD[ts % 32];
+    ts = Math.floor(ts / 32);
+  }
+  const r = randomBytes(10);
+  let rb = 0n;
+  for (const b of r) rb = (rb << 8n) | BigInt(b);
+  const randChars = new Array(16);
+  for (let i = 15; i >= 0; i--) {
+    randChars[i] = CROCKFORD[Number(rb & 31n)];
+    rb >>= 5n;
+  }
+  return tsChars.join('') + randChars.join('');
+}
+
+function safeGit(args, cwd) {
+  try {
+    return execFileSync('git', args, {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch (_err) {
+    return null;
+  }
+}
+
+function detectGit(cwd) {
+  const repoCwd = cwd || process.cwd();
+  const head = safeGit(['rev-parse', 'HEAD'], repoCwd);
+  if (!head) {
+    // Non-git directory or shallow CI clone failure — emit envelope-schema-valid
+    // sentinel that's distinguishable from a real SHA (7-zero hex, dirty=unknown).
+    return { head: '0000000', branch: 'HEAD', dirty: 'unknown' };
+  }
+  const branch = safeGit(['rev-parse', '--abbrev-ref', 'HEAD'], repoCwd);
+  const status = safeGit(['status', '--porcelain'], repoCwd);
+  return {
+    head,
+    branch: branch && branch !== 'HEAD' ? branch : 'HEAD',
+    dirty: status == null ? 'unknown' : status.length > 0,
+  };
+}
+
+function loadProducerVersion() {
+  // Resolve relative to this module file, NOT the caller's cwd. LLM-driven
+  // contexts may run helpers from arbitrary directories.
+  const pluginJsonPath = path.resolve(__dirname, '..', '..', '.claude-plugin', 'plugin.json');
+  const raw = fs.readFileSync(pluginJsonPath, 'utf8');
+  const obj = JSON.parse(raw);
+  if (!obj || typeof obj.version !== 'string' || obj.version.length === 0) {
+    throw new Error(`plugin.json missing string "version" at ${pluginJsonPath}`);
+  }
+  return obj.version;
+}
+
+/**
+ * Build an envelope object (does not write).
+ *
+ * opts:
+ *   artifactKind     'session-receipt' | 'slice-receipt' (required)
+ *   payload          plain object (required, non-null, non-array)
+ *   parentRunId      optional ULID — cross-plugin chain (e.g. evolve-insights run_id)
+ *   sessionId        optional higher-level session marker
+ *   sourceArtifacts  optional array of { path, run_id? }
+ *   toolVersions     optional object — defaults to { node: process.version }
+ *   schemaVersion    optional payload schema MAJOR.MINOR — defaults to '1.0'
+ *   git              optional override (otherwise detectGit())
+ *   runId            optional ULID override (otherwise generateUlid())
+ *   producerVersion  optional override (otherwise loadProducerVersion())
+ *   generatedAt      optional RFC 3339 timestamp (otherwise new Date().toISOString())
+ */
+function wrapEnvelope(opts) {
+  if (!opts || typeof opts !== 'object') {
+    throw new Error('wrapEnvelope: opts must be an object');
+  }
+  const artifactKind = opts.artifactKind;
+  if (!ALLOWED_ARTIFACT_KINDS.has(artifactKind)) {
+    throw new Error(
+      `wrapEnvelope: artifactKind must be one of ${[...ALLOWED_ARTIFACT_KINDS].join(', ')}, got ${JSON.stringify(artifactKind)}`,
+    );
+  }
+  if (
+    opts.payload === null ||
+    typeof opts.payload !== 'object' ||
+    Array.isArray(opts.payload)
+  ) {
+    throw new Error('wrapEnvelope: payload must be a non-null, non-array object');
+  }
+
+  const runId = opts.runId || generateUlid();
+  if (!ULID_RE.test(runId)) {
+    throw new Error(`wrapEnvelope: runId must be 26-char Crockford Base32 ULID, got ${JSON.stringify(runId)}`);
+  }
+  const producerVersion = opts.producerVersion || loadProducerVersion();
+  const generatedAt = opts.generatedAt || new Date().toISOString();
+  const git = opts.git || detectGit();
+  const schemaVersion = opts.schemaVersion || '1.0';
+
+  const sourceArtifacts = Array.isArray(opts.sourceArtifacts)
+    ? opts.sourceArtifacts
+        .filter((sa) => sa && typeof sa === 'object' && !Array.isArray(sa))
+        .map((sa) => {
+          const item = { path: String(sa.path || '') };
+          if (typeof sa.run_id === 'string' && sa.run_id.length > 0) {
+            item.run_id = sa.run_id;
+          }
+          return item;
+        })
+        .filter((sa) => sa.path.length > 0)
+    : [];
+
+  const toolVersions =
+    opts.toolVersions && typeof opts.toolVersions === 'object' && !Array.isArray(opts.toolVersions)
+      ? opts.toolVersions
+      : { node: process.version };
+
+  const envelope = {
+    producer: PLUGIN_NAME,
+    producer_version: producerVersion,
+    artifact_kind: artifactKind,
+    run_id: runId,
+    generated_at: generatedAt,
+    schema: { name: artifactKind, version: schemaVersion },
+    git: {
+      head: git.head,
+      branch: git.branch,
+      dirty: git.dirty,
+    },
+    provenance: {
+      source_artifacts: sourceArtifacts,
+      tool_versions: toolVersions,
+    },
+  };
+  if (typeof opts.sessionId === 'string' && opts.sessionId.length > 0) {
+    envelope.session_id = opts.sessionId;
+  }
+  if (typeof opts.parentRunId === 'string' && opts.parentRunId.length > 0) {
+    envelope.parent_run_id = opts.parentRunId;
+  }
+
+  return {
+    $schema: 'https://raw.githubusercontent.com/Sungmin-Cho/claude-deep-suite/main/schemas/artifact-envelope.schema.json',
+    schema_version: '1.0',
+    envelope,
+    payload: opts.payload,
+  };
+}
+
+/**
+ * Strict M3 envelope shape detector.
+ *
+ * Returns true ONLY for {schema_version: "1.0", envelope: {...}, payload: {...}}.
+ * Does not validate envelope contents — use unwrapEnvelope() for identity check.
+ *
+ * Defends against legacy v1.0 receipts whose top-level `schema_version: "1.0"`
+ * collides with envelope's `schema_version: "1.0"`: the legacy form lacks
+ * `envelope` + `payload` keys, so this returns false.
+ */
+function isEnvelope(obj) {
+  if (!obj || typeof obj !== 'object' || Array.isArray(obj)) return false;
+  if (obj.schema_version !== '1.0') return false;
+  if (!obj.envelope || typeof obj.envelope !== 'object' || Array.isArray(obj.envelope)) return false;
+  if (obj.payload === undefined) return false;
+  return true;
+}
+
+/**
+ * Unwrap envelope and verify identity. Three modes:
+ *
+ *   - Legacy (non-envelope) input → returns input unchanged. Caller must handle.
+ *   - Envelope with identity match → returns payload (object).
+ *   - Envelope with identity mismatch → returns null + stderr warning.
+ *   - Envelope with corrupt payload (null/array/non-object) → returns null + warn.
+ *
+ * Identity is checked on producer === 'deep-work', artifact_kind === expectedKind,
+ * schema.name === expectedKind. handoff §4 round-4 lesson.
+ */
+function unwrapEnvelope(obj, expectedKind) {
+  if (!isEnvelope(obj)) return obj;
+  if (!ALLOWED_ARTIFACT_KINDS.has(expectedKind)) {
+    throw new Error(
+      `unwrapEnvelope: expectedKind must be one of ${[...ALLOWED_ARTIFACT_KINDS].join(', ')}, got ${JSON.stringify(expectedKind)}`,
+    );
+  }
+  const env = obj.envelope;
+  const id = {
+    producer: env && env.producer,
+    artifact_kind: env && env.artifact_kind,
+    schema_name: env && env.schema && env.schema.name,
+  };
+  if (
+    id.producer !== PLUGIN_NAME ||
+    id.artifact_kind !== expectedKind ||
+    id.schema_name !== expectedKind
+  ) {
+    process.stderr.write(
+      `[deep-work/envelope] identity mismatch: expected producer=${PLUGIN_NAME} kind=${expectedKind}, got ${JSON.stringify(id)}\n`,
+    );
+    return null;
+  }
+  const payload = obj.payload;
+  if (payload === null || typeof payload !== 'object' || Array.isArray(payload)) {
+    // Round-5/7 lesson: corrupt-payload defense — non-object payload must not
+    // pass through silently.
+    process.stderr.write(
+      `[deep-work/envelope] corrupt payload: expected object, got ${
+        Array.isArray(payload) ? 'array' : typeof payload
+      }\n`,
+    );
+    return null;
+  }
+  return payload;
+}
+
+module.exports = {
+  PLUGIN_NAME,
+  ALLOWED_ARTIFACT_KINDS,
+  ULID_RE,
+  generateUlid,
+  detectGit,
+  loadProducerVersion,
+  wrapEnvelope,
+  isEnvelope,
+  unwrapEnvelope,
+};

--- a/hooks/scripts/receipt-migration.js
+++ b/hooks/scripts/receipt-migration.js
@@ -31,7 +31,29 @@ const V1_DEFAULTS = {
   git_after: '',
 };
 
+// v6.5.0 envelope detection: M3 envelope-wrapped receipts have
+//   { schema_version: "1.0", envelope: { ... }, payload: { ... } }.
+// receipt-migration.js targets the legacy v0 → v1.0 lift only — envelope
+// receipts have already passed through the producer-side wrap helper, which
+// guarantees the payload schema_version is "1.0" and all required fields
+// exist. We treat them as "current" (no-op).
+function isM3Envelope(obj) {
+  return (
+    obj &&
+    typeof obj === 'object' &&
+    !Array.isArray(obj) &&
+    obj.schema_version === '1.0' &&
+    obj.envelope &&
+    typeof obj.envelope === 'object' &&
+    !Array.isArray(obj.envelope) &&
+    obj.payload !== undefined
+  );
+}
+
 function migrateReceipt(receipt) {
+  if (isM3Envelope(receipt)) {
+    return { migrated: false, receipt };
+  }
   if (receipt.schema_version === CURRENT_SCHEMA) {
     return { migrated: false, receipt };
   }
@@ -118,7 +140,7 @@ function main() {
 
 // Export for testing
 if (typeof module !== 'undefined') {
-  module.exports = { migrateReceipt, processFile, CURRENT_SCHEMA, V1_DEFAULTS };
+  module.exports = { migrateReceipt, processFile, CURRENT_SCHEMA, V1_DEFAULTS, isM3Envelope };
 }
 
 // Run if called directly

--- a/hooks/scripts/session-end.sh
+++ b/hooks/scripts/session-end.sh
@@ -175,6 +175,39 @@ append_session_history() {
     local receipt_file
     for receipt_file in "$receipts_dir"/SLICE-*.json; do
       [[ -f "$receipt_file" ]] || continue
+
+      # v6.5.0 envelope identity guard. If the file is an M3 envelope, verify
+      # producer=deep-work + artifact_kind=slice-receipt + schema.name matches
+      # before counting it. Foreign envelopes (e.g. accidentally copied from
+      # another plugin) are skipped silently — slices_total stays accurate.
+      # Legacy (non-envelope) receipts pass through unchanged. Per-field grep
+      # extraction below works on either shape because envelope keys
+      # (producer, producer_version, artifact_kind, run_id, generated_at,
+      # schema, git, provenance) do not collide with payload keys
+      # (slice_id, status, tdd_mode, model_used, tests_passed_first_try, etc.).
+      if command -v node &>/dev/null; then
+        local envelope_ok
+        envelope_ok=$(node -e "
+          try {
+            const fs = require('fs');
+            const d = JSON.parse(fs.readFileSync(process.argv[1],'utf8'));
+            const isEnv = d && typeof d === 'object' && !Array.isArray(d)
+              && d.schema_version === '1.0'
+              && d.envelope && typeof d.envelope === 'object' && !Array.isArray(d.envelope)
+              && Object.prototype.hasOwnProperty.call(d, 'payload');
+            if (!isEnv) { console.log('legacy'); process.exit(0); }
+            const env = d.envelope;
+            const ok = env.producer === 'deep-work'
+              && env.artifact_kind === 'slice-receipt'
+              && env.schema && env.schema.name === 'slice-receipt';
+            console.log(ok ? 'ok' : 'mismatch');
+          } catch (_) { console.log('legacy'); }
+        " "$receipt_file" 2>/dev/null)
+        if [[ "$envelope_ok" == "mismatch" ]]; then
+          continue
+        fi
+      fi
+
       slices_total=$((slices_total + 1))
 
       # Extract per-slice data using lightweight parsing (no jq dependency)

--- a/hooks/scripts/session-end.sh
+++ b/hooks/scripts/session-end.sh
@@ -176,34 +176,30 @@ append_session_history() {
     for receipt_file in "$receipts_dir"/SLICE-*.json; do
       [[ -f "$receipt_file" ]] || continue
 
-      # v6.5.0 envelope identity guard. If the file is an M3 envelope, verify
-      # producer=deep-work + artifact_kind=slice-receipt + schema.name matches
-      # before counting it. Foreign envelopes (e.g. accidentally copied from
-      # another plugin) are skipped silently — slices_total stays accurate.
-      # Legacy (non-envelope) receipts pass through unchanged. Per-field grep
-      # extraction below works on either shape because envelope keys
-      # (producer, producer_version, artifact_kind, run_id, generated_at,
-      # schema, git, provenance) do not collide with payload keys
-      # (slice_id, status, tdd_mode, model_used, tests_passed_first_try, etc.).
-      if command -v node &>/dev/null; then
-        local envelope_ok
-        envelope_ok=$(node -e "
-          try {
-            const fs = require('fs');
-            const d = JSON.parse(fs.readFileSync(process.argv[1],'utf8'));
-            const isEnv = d && typeof d === 'object' && !Array.isArray(d)
-              && d.schema_version === '1.0'
-              && d.envelope && typeof d.envelope === 'object' && !Array.isArray(d.envelope)
-              && Object.prototype.hasOwnProperty.call(d, 'payload');
-            if (!isEnv) { console.log('legacy'); process.exit(0); }
-            const env = d.envelope;
-            const ok = env.producer === 'deep-work'
-              && env.artifact_kind === 'slice-receipt'
-              && env.schema && env.schema.name === 'slice-receipt';
-            console.log(ok ? 'ok' : 'mismatch');
-          } catch (_) { console.log('legacy'); }
-        " "$receipt_file" 2>/dev/null)
-        if [[ "$envelope_ok" == "mismatch" ]]; then
+      # v6.5.0 envelope identity guard — fast-path bash only (round-1
+      # deep-review W6 lesson — Stop hook contract is "must not block session
+      # close"; spawning `node` per receipt added 1-3 s overhead with 30+
+      # slices). The grep checks below are O(file-size) on small JSON, no
+      # process spawn. Foreign envelopes (e.g. accidentally copied from
+      # another plugin) are skipped — slices_total stays accurate. Legacy
+      # (non-envelope) receipts pass through unchanged because they never
+      # contain the substring `"envelope"`.
+      #
+      # Detection logic:
+      #   - File contains `"envelope"` AND `"schema_version": "1.0"`
+      #     → looks like envelope; check identity.
+      #   - Otherwise → legacy receipt; count.
+      #
+      # Per-field grep extraction below works on either shape because
+      # envelope keys (producer, producer_version, artifact_kind, run_id,
+      # generated_at, schema, git, provenance) do not collide with payload
+      # keys (slice_id, status, tdd_mode, model_used, etc.).
+      if grep -q '"envelope"[[:space:]]*:' "$receipt_file" 2>/dev/null \
+         && grep -q '"schema_version"[[:space:]]*:[[:space:]]*"1\.0"' "$receipt_file" 2>/dev/null; then
+        # Envelope-shaped — verify producer + artifact_kind + schema.name.
+        if ! grep -q '"producer"[[:space:]]*:[[:space:]]*"deep-work"' "$receipt_file" 2>/dev/null \
+           || ! grep -q '"artifact_kind"[[:space:]]*:[[:space:]]*"slice-receipt"' "$receipt_file" 2>/dev/null \
+           || ! grep -q '"name"[[:space:]]*:[[:space:]]*"slice-receipt"' "$receipt_file" 2>/dev/null; then
           continue
         fi
       fi

--- a/hooks/scripts/validate-receipt.sh
+++ b/hooks/scripts/validate-receipt.sh
@@ -37,12 +37,34 @@ warn() {
 json_field() {
   local file="$1"
   local field="$2"
+  # v6.5.0 envelope-aware: if the file is an M3 envelope (schema_version "1.0"
+  # + envelope object + payload key), read the field from .payload; else read
+  # from the top level. Identity guard (producer + artifact_kind +
+  # schema.name) for slice/session-receipt prevents foreign artifacts from
+  # being silently mis-identified.
   node -e "
     const fs = require('fs');
     try {
       const d = JSON.parse(fs.readFileSync(process.argv[1], 'utf8'));
+      const isEnv = d && typeof d === 'object' && !Array.isArray(d)
+        && d.schema_version === '1.0'
+        && d.envelope && typeof d.envelope === 'object' && !Array.isArray(d.envelope)
+        && Object.prototype.hasOwnProperty.call(d, 'payload');
+      let root = d;
+      if (isEnv) {
+        const env = d.envelope;
+        const kind = env.artifact_kind;
+        const okIdentity = env.producer === 'deep-work'
+          && (kind === 'slice-receipt' || kind === 'session-receipt')
+          && env.schema && env.schema.name === kind;
+        if (!okIdentity) { console.log(''); process.exit(0); }
+        if (d.payload === null || typeof d.payload !== 'object' || Array.isArray(d.payload)) {
+          console.log(''); process.exit(0);
+        }
+        root = d.payload;
+      }
       const keys = process.argv[2].split('.');
-      let v = d;
+      let v = root;
       for (const k of keys) { v = v?.[k]; }
       console.log(v ?? '');
     } catch(e) { console.log(''); }

--- a/hooks/scripts/verify-delegated-receipt-runner.js
+++ b/hooks/scripts/verify-delegated-receipt-runner.js
@@ -7,6 +7,7 @@ const [scriptDir, stateFile, receiptsDir, planMdPath, skipItemsCsv, onlyComplete
 
 const { verifyReceipts, parsePlanMd, parseStateFile } =
   require(path.join(scriptDir, 'verify-receipt-core.js'));
+const { unwrapEnvelope } = require(path.join(scriptDir, 'envelope.js'));
 
 // N-R2: state file is YAML frontmatter in a Markdown file
 // (.claude/deep-work.{SESSION_ID}.md), NOT JSON. parseStateFile extracts
@@ -17,7 +18,17 @@ const plan = parsePlanMd(planMdPath);
 let receipts = fs.readdirSync(receiptsDir)
   .filter((f) => /^SLICE-\d+\.json$/.test(f))
   .sort()
-  .map((f) => JSON.parse(fs.readFileSync(path.join(receiptsDir, f), 'utf8')));
+  .map((f) => {
+    const obj = JSON.parse(fs.readFileSync(path.join(receiptsDir, f), 'utf8'));
+    // v6.5.0 envelope-aware: unwrapEnvelope returns the original object for
+    // legacy receipts and the payload for envelope-wrapped receipts. Identity
+    // mismatch returns null — treat as missing receipt.
+    const unwrapped = unwrapEnvelope(obj, 'slice-receipt');
+    if (unwrapped === null) {
+      throw new Error(`receipt ${f}: M3 envelope identity mismatch (producer / artifact_kind / schema.name)`);
+    }
+    return unwrapped;
+  });
 
 if (onlyCompleted === '1') {
   receipts = receipts.filter((r) => r.status === 'complete');

--- a/hooks/scripts/verify-delegated-receipt-runner.js
+++ b/hooks/scripts/verify-delegated-receipt-runner.js
@@ -22,10 +22,21 @@ let receipts = fs.readdirSync(receiptsDir)
     const obj = JSON.parse(fs.readFileSync(path.join(receiptsDir, f), 'utf8'));
     // v6.5.0 envelope-aware: unwrapEnvelope returns the original object for
     // legacy receipts and the payload for envelope-wrapped receipts. Identity
-    // mismatch returns null — treat as missing receipt.
+    // mismatch returns null — for true cross-plugin envelope drift this is
+    // a real error; for legacy v0/v1.0 receipts pulled from a pre-6.5
+    // worktree this is *not* a drift but a missing migration. Make the
+    // error actionable so the user knows the recovery path
+    // (round-1 deep-review C3 lesson).
     const unwrapped = unwrapEnvelope(obj, 'slice-receipt');
     if (unwrapped === null) {
-      throw new Error(`receipt ${f}: M3 envelope identity mismatch (producer / artifact_kind / schema.name)`);
+      throw new Error(
+        `receipt ${f}: M3 envelope identity mismatch ` +
+        `(producer / artifact_kind / schema.name). If this receipt was ` +
+        `emitted by a pre-6.5.0 deep-work session, run ` +
+        `"node ${path.join(scriptDir, 'receipt-migration.js')} ${receiptsDir}" ` +
+        `to detect format. If it was emitted by a different plugin, remove it ` +
+        `from ${receiptsDir} — only deep-work slice-receipt envelopes are valid here.`,
+      );
     }
     return unwrapped;
   });

--- a/hooks/scripts/verify-delegated-receipt-runner.js
+++ b/hooks/scripts/verify-delegated-receipt-runner.js
@@ -29,13 +29,17 @@ let receipts = fs.readdirSync(receiptsDir)
     // (round-1 deep-review C3 lesson).
     const unwrapped = unwrapEnvelope(obj, 'slice-receipt');
     if (unwrapped === null) {
+      // Quote interpolated paths so the suggested recovery command remains
+      // copy-paste safe even if scriptDir/receiptsDir contain spaces
+      // (round-2 deep-review I-1).
+      const migrationCmd = `node '${path.join(scriptDir, 'receipt-migration.js')}' '${receiptsDir}'`;
       throw new Error(
         `receipt ${f}: M3 envelope identity mismatch ` +
         `(producer / artifact_kind / schema.name). If this receipt was ` +
         `emitted by a pre-6.5.0 deep-work session, run ` +
-        `"node ${path.join(scriptDir, 'receipt-migration.js')} ${receiptsDir}" ` +
+        `${migrationCmd} ` +
         `to detect format. If it was emitted by a different plugin, remove it ` +
-        `from ${receiptsDir} — only deep-work slice-receipt envelopes are valid here.`,
+        `from '${receiptsDir}' — only deep-work slice-receipt envelopes are valid here.`,
       );
     }
     return unwrapped;

--- a/hooks/scripts/verify-delegated-receipt.sh
+++ b/hooks/scripts/verify-delegated-receipt.sh
@@ -32,6 +32,19 @@ if ! command -v node >/dev/null 2>&1; then
   exit 1
 fi
 
+# v6.5.0 — Auto-migrate legacy v0 receipts to v1.0 schema before envelope
+# unwrap. Resumed sessions on a worktree pulled from pre-6.5.0 will have
+# legacy receipts that the runner's unwrapEnvelope() treats as legacy
+# (returns the input as-is); receipt-migration.js fills missing v1.0 fields
+# in place so verify-receipt-core sees a complete payload. Envelope-wrapped
+# receipts are recognised as already-current and skipped (no-op). Migration
+# failures (corrupt JSON, IO error) are logged but never block verification —
+# verify-receipt-core's own checks will surface the real issue.
+# (Round-1 deep-review C3+W7 lesson.)
+if [ -d "$RECEIPTS_DIR" ]; then
+  node "$SCRIPT_DIR/receipt-migration.js" "$RECEIPTS_DIR" >/dev/null 2>&1 || true
+fi
+
 node "$SCRIPT_DIR/verify-delegated-receipt-runner.js" \
      "$SCRIPT_DIR" "$STATE_FILE" "$RECEIPTS_DIR" "$PLAN_MD_PATH" \
      "$SKIP_ITEMS" "$ONLY_COMPLETED"

--- a/hooks/scripts/wrap-receipt-envelope.js
+++ b/hooks/scripts/wrap-receipt-envelope.js
@@ -1,0 +1,248 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * wrap-receipt-envelope.js — CLI to wrap a deep-work receipt payload in the
+ * M3 cross-plugin envelope (cf. claude-deep-suite/docs/envelope-migration.md §1).
+ *
+ * Designed to be called from markdown agent prompts (deep-finish.md,
+ * agents/implement-slice-worker.md) via the Bash tool. The agent writes the
+ * domain payload to a temp file, then invokes this helper to produce the final
+ * receipt artifact at the canonical path.
+ *
+ * Usage:
+ *   node wrap-receipt-envelope.js \
+ *     --artifact-kind <session-receipt|slice-receipt> \
+ *     --payload-file <path-to-payload.json> \
+ *     --output <path-to-final-receipt.json> \
+ *     [--parent-run-id <ULID>] \
+ *     [--session-id <id>] \
+ *     [--source-artifacts-glob <glob>]   (slice receipts → session-receipt: aggregate intra-plugin chain)
+ *     [--source-evolve-insights <path>]  (cross-plugin chain — also fills parent_run_id if not set)
+ *     [--source-harnessability <path>]   (cross-plugin chain — adds to source_artifacts only)
+ *
+ * Exit codes:
+ *   0 — wrote envelope-wrapped receipt
+ *   2 — usage / IO / argv error
+ *
+ * Self-contained: no external deps. The envelope shape is enforced by the
+ * companion validator (scripts/validate-envelope-emit.js).
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const env = require('./envelope');
+
+function usage(extra) {
+  if (extra) process.stderr.write(`error: ${extra}\n`);
+  process.stderr.write(
+    'usage: wrap-receipt-envelope.js --artifact-kind <session-receipt|slice-receipt>\n' +
+      '                                 --payload-file <payload.json>\n' +
+      '                                 --output <receipt.json>\n' +
+      '                                 [--parent-run-id <ULID>]\n' +
+      '                                 [--session-id <id>]\n' +
+      '                                 [--source-artifacts-glob <glob>]\n' +
+      '                                 [--source-evolve-insights <path>]\n' +
+      '                                 [--source-harnessability <path>]\n',
+  );
+  process.exit(2);
+}
+
+const KNOWN_FLAGS = new Set([
+  'artifact-kind',
+  'payload-file',
+  'output',
+  'parent-run-id',
+  'session-id',
+  'source-artifacts-glob',
+  'source-evolve-insights',
+  'source-harnessability',
+]);
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (!a.startsWith('--')) {
+      usage(`unexpected positional argument: ${a}`);
+    }
+    let key;
+    let value;
+    if (a.includes('=')) {
+      const eq = a.indexOf('=');
+      key = a.slice(2, eq);
+      value = a.slice(eq + 1);
+    } else {
+      key = a.slice(2);
+      const next = argv[i + 1];
+      if (next === undefined || next.startsWith('--')) {
+        usage(`flag --${key} expects a value`);
+      }
+      value = next;
+      i++;
+    }
+    if (!KNOWN_FLAGS.has(key)) {
+      usage(`unknown flag --${key}`);
+    }
+    args[key] = value;
+  }
+  return args;
+}
+
+function readJson(p) {
+  let raw;
+  try {
+    raw = fs.readFileSync(p, 'utf8');
+  } catch (err) {
+    process.stderr.write(`error: cannot read ${p}: ${err.message}\n`);
+    process.exit(2);
+  }
+  try {
+    return JSON.parse(raw);
+  } catch (err) {
+    process.stderr.write(`error: cannot parse ${p} as JSON: ${err.message}\n`);
+    process.exit(2);
+  }
+}
+
+function tryReadEnvelopeRunId(filePath) {
+  if (!filePath || !fs.existsSync(filePath)) return null;
+  try {
+    const obj = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    if (env.isEnvelope(obj) && obj.envelope && typeof obj.envelope.run_id === 'string') {
+      return obj.envelope.run_id;
+    }
+    return null;
+  } catch (_err) {
+    return null;
+  }
+}
+
+function expandSourceArtifactsGlob(globArg, baseCwd) {
+  // Minimal POSIX-style glob: supports a single trailing `*` segment within
+  // a literal directory path (e.g. `WORK_DIR/receipts/SLICE-*.json`).
+  // Sufficient for deep-work's session-receipt → slice-receipt aggregation.
+  if (!globArg) return [];
+  const abs = path.isAbsolute(globArg) ? globArg : path.resolve(baseCwd, globArg);
+  const dir = path.dirname(abs);
+  const pattern = path.basename(abs);
+  if (!fs.existsSync(dir) || !fs.statSync(dir).isDirectory()) {
+    return [];
+  }
+  const escaped = pattern
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+    .replace(/\*/g, '.*');
+  const re = new RegExp('^' + escaped + '$');
+  return fs.readdirSync(dir)
+    .filter((f) => re.test(f))
+    .sort()
+    .map((f) => path.join(dir, f));
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const required = ['artifact-kind', 'payload-file', 'output'];
+  for (const r of required) {
+    if (!args[r]) usage(`missing required flag --${r}`);
+  }
+
+  const artifactKind = args['artifact-kind'];
+  if (!env.ALLOWED_ARTIFACT_KINDS.has(artifactKind)) {
+    usage(
+      `--artifact-kind must be one of ${[...env.ALLOWED_ARTIFACT_KINDS].join(', ')}, got "${artifactKind}"`,
+    );
+  }
+
+  const payloadPath = path.resolve(process.cwd(), args['payload-file']);
+  const outputPath = path.resolve(process.cwd(), args['output']);
+
+  const payload = readJson(payloadPath);
+  if (payload === null || typeof payload !== 'object' || Array.isArray(payload)) {
+    process.stderr.write(
+      `error: payload at ${payloadPath} must be a non-null, non-array object\n`,
+    );
+    process.exit(2);
+  }
+
+  // Cross-plugin chain: harvest run_ids from consumed artifacts.
+  const sourceArtifacts = [];
+
+  // Cross-plugin: deep-evolve evolve-insights (handoff §3.3 chain row).
+  let parentRunId = args['parent-run-id'] || undefined;
+  if (args['source-evolve-insights']) {
+    const evolvePath = path.resolve(process.cwd(), args['source-evolve-insights']);
+    const evolveRunId = tryReadEnvelopeRunId(evolvePath);
+    sourceArtifacts.push({
+      path: args['source-evolve-insights'],
+      ...(evolveRunId ? { run_id: evolveRunId } : {}),
+    });
+    if (!parentRunId && evolveRunId) {
+      parentRunId = evolveRunId;
+    }
+  }
+
+  // Cross-plugin: deep-dashboard harnessability-report (multi-source, no parent).
+  if (args['source-harnessability']) {
+    const harnPath = path.resolve(process.cwd(), args['source-harnessability']);
+    const harnRunId = tryReadEnvelopeRunId(harnPath);
+    sourceArtifacts.push({
+      path: args['source-harnessability'],
+      ...(harnRunId ? { run_id: harnRunId } : {}),
+    });
+  }
+
+  // Intra-plugin: session-receipt aggregates slice receipts.
+  if (args['source-artifacts-glob']) {
+    const slicePaths = expandSourceArtifactsGlob(args['source-artifacts-glob'], process.cwd());
+    for (const sp of slicePaths) {
+      const runId = tryReadEnvelopeRunId(sp);
+      const rel = path.relative(process.cwd(), sp);
+      sourceArtifacts.push({
+        path: rel.length > 0 ? rel : sp,
+        ...(runId ? { run_id: runId } : {}),
+      });
+    }
+  }
+
+  let wrapped;
+  try {
+    wrapped = env.wrapEnvelope({
+      artifactKind,
+      payload,
+      parentRunId,
+      sessionId: args['session-id'] || undefined,
+      sourceArtifacts,
+    });
+  } catch (err) {
+    process.stderr.write(`error: ${err.message}\n`);
+    process.exit(2);
+  }
+
+  const outDir = path.dirname(outputPath);
+  if (!fs.existsSync(outDir)) {
+    try {
+      fs.mkdirSync(outDir, { recursive: true });
+    } catch (err) {
+      process.stderr.write(`error: cannot mkdir ${outDir}: ${err.message}\n`);
+      process.exit(2);
+    }
+  }
+
+  try {
+    fs.writeFileSync(outputPath, JSON.stringify(wrapped, null, 2) + '\n', 'utf8');
+  } catch (err) {
+    process.stderr.write(`error: cannot write ${outputPath}: ${err.message}\n`);
+    process.exit(2);
+  }
+
+  process.stdout.write(
+    `wrapped: ${outputPath} (run_id=${wrapped.envelope.run_id}, artifact_kind=${wrapped.envelope.artifact_kind})\n`,
+  );
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { expandSourceArtifactsGlob, tryReadEnvelopeRunId };

--- a/hooks/scripts/wrap-receipt-envelope.js
+++ b/hooks/scripts/wrap-receipt-envelope.js
@@ -110,7 +110,12 @@ function tryReadEnvelopeRunId(filePath) {
   if (!filePath || !fs.existsSync(filePath)) return null;
   try {
     const obj = JSON.parse(fs.readFileSync(filePath, 'utf8'));
-    if (env.isEnvelope(obj) && obj.envelope && typeof obj.envelope.run_id === 'string') {
+    // Round-1 deep-review W4: require strict envelope (payload non-null/
+    // non-array object), not just structural shape. A corrupt envelope's
+    // run_id must not contribute to provenance.source_artifacts[] —
+    // downstream readers would have a chain pointing at a payload that
+    // unwrapEnvelope rejects.
+    if (env.isValidEnvelope(obj) && typeof obj.envelope.run_id === 'string') {
       return obj.envelope.run_id;
     }
     return null;
@@ -229,10 +234,25 @@ function main() {
     }
   }
 
+  // C1 (round 1) — Atomic write: write to a unique temp path then rename.
+  // Mid-write interruption (Ctrl-C, OOM, hook timeout) or two concurrent
+  // finishers must not leave a truncated session-receipt.json that downstream
+  // readers (verify-delegated-receipt-runner.js, validate-receipt.sh,
+  // gather-signals.sh) parse-fail on. Mirrors the temp+rename pattern used by
+  // receipt-migration.js:103-106 and session-end.sh's _append_with_lock.
+  const tmpPath = `${outputPath}.tmp.${process.pid}.${Date.now()}`;
   try {
-    fs.writeFileSync(outputPath, JSON.stringify(wrapped, null, 2) + '\n', 'utf8');
+    fs.writeFileSync(tmpPath, JSON.stringify(wrapped, null, 2) + '\n', 'utf8');
   } catch (err) {
-    process.stderr.write(`error: cannot write ${outputPath}: ${err.message}\n`);
+    try { fs.unlinkSync(tmpPath); } catch (_) { /* ignore */ }
+    process.stderr.write(`error: cannot write ${tmpPath}: ${err.message}\n`);
+    process.exit(2);
+  }
+  try {
+    fs.renameSync(tmpPath, outputPath);
+  } catch (err) {
+    try { fs.unlinkSync(tmpPath); } catch (_) { /* ignore */ }
+    process.stderr.write(`error: cannot rename ${tmpPath} → ${outputPath}: ${err.message}\n`);
     process.exit(2);
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-deep-work/deep-work",
-  "version": "6.4.2",
+  "version": "6.5.0",
   "description": "Deep Work plugin for Claude Code - Evidence-Driven Development Protocol with TDD enforcement, Health Engine (drift detection + fitness functions), worktree isolation, model auto-routing, receipt validation, 6-phase workflow with Phase 5 Integrate",
   "author": "sungmin",
   "license": "MIT",

--- a/scripts/validate-envelope-emit.js
+++ b/scripts/validate-envelope-emit.js
@@ -1,0 +1,293 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * validate-envelope-emit.js — Self-test validator for deep-work's M3 envelope
+ * emission. Mirrors the suite-side schema (claude-deep-suite/schemas/
+ * artifact-envelope.schema.json) without external deps so this works as a
+ * release-lint inside the deep-work plugin's own CI/test pipeline.
+ *
+ * Validates:
+ *   - Top-level shape (schema_version === '1.0', envelope object, payload object).
+ *   - additionalProperties:false on root, envelope, git, schema, provenance,
+ *     source_artifacts items (root + envelope allow `^x-` prefixed keys).
+ *   - producer === 'deep-work' (plugin identity).
+ *   - artifact_kind === schema.name (envelope identity guard — round-4 lesson).
+ *   - artifact_kind ∈ {session-receipt, slice-receipt}.
+ *   - run_id is 26-char Crockford Base32 ULID.
+ *   - parent_run_id (if present) is 26-char ULID.
+ *   - producer_version is SemVer 2.0.0 strict.
+ *   - generated_at is RFC 3339.
+ *   - git.head matches /^[a-f0-9]{7,40}$/, git.dirty ∈ {true,false,'unknown'}.
+ *   - provenance.source_artifacts[].path non-empty, run_id (if present) is ULID.
+ *   - provenance.tool_versions container is object (not array).
+ *   - provenance.tool_versions values are string OR (object && !array).
+ *   - payload is non-null, non-array object.
+ *   - payload.schema_version === '1.0' (preserved field from legacy receipts).
+ *
+ * Usage:
+ *   node validate-envelope-emit.js <file.json> [<file2.json> ...]
+ *
+ * Exit codes:
+ *   0 — all valid
+ *   1 — at least one validation error
+ *   2 — usage / IO error
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const KEBAB_RE = /^[a-z][a-z0-9]*(-[a-z0-9]+)*$/;
+const ULID_RE = /^[0-9A-HJKMNP-TV-Z]{26}$/;
+// Official SemVer 2.0.0 regex (semver.org).
+const SEMVER_RE =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
+const RFC3339_RE =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
+const GIT_HEAD_RE = /^[a-f0-9]{7,40}$/;
+const SCHEMA_VERSION_RE = /^\d+\.\d+$/;
+
+const PLUGIN_NAME = 'deep-work';
+const ALLOWED_KINDS = new Set(['session-receipt', 'slice-receipt']);
+
+const ROOT_KEYS = new Set(['$schema', 'schema_version', 'envelope', 'payload']);
+const ENVELOPE_KEYS = new Set([
+  'producer', 'producer_version', 'artifact_kind', 'run_id', 'session_id',
+  'parent_run_id', 'generated_at', 'schema', 'git', 'provenance',
+]);
+const ENVELOPE_REQUIRED = [
+  'producer', 'producer_version', 'artifact_kind', 'run_id', 'generated_at',
+  'schema', 'git', 'provenance',
+];
+const SCHEMA_KEYS = new Set(['name', 'version']);
+const GIT_KEYS = new Set(['head', 'branch', 'worktree', 'dirty']);
+const GIT_REQUIRED = ['head', 'branch', 'dirty'];
+const PROVENANCE_KEYS = new Set(['source_artifacts', 'tool_versions']);
+const SOURCE_ARTIFACT_KEYS = new Set(['path', 'run_id']);
+
+function isPlainObject(v) {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+function checkAdditionalProps(obj, allowed, label, errors, allowXPrefix) {
+  for (const k of Object.keys(obj)) {
+    if (allowed.has(k)) continue;
+    if (allowXPrefix && k.startsWith('x-')) continue;
+    errors.push(`${label}: unknown key "${k}"`);
+  }
+}
+
+function validateGit(git, errors) {
+  if (!isPlainObject(git)) {
+    errors.push('envelope.git: must be an object');
+    return;
+  }
+  for (const r of GIT_REQUIRED) {
+    if (!(r in git)) errors.push(`envelope.git: missing required key "${r}"`);
+  }
+  checkAdditionalProps(git, GIT_KEYS, 'envelope.git', errors, false);
+  if (typeof git.head === 'string' && !GIT_HEAD_RE.test(git.head)) {
+    errors.push(`envelope.git.head: must match /^[a-f0-9]{7,40}$/, got "${git.head}"`);
+  }
+  if (typeof git.branch !== 'string' || git.branch.length === 0) {
+    errors.push('envelope.git.branch: must be non-empty string');
+  }
+  if (
+    typeof git.dirty !== 'boolean' &&
+    git.dirty !== 'unknown'
+  ) {
+    errors.push(`envelope.git.dirty: must be boolean or "unknown", got ${JSON.stringify(git.dirty)}`);
+  }
+  if ('worktree' in git && typeof git.worktree !== 'string') {
+    errors.push('envelope.git.worktree: if present, must be string');
+  }
+}
+
+function validateSchemaBlock(schema, artifactKind, errors) {
+  if (!isPlainObject(schema)) {
+    errors.push('envelope.schema: must be an object');
+    return;
+  }
+  checkAdditionalProps(schema, SCHEMA_KEYS, 'envelope.schema', errors, false);
+  if (typeof schema.name !== 'string' || schema.name.length === 0) {
+    errors.push('envelope.schema.name: must be non-empty string');
+  }
+  if (typeof schema.version !== 'string' || !SCHEMA_VERSION_RE.test(schema.version)) {
+    errors.push(`envelope.schema.version: must match /^\\d+\\.\\d+$/, got ${JSON.stringify(schema.version)}`);
+  }
+  // Identity check (round-4 lesson).
+  if (schema.name !== artifactKind) {
+    errors.push(
+      `envelope.schema.name (${JSON.stringify(schema.name)}) must equal envelope.artifact_kind (${JSON.stringify(artifactKind)})`,
+    );
+  }
+}
+
+function validateProvenance(prov, errors) {
+  if (!isPlainObject(prov)) {
+    errors.push('envelope.provenance: must be an object');
+    return;
+  }
+  for (const r of ['source_artifacts', 'tool_versions']) {
+    if (!(r in prov)) errors.push(`envelope.provenance: missing required key "${r}"`);
+  }
+  checkAdditionalProps(prov, PROVENANCE_KEYS, 'envelope.provenance', errors, false);
+
+  if ('source_artifacts' in prov) {
+    if (!Array.isArray(prov.source_artifacts)) {
+      errors.push('envelope.provenance.source_artifacts: must be array');
+    } else {
+      prov.source_artifacts.forEach((sa, idx) => {
+        if (!isPlainObject(sa)) {
+          errors.push(`envelope.provenance.source_artifacts[${idx}]: must be object`);
+          return;
+        }
+        checkAdditionalProps(sa, SOURCE_ARTIFACT_KEYS, `envelope.provenance.source_artifacts[${idx}]`, errors, false);
+        if (typeof sa.path !== 'string' || sa.path.length === 0) {
+          errors.push(`envelope.provenance.source_artifacts[${idx}].path: must be non-empty string`);
+        }
+        if ('run_id' in sa && typeof sa.run_id !== 'string') {
+          errors.push(`envelope.provenance.source_artifacts[${idx}].run_id: must be string`);
+        }
+      });
+    }
+  }
+
+  if ('tool_versions' in prov) {
+    // JS gotcha: `typeof [] === 'object'`. Guard with Array.isArray() (handoff §4 round-3).
+    if (!isPlainObject(prov.tool_versions)) {
+      errors.push('envelope.provenance.tool_versions: must be object (not array)');
+    } else {
+      for (const [k, v] of Object.entries(prov.tool_versions)) {
+        const isString = typeof v === 'string';
+        const isObject = isPlainObject(v);
+        if (!isString && !isObject) {
+          errors.push(
+            `envelope.provenance.tool_versions[${JSON.stringify(k)}]: must be string or object, got ${
+              Array.isArray(v) ? 'array' : typeof v
+            }`,
+          );
+        }
+      }
+    }
+  }
+}
+
+function validateEnvelopeBlock(env, errors) {
+  if (!isPlainObject(env)) {
+    errors.push('envelope: must be an object');
+    return;
+  }
+  for (const r of ENVELOPE_REQUIRED) {
+    if (!(r in env)) errors.push(`envelope: missing required key "${r}"`);
+  }
+  checkAdditionalProps(env, ENVELOPE_KEYS, 'envelope', errors, true);
+
+  if (env.producer !== PLUGIN_NAME) {
+    errors.push(`envelope.producer: must be "${PLUGIN_NAME}", got ${JSON.stringify(env.producer)}`);
+  }
+  if (typeof env.producer_version !== 'string' || !SEMVER_RE.test(env.producer_version)) {
+    errors.push(`envelope.producer_version: must be SemVer 2.0.0, got ${JSON.stringify(env.producer_version)}`);
+  }
+  if (typeof env.artifact_kind !== 'string' || !KEBAB_RE.test(env.artifact_kind)) {
+    errors.push(`envelope.artifact_kind: must be kebab-case, got ${JSON.stringify(env.artifact_kind)}`);
+  } else if (!ALLOWED_KINDS.has(env.artifact_kind)) {
+    errors.push(
+      `envelope.artifact_kind: must be one of ${[...ALLOWED_KINDS].join(', ')}, got ${JSON.stringify(env.artifact_kind)}`,
+    );
+  }
+  if (typeof env.run_id !== 'string' || !ULID_RE.test(env.run_id)) {
+    errors.push(`envelope.run_id: must be 26-char Crockford Base32 ULID, got ${JSON.stringify(env.run_id)}`);
+  }
+  if ('parent_run_id' in env) {
+    if (typeof env.parent_run_id !== 'string' || !ULID_RE.test(env.parent_run_id)) {
+      errors.push(
+        `envelope.parent_run_id: if present, must be 26-char ULID, got ${JSON.stringify(env.parent_run_id)}`,
+      );
+    }
+  }
+  if ('session_id' in env && typeof env.session_id !== 'string') {
+    errors.push('envelope.session_id: if present, must be string');
+  }
+  if (typeof env.generated_at !== 'string' || !RFC3339_RE.test(env.generated_at)) {
+    errors.push(`envelope.generated_at: must be RFC 3339, got ${JSON.stringify(env.generated_at)}`);
+  }
+  validateSchemaBlock(env.schema, env.artifact_kind, errors);
+  validateGit(env.git, errors);
+  validateProvenance(env.provenance, errors);
+}
+
+function validateRoot(obj, errors) {
+  if (!isPlainObject(obj)) {
+    errors.push('root: must be an object');
+    return;
+  }
+  for (const r of ['schema_version', 'envelope', 'payload']) {
+    if (!(r in obj)) errors.push(`root: missing required key "${r}"`);
+  }
+  checkAdditionalProps(obj, ROOT_KEYS, 'root', errors, true);
+  if (obj.schema_version !== '1.0') {
+    errors.push(`root.schema_version: must be "1.0", got ${JSON.stringify(obj.schema_version)}`);
+  }
+  validateEnvelopeBlock(obj.envelope, errors);
+
+  // Payload shape: minimal — non-null, non-array object. Domain-specific
+  // payload schema lives in claude-deep-suite payload-registry (Phase 3).
+  if (obj.payload === null || typeof obj.payload !== 'object' || Array.isArray(obj.payload)) {
+    errors.push('payload: must be a non-null, non-array object');
+  }
+  // Preserve legacy contract: payload retains its own schema_version === '1.0'.
+  if (isPlainObject(obj.payload) && obj.payload.schema_version !== '1.0') {
+    errors.push(`payload.schema_version: must be "1.0", got ${JSON.stringify(obj.payload.schema_version)}`);
+  }
+}
+
+function validate(filePath) {
+  let raw;
+  try {
+    raw = fs.readFileSync(filePath, 'utf8');
+  } catch (err) {
+    return { ok: false, errors: [`cannot read ${filePath}: ${err.message}`], ioError: true };
+  }
+  let obj;
+  try {
+    obj = JSON.parse(raw);
+  } catch (err) {
+    return { ok: false, errors: [`cannot parse ${filePath}: ${err.message}`] };
+  }
+  const errors = [];
+  validateRoot(obj, errors);
+  return { ok: errors.length === 0, errors };
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  if (argv.length === 0) {
+    process.stderr.write('usage: validate-envelope-emit.js <file.json> [<file2.json> ...]\n');
+    process.exit(2);
+  }
+  let allOk = true;
+  for (const a of argv) {
+    const filePath = path.resolve(process.cwd(), a);
+    const r = validate(filePath);
+    if (r.ok) {
+      process.stdout.write(`OK   ${a}\n`);
+    } else {
+      allOk = false;
+      process.stdout.write(`FAIL ${a}\n`);
+      for (const e of r.errors) {
+        process.stdout.write(`  - ${e}\n`);
+      }
+      if (r.ioError) {
+        process.exit(2);
+      }
+    }
+  }
+  process.exit(allOk ? 0 : 1);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { validate, validateRoot, ULID_RE, SEMVER_RE, RFC3339_RE };

--- a/skills/deep-integrate/gather-signals.sh
+++ b/skills/deep-integrate/gather-signals.sh
@@ -174,16 +174,43 @@ else
   fi
 fi
 
-# ─── Artifacts collection (defensive) ───────────────────────
+# ─── Artifacts collection (defensive, envelope-aware v6.5.0) ───────
+# read_json_safe <path> [<expected_producer> [<expected_artifact_kind>]]
+#
+# Detects M3 envelope wrapping (cf. claude-deep-suite/docs/envelope-migration.md
+# §1: schema_version === "1.0" + envelope object + payload key) and returns
+# `.payload` instead of the wrapped root. Identity guard: when expected_producer
+# / expected_artifact_kind are provided, foreign envelopes resolve to null
+# (handoff §4 round-4 lesson — defense-in-depth against another plugin's
+# artifact landing at the same cache path).
+#
+# Legacy (non-envelope) JSON passes through unchanged. Invalid JSON also
+# resolves to null with a warn message (preserved behavior).
 read_json_safe() {
   local path="$1"
+  local expected_producer="${2:-}"
+  local expected_kind="${3:-}"
   if [[ ! -s "$path" ]]; then echo "null"; return; fi
-  if jq -e 'type' "$path" >/dev/null 2>&1; then
-    cat "$path"
-  else
+  if ! jq -e 'type' "$path" >/dev/null 2>&1; then
     warn "invalid JSON at $path — null fallback"
-    echo "null"
+    echo "null"; return
   fi
+  jq --arg ep "$expected_producer" --arg ek "$expected_kind" '
+    if (.schema_version == "1.0"
+        and ((.envelope|type) == "object")
+        and has("payload")) then
+      if (($ep == "" or .envelope.producer == $ep)
+          and ($ek == "" or .envelope.artifact_kind == $ek)
+          and (.envelope.schema.name == .envelope.artifact_kind)
+          and ((.payload|type) == "object")) then
+        .payload
+      else
+        null
+      end
+    else
+      .
+    end
+  ' "$path"
 }
 
 # C2 fix 원칙: 설치된 플러그인은 **placeholder object(모든 필드 null)** 반환,
@@ -194,7 +221,9 @@ read_json_safe() {
 # 항상 true였고 의도 전달만 방해했음 — v6.3.0 review W3)
 if [[ -n "$SESSION_ID" && -n "$WORK_DIR_SLUG" ]]; then
   sr="$PROJECT_ROOT/$WORK_DIR_SLUG/session-receipt.json"
-  dw_artifact=$(read_json_safe "$sr")
+  # v6.5.0: deep-work emits its own session-receipt as an M3 envelope. Identity
+  # guard ensures we don't accept another plugin's envelope at the same path.
+  dw_artifact=$(read_json_safe "$sr" "deep-work" "session-receipt")
   dw_json=$(jq -n --argjson sr "$dw_artifact" --arg p "$PROJECT_ROOT/$WORK_DIR_SLUG/report.md" \
     '{session_receipt:$sr, report_md_path:$p}')
 else
@@ -202,8 +231,11 @@ else
 fi
 
 # deep-review (C2 fix: 설치된 경우 항상 object 반환)
+# v6.5.0 envelope-aware: recurring-findings will be wrapped in M3 envelope when
+# claude-deep-review adopts it (Phase 2 priority #5). Identity guard prevents
+# foreign envelopes at the same path from leaking into our consumption.
 if printf '%s' "$PLUGINS_JSON" | jq -e '.installed[]? | select(.=="deep-review")' >/dev/null 2>&1; then
-  rf=$(read_json_safe "$PROJECT_ROOT/.deep-review/recurring-findings.json")
+  rf=$(read_json_safe "$PROJECT_ROOT/.deep-review/recurring-findings.json" "deep-review" "recurring-findings")
   fitness=$(read_json_safe "$PROJECT_ROOT/.deep-review/fitness.json")
   latest_report="$(ls -1t "$PROJECT_ROOT"/.deep-review/reports/*-review.md 2>/dev/null | head -1 || true)"
   latest_json=$(jq -n --arg p "$latest_report" 'if $p == "" then null else $p end')
@@ -234,9 +266,11 @@ else
 fi
 
 # deep-docs (C2 fix)
+# v6.5.0 envelope-aware: deep-docs already adopted M3 envelope (Phase 2 #1).
+# Identity guard rejects foreign envelopes at .deep-docs/last-scan.json.
 if printf '%s' "$PLUGINS_JSON" | jq -e '.installed[]? | select(.=="deep-docs")' >/dev/null 2>&1; then
   ls_path="$PROJECT_ROOT/.deep-docs/last-scan.json"
-  ls_raw=$(read_json_safe "$ls_path")
+  ls_raw=$(read_json_safe "$ls_path" "deep-docs" "last-scan")
   if [[ "$ls_raw" != "null" ]]; then
     scanned_at=$(printf '%s' "$ls_raw" | jq -r '.scanned_at // empty')
     issues_summary=$(printf '%s' "$ls_raw" | jq '[.documents[]? | {(.path): (.issues | length)}] | add // {}')
@@ -252,8 +286,10 @@ else
 fi
 
 # deep-dashboard (C2, C3 fix: `.name` → `.id`)
+# v6.5.0 envelope-aware: deep-dashboard already adopted M3 envelope (Phase 2 #2).
+# Identity guard rejects foreign envelopes at .deep-dashboard/harnessability-report.json.
 if printf '%s' "$PLUGINS_JSON" | jq -e '.installed[]? | select(.=="deep-dashboard")' >/dev/null 2>&1; then
-  h_raw=$(read_json_safe "$PROJECT_ROOT/.deep-dashboard/harnessability-report.json")
+  h_raw=$(read_json_safe "$PROJECT_ROOT/.deep-dashboard/harnessability-report.json" "deep-dashboard" "harnessability-report")
   if [[ "$h_raw" != "null" ]]; then
     score=$(printf '%s' "$h_raw" | jq '.total // null')
     # C3 fix: scorer.js dimension field는 {id, label, weight, score, checks}이며 `.name`은 없음
@@ -270,11 +306,14 @@ fi
 
 # deep-evolve (C2 fix)
 if printf '%s' "$PLUGINS_JSON" | jq -e '.installed[]? | select(.=="deep-evolve")' >/dev/null 2>&1; then
+  # current.json is a small index file maintained by deep-evolve — left as legacy
+  # (no envelope expected). evolve-insights.json will move to envelope when
+  # claude-deep-evolve adopts M3 (Phase 2 priority #4).
   current_json=$(read_json_safe "$PROJECT_ROOT/.deep-evolve/current.json")
   if [[ "$current_json" != "null" ]]; then
     evolve_sid=$(printf '%s' "$current_json" | jq -r '.session_id // empty')
     if [[ -n "$evolve_sid" ]]; then
-      insights_json=$(read_json_safe "$PROJECT_ROOT/.deep-evolve/$evolve_sid/evolve-insights.json")
+      insights_json=$(read_json_safe "$PROJECT_ROOT/.deep-evolve/$evolve_sid/evolve-insights.json" "deep-evolve" "evolve-insights")
       de_json=$(jq -n --argjson i "$insights_json" --arg sid "$evolve_sid" \
         '{session_id:$sid, insights:$i}')
     else
@@ -288,10 +327,20 @@ else
 fi
 
 # deep-wiki (C2 fix)
+# v6.5.0 envelope-aware: wiki index.json will move to envelope when
+# claude-deep-wiki adopts M3 (Phase 2 priority #6). Until then, the legacy
+# pass-through branch keeps `pages` at the top level. After adoption, the
+# read_json_safe envelope unwrap returns the payload, which keeps `pages` at
+# the same top level — so the `.pages | length` jq expression remains correct.
 if printf '%s' "$PLUGINS_JSON" | jq -e '.installed[]? | select(.=="deep-wiki")' >/dev/null 2>&1; then
   widx="$PROJECT_ROOT/.wiki-meta/index.json"
   if [[ -f "$widx" ]]; then
-    pages_count=$(jq 'try (.pages | length) catch 0' "$widx" 2>/dev/null || echo 0)
+    widx_payload=$(read_json_safe "$widx" "deep-wiki" "index")
+    if [[ "$widx_payload" == "null" ]]; then
+      pages_count=0
+    else
+      pages_count=$(printf '%s' "$widx_payload" | jq 'try (.pages | length) catch 0' 2>/dev/null || echo 0)
+    fi
     dwiki_json=$(jq -n --argjson pc "$pages_count" '{pages_count:$pc}')
   else
     dwiki_json='{"pages_count":null}'

--- a/skills/deep-research/SKILL.md
+++ b/skills/deep-research/SKILL.md
@@ -60,31 +60,37 @@ $ARGUMENTS에 `--incremental` 포함 시: `last_research_commit` 기준 git diff
 
 Phase 1 Research 시작 시 외부 플러그인 데이터를 참조한다. 이 데이터는 "참고" 수준이며, 현재 작업과 관련 없으면 무시한다.
 
-### Harnessability Context
+### Harnessability Context (envelope-aware v6.5.0)
 
 `.deep-dashboard/harnessability-report.json`이 존재하면:
-1. 파일 읽기 및 freshness 확인:
-   - `generated_at` 필드가 있으면 현재 시점과 비교
+1. 파일 읽기 및 envelope 감지:
+   - 파일이 M3 envelope 형태(`{schema_version: "1.0", envelope: {...}, payload: {...}}`)이면 identity guard를 적용:
+     `envelope.producer === "deep-dashboard"` ∧ `envelope.artifact_kind === "harnessability-report"` ∧ `envelope.schema.name === envelope.artifact_kind` 가 모두 참인 경우에만 `payload`를 사용. 하나라도 어긋나면 "foreign envelope at harnessability-report path — skip" 경고 후 건너뜀.
+   - Legacy(non-envelope) 파일이면 root 객체를 그대로 사용 (forward-compat).
+2. Freshness 확인 (envelope이면 `envelope.generated_at`을 우선, 없으면 payload root의 `generated_at`):
    - 7일 이상 경과한 리포트는 "stale harnessability report — skip" 경고 후 건너뜀
    - `generated_at` 필드가 없으면 그대로 사용 (하위 호환)
-2. 점수가 낮은 차원(< 5.0)을 research context에 포함:
+3. 점수가 낮은 차원(< 5.0)을 research context에 포함 — `dimensions[]` / `total` 등의 필드는 envelope 모드/legacy 모드 모두에서 동일하게 payload root 또는 객체 root에서 읽는다:
    ```
    이 프로젝트의 harnessability 진단 결과:
    - <dimension>: <score>/10 → <suggestion>
    이 작업에서 관련 영역을 개선할 수 있으면 함께 고려.
    ```
-3. 이 정보는 이후 Section 2의 Topology Detection에서 참조 가능. 여기서는 research context에 텍스트로만 포함.
+4. 이 정보는 이후 Section 2의 Topology Detection에서 참조 가능. 여기서는 research context에 텍스트로만 포함.
 
-### Evolve Insights Context
+### Evolve Insights Context (envelope-aware v6.5.0)
 
-`.deep-evolve/evolve-insights.json`이 존재하면:
-1. 파일 읽기
-2. `insights_for_deep_work` 항목을 research context에 포함:
+`.deep-evolve/evolve-insights.json`(또는 `.deep-evolve/<session>/evolve-insights.json`)이 존재하면:
+1. 파일 읽기 및 envelope 감지:
+   - M3 envelope 이면 `envelope.producer === "deep-evolve"` ∧ `envelope.artifact_kind === "evolve-insights"` ∧ `envelope.schema.name === envelope.artifact_kind` 검증 후 `payload`를 사용. mismatch는 skip.
+   - Legacy 파일이면 root 객체 그대로 사용.
+2. `insights_for_deep_work` 항목을 research context에 포함 (envelope 모드/legacy 모드 모두 payload/root 에서 직접 접근):
    ```
    deep-evolve 메타 아카이브 기반 인사이트:
    - <pattern>: <evidence> → <suggestion>
    ```
 3. 이 인사이트는 "참고" 수준 — 현재 작업과 관련 없으면 무시
+4. 향후 (Phase 5 deep-integrate) 에서 session-receipt 의 `envelope.parent_run_id` 가 이 evolve-insights 의 `envelope.run_id` 로 채워진다 (cross-plugin chain).
 
 # Section 2: Phase 실행
 

--- a/tests/envelope-chain.test.js
+++ b/tests/envelope-chain.test.js
@@ -1,0 +1,215 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const { ULID_RE } = require('../scripts/validate-envelope-emit.js');
+const {
+  expandSourceArtifactsGlob,
+  tryReadEnvelopeRunId,
+} = require('../hooks/scripts/wrap-receipt-envelope.js');
+const { wrapEnvelope, generateUlid, isEnvelope } = require('../hooks/scripts/envelope.js');
+
+const WRAP_CLI = path.resolve(
+  __dirname,
+  '..',
+  'hooks',
+  'scripts',
+  'wrap-receipt-envelope.js',
+);
+const VALIDATE_CLI = path.resolve(
+  __dirname,
+  '..',
+  'scripts',
+  'validate-envelope-emit.js',
+);
+
+function tmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'dw-chain-'));
+}
+
+function writeJson(p, obj) {
+  fs.writeFileSync(p, JSON.stringify(obj, null, 2));
+}
+
+function runWrap(args) {
+  return execFileSync('node', [WRAP_CLI, ...args], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+function runValidate(file) {
+  return execFileSync('node', [VALIDATE_CLI, file], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+describe('envelope-chain — slice receipts wrapped via wrap-receipt-envelope.js', () => {
+  it('emits a valid envelope and survives the validator', () => {
+    const dir = tmpDir();
+    const payload = path.join(dir, 'payload.json');
+    const out = path.join(dir, 'SLICE-001.json');
+    writeJson(payload, { schema_version: '1.0', slice_id: 'SLICE-001', status: 'complete' });
+
+    runWrap([
+      '--artifact-kind', 'slice-receipt',
+      '--payload-file', payload,
+      '--output', out,
+    ]);
+
+    runValidate(out);
+
+    const obj = JSON.parse(fs.readFileSync(out, 'utf8'));
+    assert.equal(obj.envelope.producer, 'deep-work');
+    assert.equal(obj.envelope.artifact_kind, 'slice-receipt');
+    assert.equal(obj.envelope.schema.name, 'slice-receipt');
+    assert.match(obj.envelope.run_id, ULID_RE);
+    assert.equal(obj.payload.slice_id, 'SLICE-001');
+  });
+});
+
+describe('envelope-chain — session-receipt parent_run_id matches consumed evolve-insights', () => {
+  it('cross-plugin chain: session-receipt.envelope.parent_run_id === evolve-insights.envelope.run_id', () => {
+    const dir = tmpDir();
+
+    // Stand up a fake evolve-insights envelope (as another plugin would emit it).
+    const evolveRunId = generateUlid();
+    const evolveEnvelope = {
+      $schema: 'https://example/envelope.schema.json',
+      schema_version: '1.0',
+      envelope: {
+        producer: 'deep-evolve',
+        producer_version: '3.1.1',
+        artifact_kind: 'evolve-insights',
+        run_id: evolveRunId,
+        generated_at: new Date().toISOString(),
+        schema: { name: 'evolve-insights', version: '1.0' },
+        git: { head: 'aaa1111', branch: 'main', dirty: false },
+        provenance: { source_artifacts: [], tool_versions: { node: process.version } },
+      },
+      payload: { schema_version: '1.0', insights_for_deep_work: [] },
+    };
+    const evolvePath = path.join(dir, 'evolve-insights.json');
+    writeJson(evolvePath, evolveEnvelope);
+    assert.equal(isEnvelope(evolveEnvelope), true);
+    assert.equal(tryReadEnvelopeRunId(evolvePath), evolveRunId);
+
+    // Slice receipts (intra-plugin chain — session aggregates these).
+    const sliceDir = path.join(dir, 'receipts');
+    fs.mkdirSync(sliceDir);
+    const sliceIds = [];
+    for (let i = 1; i <= 3; i++) {
+      const num = String(i).padStart(3, '0');
+      const sPayload = path.join(dir, `slice-payload-${num}.json`);
+      const sOut = path.join(sliceDir, `SLICE-${num}.json`);
+      writeJson(sPayload, { schema_version: '1.0', slice_id: `SLICE-${num}`, status: 'complete' });
+      runWrap([
+        '--artifact-kind', 'slice-receipt',
+        '--payload-file', sPayload,
+        '--output', sOut,
+      ]);
+      const sObj = JSON.parse(fs.readFileSync(sOut, 'utf8'));
+      sliceIds.push({ run_id: sObj.envelope.run_id, path: sOut });
+    }
+
+    // Session-receipt: parent_run_id from evolve, source_artifacts aggregating slices + evolve.
+    const sessionPayload = path.join(dir, 'session-payload.json');
+    const sessionOut = path.join(dir, 'session-receipt.json');
+    writeJson(sessionPayload, {
+      schema_version: '1.0',
+      canonical: false,
+      derived_from: 'receipts/SLICE-*.json',
+      session_id: 'dw-test',
+      slices: { total: 3, completed: 3, spike: 0 },
+    });
+    runWrap([
+      '--artifact-kind', 'session-receipt',
+      '--payload-file', sessionPayload,
+      '--output', sessionOut,
+      '--source-evolve-insights', evolvePath,
+      '--source-artifacts-glob', path.join(sliceDir, 'SLICE-*.json'),
+    ]);
+
+    runValidate(sessionOut);
+
+    const session = JSON.parse(fs.readFileSync(sessionOut, 'utf8'));
+
+    // Cross-plugin chain assertion (handoff §3.3).
+    assert.equal(
+      session.envelope.parent_run_id,
+      evolveRunId,
+      'session-receipt.parent_run_id must equal consumed evolve-insights.run_id',
+    );
+
+    // source_artifacts must include evolve + all 3 slice run_ids.
+    const recordedRunIds = (session.envelope.provenance.source_artifacts || [])
+      .map((sa) => sa.run_id)
+      .filter(Boolean)
+      .sort();
+    const expected = [evolveRunId, ...sliceIds.map((s) => s.run_id)].sort();
+    assert.deepEqual(recordedRunIds, expected, 'source_artifacts run_ids do not match expected chain');
+  });
+
+  it('honors explicit --parent-run-id over auto-detect', () => {
+    const dir = tmpDir();
+    const explicit = generateUlid();
+    const sessionPayload = path.join(dir, 'session-payload.json');
+    const sessionOut = path.join(dir, 'session-receipt.json');
+    writeJson(sessionPayload, { schema_version: '1.0', canonical: false });
+    runWrap([
+      '--artifact-kind', 'session-receipt',
+      '--payload-file', sessionPayload,
+      '--output', sessionOut,
+      '--parent-run-id', explicit,
+    ]);
+    const session = JSON.parse(fs.readFileSync(sessionOut, 'utf8'));
+    assert.equal(session.envelope.parent_run_id, explicit);
+  });
+});
+
+describe('envelope-chain — expandSourceArtifactsGlob', () => {
+  it('matches SLICE-*.json files in lex order', () => {
+    const dir = tmpDir();
+    fs.writeFileSync(path.join(dir, 'SLICE-002.json'), '{}');
+    fs.writeFileSync(path.join(dir, 'SLICE-001.json'), '{}');
+    fs.writeFileSync(path.join(dir, 'SLICE-003.json'), '{}');
+    fs.writeFileSync(path.join(dir, 'unrelated.json'), '{}');
+    const matches = expandSourceArtifactsGlob(path.join(dir, 'SLICE-*.json'), process.cwd());
+    assert.equal(matches.length, 3);
+    assert.ok(matches[0].endsWith('SLICE-001.json'));
+    assert.ok(matches[2].endsWith('SLICE-003.json'));
+  });
+
+  it('returns empty array for non-existent directory', () => {
+    const matches = expandSourceArtifactsGlob('/non-existent-dir-xyz/foo-*.json', process.cwd());
+    assert.deepEqual(matches, []);
+  });
+});
+
+describe('envelope-chain — wrapEnvelope intra-plugin chain via lib', () => {
+  it('builds session-receipt envelope with slice run_ids in source_artifacts', () => {
+    const sliceA = generateUlid();
+    const sliceB = generateUlid();
+    const evolve = generateUlid();
+    const env = wrapEnvelope({
+      artifactKind: 'session-receipt',
+      payload: { schema_version: '1.0', slices: { total: 2 } },
+      parentRunId: evolve,
+      sourceArtifacts: [
+        { path: 'evolve-insights.json', run_id: evolve },
+        { path: 'receipts/SLICE-001.json', run_id: sliceA },
+        { path: 'receipts/SLICE-002.json', run_id: sliceB },
+      ],
+      git: { head: 'abc1234', branch: 'main', dirty: false },
+    });
+    assert.equal(env.envelope.parent_run_id, evolve);
+    const ids = env.envelope.provenance.source_artifacts.map((sa) => sa.run_id);
+    assert.deepEqual(ids, [evolve, sliceA, sliceB]);
+  });
+});

--- a/tests/envelope-chain.test.js
+++ b/tests/envelope-chain.test.js
@@ -192,6 +192,65 @@ describe('envelope-chain — expandSourceArtifactsGlob', () => {
   });
 });
 
+describe('envelope-chain — tryReadEnvelopeRunId rejects corrupt envelope (W4)', () => {
+  it('returns null for envelope with payload: null', () => {
+    const dir = tmpDir();
+    const corrupt = path.join(dir, 'corrupt.json');
+    writeJson(corrupt, {
+      schema_version: '1.0',
+      envelope: {
+        producer: 'deep-evolve',
+        artifact_kind: 'evolve-insights',
+        run_id: '01JTKEV0NHABCDEFGHJKMNPQRS',
+        schema: { name: 'evolve-insights', version: '1.0' },
+        git: { head: 'abc1234', branch: 'main', dirty: false },
+        provenance: { source_artifacts: [], tool_versions: {} },
+      },
+      payload: null,
+    });
+    assert.strictEqual(tryReadEnvelopeRunId(corrupt), null);
+  });
+
+  it('returns null for envelope with payload: array', () => {
+    const dir = tmpDir();
+    const corrupt = path.join(dir, 'corrupt.json');
+    writeJson(corrupt, {
+      schema_version: '1.0',
+      envelope: { run_id: '01JTKEV0NHABCDEFGHJKMNPQRS' },
+      payload: [1, 2, 3],
+    });
+    assert.strictEqual(tryReadEnvelopeRunId(corrupt), null);
+  });
+
+  it('returns the run_id for valid envelope', () => {
+    const dir = tmpDir();
+    const valid = path.join(dir, 'valid.json');
+    writeJson(valid, {
+      schema_version: '1.0',
+      envelope: { run_id: '01JTKEV0NHABCDEFGHJKMNPQRS' },
+      payload: { x: 1 },
+    });
+    assert.strictEqual(tryReadEnvelopeRunId(valid), '01JTKEV0NHABCDEFGHJKMNPQRS');
+  });
+});
+
+describe('envelope-chain — atomic write (C1)', () => {
+  it('does not leave a .tmp file after successful write', () => {
+    const dir = tmpDir();
+    const payload = path.join(dir, 'payload.json');
+    const out = path.join(dir, 'SLICE-001.json');
+    writeJson(payload, { schema_version: '1.0', slice_id: 'SLICE-001', status: 'complete' });
+    runWrap([
+      '--artifact-kind', 'slice-receipt',
+      '--payload-file', payload,
+      '--output', out,
+    ]);
+    assert.ok(fs.existsSync(out), 'final output must exist');
+    const tmpResidue = fs.readdirSync(dir).filter((f) => f.includes('.tmp.'));
+    assert.deepEqual(tmpResidue, [], `tmp residue left behind: ${JSON.stringify(tmpResidue)}`);
+  });
+});
+
 describe('envelope-chain — wrapEnvelope intra-plugin chain via lib', () => {
   it('builds session-receipt envelope with slice run_ids in source_artifacts', () => {
     const sliceA = generateUlid();

--- a/tests/envelope-emit.test.js
+++ b/tests/envelope-emit.test.js
@@ -1,0 +1,373 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const {
+  validate,
+  ULID_RE,
+  SEMVER_RE,
+  RFC3339_RE,
+} = require('../scripts/validate-envelope-emit.js');
+const {
+  generateUlid,
+  wrapEnvelope,
+  isEnvelope,
+  unwrapEnvelope,
+  loadProducerVersion,
+} = require('../hooks/scripts/envelope.js');
+
+const FIXTURES = path.join(__dirname, 'fixtures');
+
+function tmpFile(name, content) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dw-env-'));
+  const p = path.join(dir, name);
+  fs.writeFileSync(p, content);
+  return p;
+}
+
+describe('envelope.js — generateUlid', () => {
+  it('produces a 26-char Crockford Base32 string', () => {
+    for (let i = 0; i < 50; i++) {
+      const u = generateUlid();
+      assert.equal(u.length, 26, `expected 26 chars, got ${u.length}: ${u}`);
+      assert.match(u, ULID_RE, `not a valid ULID: ${u}`);
+    }
+  });
+
+  it('is lex-monotonic across timestamps (MSB-first)', () => {
+    const earlier = generateUlid(1700000000000);
+    const later = generateUlid(1800000000000);
+    assert.ok(earlier < later, `expected ${earlier} < ${later}`);
+  });
+});
+
+describe('envelope.js — wrapEnvelope identity', () => {
+  it('rejects unknown artifactKind', () => {
+    assert.throws(
+      () => wrapEnvelope({ artifactKind: 'evolve-insights', payload: { schema_version: '1.0' } }),
+      /artifactKind must be one of session-receipt, slice-receipt/,
+    );
+  });
+
+  it('rejects null payload', () => {
+    assert.throws(
+      () => wrapEnvelope({ artifactKind: 'slice-receipt', payload: null }),
+      /payload must be a non-null, non-array object/,
+    );
+  });
+
+  it('rejects array payload (handoff §4 corrupt-payload defense)', () => {
+    assert.throws(
+      () => wrapEnvelope({ artifactKind: 'slice-receipt', payload: [{ a: 1 }] }),
+      /payload must be a non-null, non-array object/,
+    );
+  });
+
+  it('emits identity-matched envelope (artifact_kind === schema.name)', () => {
+    const env = wrapEnvelope({
+      artifactKind: 'slice-receipt',
+      payload: { schema_version: '1.0', slice_id: 'SLICE-001' },
+      git: { head: 'abc1234', branch: 'main', dirty: false },
+    });
+    assert.equal(env.envelope.producer, 'deep-work');
+    assert.equal(env.envelope.artifact_kind, 'slice-receipt');
+    assert.equal(env.envelope.schema.name, 'slice-receipt');
+    assert.match(env.envelope.run_id, ULID_RE);
+    assert.match(env.envelope.producer_version, SEMVER_RE);
+    assert.match(env.envelope.generated_at, RFC3339_RE);
+  });
+
+  it('preserves caller-provided parent_run_id (cross-plugin chain)', () => {
+    const parent = generateUlid();
+    const env = wrapEnvelope({
+      artifactKind: 'session-receipt',
+      payload: { schema_version: '1.0' },
+      parentRunId: parent,
+      git: { head: 'abc1234', branch: 'main', dirty: false },
+    });
+    assert.equal(env.envelope.parent_run_id, parent);
+  });
+});
+
+describe('envelope.js — unwrapEnvelope guards', () => {
+  function buildEnvelope(overrides) {
+    const e = {
+      $schema: 'https://example/envelope.schema.json',
+      schema_version: '1.0',
+      envelope: {
+        producer: 'deep-work',
+        producer_version: '6.5.0',
+        artifact_kind: 'slice-receipt',
+        run_id: '01JTKGZQ7NABCDEFGHJKMNPQRS',
+        generated_at: '2026-05-07T10:15:42.123Z',
+        schema: { name: 'slice-receipt', version: '1.0' },
+        git: { head: 'abc1234', branch: 'main', dirty: false },
+        provenance: { source_artifacts: [], tool_versions: { node: 'v20.11.0' } },
+      },
+      payload: { schema_version: '1.0', slice_id: 'SLICE-001' },
+    };
+    return Object.assign(e, overrides || {});
+  }
+
+  it('passes legacy (non-envelope) input through unchanged', () => {
+    const legacy = { schema_version: '1.0', slice_id: 'SLICE-001' };
+    const out = unwrapEnvelope(legacy, 'slice-receipt');
+    assert.strictEqual(out, legacy);
+  });
+
+  it('returns payload for matching identity', () => {
+    const env = buildEnvelope();
+    const payload = unwrapEnvelope(env, 'slice-receipt');
+    assert.equal(payload.slice_id, 'SLICE-001');
+  });
+
+  it('returns null on producer mismatch', () => {
+    const env = buildEnvelope();
+    env.envelope.producer = 'deep-evolve';
+    assert.strictEqual(unwrapEnvelope(env, 'slice-receipt'), null);
+  });
+
+  it('returns null on artifact_kind mismatch', () => {
+    const env = buildEnvelope();
+    assert.strictEqual(unwrapEnvelope(env, 'session-receipt'), null);
+  });
+
+  it('returns null on schema.name vs artifact_kind drift (round-4 lesson)', () => {
+    const env = buildEnvelope();
+    env.envelope.schema.name = 'session-receipt';
+    assert.strictEqual(unwrapEnvelope(env, 'slice-receipt'), null);
+  });
+
+  it('returns null when payload is null/array (corrupt-payload defense)', () => {
+    const env = buildEnvelope();
+    env.payload = null;
+    assert.strictEqual(unwrapEnvelope(env, 'slice-receipt'), null);
+
+    const env2 = buildEnvelope();
+    env2.payload = ['oops'];
+    assert.strictEqual(unwrapEnvelope(env2, 'slice-receipt'), null);
+  });
+});
+
+describe('envelope.js — isEnvelope detection', () => {
+  it('returns false for legacy receipt with numeric schema_version', () => {
+    assert.equal(isEnvelope({ schema_version: 1, slice_id: 'SLICE-001' }), false);
+  });
+
+  it('returns false for receipt with schema_version string but no envelope/payload', () => {
+    assert.equal(isEnvelope({ schema_version: '1.0', slice_id: 'SLICE-001' }), false);
+  });
+
+  it('returns true only when schema_version === "1.0" + envelope + payload all present', () => {
+    assert.equal(
+      isEnvelope({ schema_version: '1.0', envelope: {}, payload: {} }),
+      true,
+    );
+  });
+});
+
+describe('envelope.js — loadProducerVersion', () => {
+  it('reads from plugin module path, not caller cwd (literal-cwd-resolve)', () => {
+    const origCwd = process.cwd();
+    try {
+      // Switch to /tmp (a non-plugin directory) — loadProducerVersion must
+      // still find plugin.json relative to its own __dirname.
+      process.chdir(os.tmpdir());
+      const v = loadProducerVersion();
+      assert.match(v, SEMVER_RE);
+    } finally {
+      process.chdir(origCwd);
+    }
+  });
+});
+
+describe('validate-envelope-emit.js — fixtures', () => {
+  it('passes sample-slice-receipt.json', () => {
+    const r = validate(path.join(FIXTURES, 'sample-slice-receipt.json'));
+    assert.deepEqual(r.errors, [], 'unexpected validation errors');
+    assert.equal(r.ok, true);
+  });
+
+  it('passes sample-session-receipt.json', () => {
+    const r = validate(path.join(FIXTURES, 'sample-session-receipt.json'));
+    assert.deepEqual(r.errors, [], 'unexpected validation errors');
+    assert.equal(r.ok, true);
+  });
+});
+
+describe('validate-envelope-emit.js — strict additionalProperties (handoff §4 strict mirror)', () => {
+  function buildValid() {
+    return JSON.parse(
+      fs.readFileSync(path.join(FIXTURES, 'sample-slice-receipt.json'), 'utf8'),
+    );
+  }
+
+  function expectFailure(obj, regex) {
+    const f = tmpFile('case.json', JSON.stringify(obj));
+    const r = validate(f);
+    assert.equal(r.ok, false, 'expected validation failure but got ok');
+    const matched = r.errors.some((e) => regex.test(e));
+    assert.ok(matched, `errors did not include ${regex}: ${r.errors.join('; ')}`);
+  }
+
+  it('rejects unknown root key (no x- prefix)', () => {
+    const o = buildValid();
+    o.foo = 'bar';
+    expectFailure(o, /root: unknown key "foo"/);
+  });
+
+  it('accepts x-* root extension (forward-compat)', () => {
+    const o = buildValid();
+    o['x-custom'] = { hi: 1 };
+    const f = tmpFile('case.json', JSON.stringify(o));
+    const r = validate(f);
+    assert.deepEqual(r.errors, []);
+  });
+
+  it('rejects unknown envelope key', () => {
+    const o = buildValid();
+    o.envelope.unknown_thing = 'oops';
+    expectFailure(o, /envelope: unknown key "unknown_thing"/);
+  });
+
+  it('rejects unknown git key', () => {
+    const o = buildValid();
+    o.envelope.git.extra = 1;
+    expectFailure(o, /envelope\.git: unknown key "extra"/);
+  });
+
+  it('rejects unknown schema key', () => {
+    const o = buildValid();
+    o.envelope.schema.tier = 'beta';
+    expectFailure(o, /envelope\.schema: unknown key "tier"/);
+  });
+
+  it('rejects unknown provenance key', () => {
+    const o = buildValid();
+    o.envelope.provenance.notes = 'hi';
+    expectFailure(o, /envelope\.provenance: unknown key "notes"/);
+  });
+
+  it('rejects unknown source_artifacts[i] key', () => {
+    const o = buildValid();
+    o.envelope.provenance.source_artifacts.push({ path: 'a.json', size: 100 });
+    expectFailure(o, /envelope\.provenance\.source_artifacts\[0\]: unknown key "size"/);
+  });
+
+  it('rejects array tool_versions container (typeof gotcha guard)', () => {
+    const o = buildValid();
+    o.envelope.provenance.tool_versions = ['v20'];
+    expectFailure(o, /tool_versions: must be object/);
+  });
+
+  it('rejects array value inside tool_versions (per-value guard)', () => {
+    const o = buildValid();
+    o.envelope.provenance.tool_versions.node = ['v20'];
+    expectFailure(o, /tool_versions\["node"\]: must be string or object/);
+  });
+
+  it('rejects schema.name ≠ artifact_kind drift (identity check)', () => {
+    const o = buildValid();
+    o.envelope.schema.name = 'session-receipt';
+    expectFailure(o, /envelope\.schema\.name.*must equal envelope\.artifact_kind/);
+  });
+
+  it('rejects bad ULID (Crockford alphabet violation: I/L/O/U)', () => {
+    const o = buildValid();
+    o.envelope.run_id = '01JTKGZQ7NABCDEFGHJKMNPQRI'; // ends in "I" — not allowed
+    expectFailure(o, /envelope\.run_id: must be 26-char Crockford Base32 ULID/);
+  });
+
+  it('rejects ULID with leading-zero on first chunk and 27 chars', () => {
+    const o = buildValid();
+    o.envelope.run_id = '01JTKGZQ7NABCDEFGHJKMNPQRSX';
+    expectFailure(o, /envelope\.run_id: must be 26-char Crockford Base32 ULID/);
+  });
+
+  it('rejects bad SemVer (leading zero)', () => {
+    const o = buildValid();
+    o.envelope.producer_version = '01.0.0';
+    expectFailure(o, /producer_version: must be SemVer 2\.0\.0/);
+  });
+
+  it('rejects non-RFC3339 timestamp', () => {
+    const o = buildValid();
+    o.envelope.generated_at = '2026/05/07 10:00:00';
+    expectFailure(o, /envelope\.generated_at: must be RFC 3339/);
+  });
+
+  it('rejects bad git.head (uppercase hex / non-hex / wrong length)', () => {
+    const o = buildValid();
+    o.envelope.git.head = 'XYZ1234';
+    expectFailure(o, /envelope\.git\.head: must match/);
+
+    const o2 = buildValid();
+    o2.envelope.git.head = 'abc'; // 3 chars (need 7)
+    expectFailure(o2, /envelope\.git\.head: must match/);
+  });
+
+  it('rejects bad git.dirty value', () => {
+    const o = buildValid();
+    o.envelope.git.dirty = 'maybe';
+    expectFailure(o, /envelope\.git\.dirty: must be boolean or "unknown"/);
+  });
+
+  it('rejects wrong producer (plugin identity)', () => {
+    const o = buildValid();
+    o.envelope.producer = 'deep-evolve';
+    expectFailure(o, /envelope\.producer: must be "deep-work"/);
+  });
+
+  it('rejects unknown artifact_kind', () => {
+    const o = buildValid();
+    o.envelope.artifact_kind = 'scratch-pad';
+    o.envelope.schema.name = 'scratch-pad';
+    expectFailure(o, /envelope\.artifact_kind: must be one of session-receipt, slice-receipt/);
+  });
+
+  it('rejects payload as array', () => {
+    const o = buildValid();
+    o.payload = [1, 2, 3];
+    expectFailure(o, /payload: must be a non-null, non-array object/);
+  });
+
+  it('rejects payload as null', () => {
+    const o = buildValid();
+    o.payload = null;
+    expectFailure(o, /payload: must be a non-null, non-array object/);
+  });
+
+  it('rejects payload missing schema_version', () => {
+    const o = buildValid();
+    o.payload = { slice_id: 'SLICE-001' };
+    expectFailure(o, /payload\.schema_version: must be "1\.0"/);
+  });
+
+  it('rejects bad parent_run_id format', () => {
+    const o = buildValid();
+    o.envelope.parent_run_id = 'not-a-ulid';
+    expectFailure(o, /envelope\.parent_run_id: if present, must be 26-char ULID/);
+  });
+
+  it('rejects missing required envelope key', () => {
+    const o = buildValid();
+    delete o.envelope.run_id;
+    expectFailure(o, /envelope: missing required key "run_id"/);
+  });
+
+  it('rejects missing root payload key', () => {
+    const o = buildValid();
+    delete o.payload;
+    expectFailure(o, /root: missing required key "payload"/);
+  });
+
+  it('rejects bad schema.version pattern', () => {
+    const o = buildValid();
+    o.envelope.schema.version = '1';
+    expectFailure(o, /envelope\.schema\.version: must match/);
+  });
+});

--- a/tests/envelope-emit.test.js
+++ b/tests/envelope-emit.test.js
@@ -16,6 +16,7 @@ const {
   generateUlid,
   wrapEnvelope,
   isEnvelope,
+  isValidEnvelope,
   unwrapEnvelope,
   loadProducerVersion,
 } = require('../hooks/scripts/envelope.js');
@@ -162,11 +163,44 @@ describe('envelope.js — isEnvelope detection', () => {
     assert.equal(isEnvelope({ schema_version: '1.0', slice_id: 'SLICE-001' }), false);
   });
 
-  it('returns true only when schema_version === "1.0" + envelope + payload all present', () => {
+  it('returns true (loose detection) when schema_version === "1.0" + envelope + payload all present', () => {
     assert.equal(
       isEnvelope({ schema_version: '1.0', envelope: {}, payload: {} }),
       true,
     );
+  });
+
+  it('returns true even when payload is null/falsy/array (loose detection only — unwrapEnvelope rejects)', () => {
+    assert.equal(isEnvelope({ schema_version: '1.0', envelope: {}, payload: null }), true);
+    assert.equal(isEnvelope({ schema_version: '1.0', envelope: {}, payload: false }), true);
+    assert.equal(isEnvelope({ schema_version: '1.0', envelope: {}, payload: [] }), true);
+  });
+});
+
+describe('envelope.js — isValidEnvelope (strict W4 gate)', () => {
+  it('returns true only when payload is a non-null/non-array plain object', () => {
+    assert.equal(
+      isValidEnvelope({ schema_version: '1.0', envelope: {}, payload: { a: 1 } }),
+      true,
+    );
+  });
+
+  it('rejects payload null', () => {
+    assert.equal(
+      isValidEnvelope({ schema_version: '1.0', envelope: {}, payload: null }),
+      false,
+    );
+  });
+
+  it('rejects payload false / array / primitive (corrupt-payload defense)', () => {
+    assert.equal(isValidEnvelope({ schema_version: '1.0', envelope: {}, payload: false }), false);
+    assert.equal(isValidEnvelope({ schema_version: '1.0', envelope: {}, payload: 0 }), false);
+    assert.equal(isValidEnvelope({ schema_version: '1.0', envelope: {}, payload: 'x' }), false);
+    assert.equal(isValidEnvelope({ schema_version: '1.0', envelope: {}, payload: [1] }), false);
+  });
+
+  it('rejects non-envelope (legacy receipts)', () => {
+    assert.equal(isValidEnvelope({ schema_version: '1.0', slice_id: 'SLICE-001' }), false);
   });
 });
 

--- a/tests/fixtures/sample-session-receipt.json
+++ b/tests/fixtures/sample-session-receipt.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://raw.githubusercontent.com/Sungmin-Cho/claude-deep-suite/main/schemas/artifact-envelope.schema.json",
+  "schema_version": "1.0",
+  "envelope": {
+    "producer": "deep-work",
+    "producer_version": "6.5.0",
+    "artifact_kind": "session-receipt",
+    "run_id": "01JTKH22NHABCDEFGHJKMNPQRS",
+    "session_id": "dw-2026-05-07T10-00-00-000Z",
+    "parent_run_id": "01JTKEV0NHABCDEFGHJKMNPQRS",
+    "generated_at": "2026-05-07T11:42:08.456Z",
+    "schema": { "name": "session-receipt", "version": "1.0" },
+    "git": {
+      "head": "def5678",
+      "branch": "feat/m3-envelope-adoption",
+      "dirty": false
+    },
+    "provenance": {
+      "source_artifacts": [
+        { "path": ".deep-evolve/2026-05-07/evolve-insights.json", "run_id": "01JTKEV0NHABCDEFGHJKMNPQRS" },
+        { "path": ".deep-work/2026-05-07T10-00-00-000Z/receipts/SLICE-001.json", "run_id": "01JTKGZQ7NABCDEFGHJKMNPQRS" }
+      ],
+      "tool_versions": { "node": "v20.11.0" }
+    }
+  },
+  "payload": {
+    "schema_version": "1.0",
+    "canonical": false,
+    "derived_from": "receipts/SLICE-*.json",
+    "session_id": "dw-2026-05-07T10-00-00-000Z",
+    "task_description": "Sample task for envelope adoption fixture",
+    "started_at": "2026-05-07T10:00:00.000Z",
+    "finished_at": "2026-05-07T11:42:00.000Z",
+    "worktree_branch": "feat/m3-envelope-adoption",
+    "worktree_base_commit": "abc1234",
+    "outcome": "merge",
+    "outcome_ref": null,
+    "slices": {
+      "total": 1,
+      "completed": 1,
+      "spike": 0
+    },
+    "tdd_compliance": {
+      "strict": 1,
+      "relaxed": 0,
+      "override": 0,
+      "spike": 0
+    },
+    "quality_score": 8.7,
+    "quality_breakdown": {
+      "tdd_compliance": 1.0,
+      "sensor_clean": 0.9
+    }
+  }
+}

--- a/tests/fixtures/sample-slice-receipt.json
+++ b/tests/fixtures/sample-slice-receipt.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://raw.githubusercontent.com/Sungmin-Cho/claude-deep-suite/main/schemas/artifact-envelope.schema.json",
+  "schema_version": "1.0",
+  "envelope": {
+    "producer": "deep-work",
+    "producer_version": "6.5.0",
+    "artifact_kind": "slice-receipt",
+    "run_id": "01JTKGZQ7NABCDEFGHJKMNPQRS",
+    "session_id": "dw-2026-05-07T10-00-00-000Z",
+    "generated_at": "2026-05-07T10:15:42.123Z",
+    "schema": { "name": "slice-receipt", "version": "1.0" },
+    "git": {
+      "head": "abc1234",
+      "branch": "feat/m3-envelope-adoption",
+      "dirty": false
+    },
+    "provenance": {
+      "source_artifacts": [],
+      "tool_versions": { "node": "v20.11.0" }
+    }
+  },
+  "payload": {
+    "schema_version": "1.0",
+    "slice_id": "SLICE-001",
+    "cluster_id": "_default",
+    "status": "complete",
+    "tdd": {
+      "state_transitions": ["PENDING", "RED_VERIFIED", "GREEN", "SENSOR_CLEAN"],
+      "red_verification_output": "AssertionError: expected undefined to be 1"
+    },
+    "git_before_slice": "abc1234",
+    "git_after_slice": "def5678",
+    "changes": {
+      "git_diff": "diff --git a/src/a.js b/src/a.js\n+function add(a,b){return a+b}\n"
+    },
+    "sensor_results": {
+      "lint": "pass",
+      "typecheck": "pass",
+      "reviewCheck": "pass"
+    },
+    "spec_compliance": {
+      "passed": true
+    },
+    "slice_review": {
+      "stage1": "pass",
+      "stage2": "pass"
+    },
+    "harness_metadata": {
+      "model_id": "claude-sonnet-4-5",
+      "rework_count": 0,
+      "tests_passed_first_try": true
+    }
+  }
+}

--- a/tests/integration/v6.4.0-smoke.test.js
+++ b/tests/integration/v6.4.0-smoke.test.js
@@ -192,7 +192,7 @@ describe('v6.4.0 integration — Health Engine command contracts', () => {
 });
 
 describe('release metadata', () => {
-  it('current release metadata and docs are bumped to 6.4.1', () => {
+  it('current release metadata and docs are bumped to 6.5.0', () => {
     const root = path.join(__dirname, '..', '..');
     const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
     const plugin = JSON.parse(fs.readFileSync(path.join(root, '.claude-plugin', 'plugin.json'), 'utf8'));
@@ -200,10 +200,10 @@ describe('release metadata', () => {
     const changelog = fs.readFileSync(path.join(root, 'CHANGELOG.md'), 'utf8');
     const changelogKo = fs.readFileSync(path.join(root, 'CHANGELOG.ko.md'), 'utf8');
 
-    assert.equal(pkg.version, '6.4.1');
-    assert.equal(plugin.version, '6.4.1');
-    assert.match(claude, /^# deep-work v6\.4\.1/m);
-    assert.match(changelog, /^## \[6\.4\.1\] - 2026-04-26/m);
-    assert.match(changelogKo, /^## \[6\.4\.1\] - 2026-04-26/m);
+    assert.equal(pkg.version, '6.5.0');
+    assert.equal(plugin.version, '6.5.0');
+    assert.match(claude, /^# deep-work v6\.5\.0/m);
+    assert.match(changelog, /^## \[6\.5\.0\] - 2026-05-07/m);
+    assert.match(changelogKo, /^## \[6\.5\.0\] - 2026-05-07/m);
   });
 });


### PR DESCRIPTION
## Summary

Adopts the **claude-deep-suite M3 cross-plugin envelope** for `session-receipt.json` and `receipts/SLICE-*.json` — the 3rd plugin in the 6-plugin Phase 2 migration (after deep-docs PR #2/#3 and deep-dashboard PR #4). Implements both writer (envelope wrap) and reader (envelope-aware unwrap with identity guard) sides plus 75 self-tests, including a cross-plugin chain assertion.

Identity contract: `producer=deep-work`, `artifact_kind ∈ {session-receipt, slice-receipt}`, `schema.name === artifact_kind`. cf. `claude-deep-suite/docs/envelope-migration.md` §1.

## Highlights

**Writer** (markdown agent prompts call a Node helper):
- `hooks/scripts/envelope.js` — shared library: MSB-first ULID, `detectGit` with safe `0000000` fallback, `loadProducerVersion` resolved relative to module `__dirname` (literal-cwd-resolve), `wrapEnvelope`/`unwrapEnvelope` with full identity + corrupt-payload guards, plus `isValidEnvelope` for chain extraction.
- `hooks/scripts/wrap-receipt-envelope.js` — CLI helper with **atomic temp+rename write** (round-1 C1) and `--source-evolve-insights` / `--source-harnessability` / `--source-artifacts-glob` for cross-plugin chain (sets `parent_run_id` from consumed evolve-insights envelope, aggregates `provenance.source_artifacts[]`).
- `agents/implement-slice-worker.md` — slice protocol writes payload to temp then invokes the helper.
- `commands/deep-finish.md` — Section 7-Z performs the envelope wrap exactly once after outcome is decided (Section 2/2-1/7 update the same payload temp file). Bash uses `set -euo pipefail` and gates cleanup on helper success (round-1 C2).

**Reader** (envelope-aware unwrap with identity guard + legacy pass-through):
- `verify-delegated-receipt-runner.js` — unwraps every SLICE-*.json before passing to `verify-receipt-core`. Identity-mismatch error message points to `receipt-migration.js` for legacy recovery (round-1 C3).
- `verify-delegated-receipt.sh` — auto-runs `receipt-migration.js` before the runner (idempotent on already-current files).
- `validate-receipt.sh` — `json_field` detects envelope and reads from `.payload` with identity guard.
- `session-end.sh` — bash-only grep fast path for envelope identity (round-1 W6, no Node spawn per receipt).
- `receipt-migration.js` — recognizes envelope-wrapped receipts as already-migrated.
- `gather-signals.sh` — cross-plugin consumer `read_json_safe` accepts `expected_producer`/`expected_kind` for defense-in-depth.
- `deep-research/SKILL.md` — Cross-Plugin Context (Harnessability + Evolve Insights) documents envelope detection + identity guard.
- `commands/deep-receipt.md` / `deep-status.md` / `deep-report.md` — receipt read instructions document the envelope-aware unwrap rule.

**Self-test**:
- `scripts/validate-envelope-emit.js` — zero-dep validator mirroring suite envelope schema. Enforces `additionalProperties: false` on all nested objects, ULID Crockford alphabet (rejects I/L/O/U), SemVer 2.0.0 strict, RFC 3339, kebab-case, `schema.name === artifact_kind` identity, payload non-null/non-array object.
- `tests/envelope-emit.test.js` (51 cases) + `tests/envelope-chain.test.js` (10 cases) — covers identity guards, corrupt-payload defense, ULID monotonicity, SemVer strict, `parent_run_id` cross-plugin chain assertion, intra-plugin chain, atomic-write residue check.
- `tests/fixtures/sample-{session,slice}-receipt.json` — production-ready envelope examples (Phase 3 input for suite-side payload-registry placeholder → authoritative shape upgrade).

## Review history

3 commits, 2 deep-review rounds, converged at round 2:

- `e663786` — initial implementation (27 files, +1995 -51).
- `d8a361e` — round-1 fixes: 3 Critical (atomic write, gated rm, actionable migration error) + 4 Warning (session_id resolution, isValidEnvelope strict gate, bash-only session-end, auto-migration). 75 tests pass (was 66, +9 new).
- `71fff70` — round-2 polish: 2 cosmetic Info (doc prose drift, path quoting in error message). Round 2 verdict: **APPROVE**.

Codex adversarial timed out at both 300s and 200s in both rounds (recognized as tooling unavailability per `claude-deep-suite/docs/superpowers/plans/2026-05-07-m3-phase2-handoff.md` §4). 1-way Opus synthesis is authoritative per deep-review skill spec §5.1 partial-success rule.

8 deferred items (W1, W3, W5, W8, W9, I1, I2, I3, I4, I6, I7, I-R2-3) recorded in `.deep-review/responses/2026-05-07-{193500,200500}-response.md` for v6.5.1 backlog.

## Test plan

- [x] `node --test tests/envelope-emit.test.js tests/envelope-chain.test.js tests/integration/v6.4.0-smoke.test.js hooks/scripts/receipt-migration.test.js` → 75 pass / 0 fail
- [x] `node --test hooks/scripts/*.test.js` → 430 pass / 0 fail (no regression in receipt-race or other hook tests)
- [x] `bash scripts/validate-agents.sh` → all agents valid
- [x] `node scripts/validate-envelope-emit.js tests/fixtures/sample-{session,slice}-receipt.json` → both OK
- [x] Round 2 deep-review (1-way Opus) → APPROVE

## Out of scope (Phase 3 batch — claude-deep-suite repo)

Per claude-deep-suite handoff §1, Phase 2 plugin PRs touch the plugin repo only. The following are batched in Phase 3:

- `claude-deep-suite/.claude-plugin/marketplace.json` — `deep-work` plugin SHA bump.
- `claude-deep-suite/schemas/payload-registry/deep-work/{session,slice}-receipt/v1.0.schema.json` — placeholder → authoritative shape upgrade (using `tests/fixtures/sample-{session,slice}-receipt.json` as input).
- `claude-deep-suite/docs/envelope-migration.md` §6.1 Adoption ledger — deep-work row + T+0 timer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)