### PR TITLE
feat(m5.7.A): emit handoff + compaction-state envelopes (v6.6.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deep-work",
-  "version": "6.5.0",
+  "version": "6.6.0",
   "description": "Evidence-Driven Development Protocol — 3-layer architecture with Skill-based phase dispatch, computational enforcement (worktree guard + phase transition injection), TDD enforcement, and receipt validation",
   "author": {
     "name": "sungmin"

--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.6.0] - 2026-05-12
+
+### Added — M5.7.A 플러그인측 cross-plugin handoff + dashboard compaction telemetry 채택
+
+- **`hooks/scripts/emit-handoff.js`** — handoff payload를 M3 envelope으로 wrap하여 (`artifact_kind = "handoff"`, `schema.name = "handoff"`, `schema.version = "1.0"`) `.deep-work/handoffs/` 또는 세션별 디렉토리에 기록하는 CLI 헬퍼. 플래그: `--payload-file`, `--output`, `--source-session-receipt` (자동 `parent_run_id` chain), `--source-review-report`, `--parent-run-id`, `--session-id`. write 전 payload required 필드 enforce: `schema_version`, `handoff_kind`, `from{producer,completed_at}`, `to{producer,intent}`, `summary`, `next_action_brief` — `claude-deep-suite/schemas/handoff.schema.json` + dashboard `PAYLOAD_REQUIRED_FIELDS["deep-work/handoff"]`와 일치.
+- **`hooks/scripts/emit-compaction-state.js`** — compaction-state payload를 M3 envelope으로 wrap하는 CLI 헬퍼 (`artifact_kind = "compaction-state"`, `schema.name = "compaction-state"`). 두 입력 모드: hook-driven용 CLI 플래그 (`--trigger`, `--preserved`, `--discarded`, `--strategy`, `--pre-tokens`, `--post-tokens`) 또는 skill 합성용 `--payload-file`. Trigger enum을 suite schema 기준으로 검증 (`phase-transition`, `slice-green`, `loop-epoch-end`, `window-threshold`, `manual`, `session-stop`). Strategy enum 검증. Dashboard 메트릭 `suite.compaction.frequency` + `suite.compaction.preserved_artifact_ratio`를 구동.
+- **`commands/deep-finish.md` §7-Z-A** — envelope wrap 후 새 섹션이 `--handoff-to=<plugin>` 지정 시 (또는 사용자가 인터랙티브로 opt-in 시) cross-plugin handoff를 emit. session-receipt envelope에 `parent_run_id`를 자동 chain. dashboard flat-dir `SOURCE_SPECS`에 맞게 `.deep-work/handoffs/<UTC-ts>-<session_id>.json`로 기록.
+- **`hooks/scripts/session-end.sh`** Stop hook — 세션 종료 시 best-effort로 `compaction-state.json` emit (`trigger: session-stop`, session-receipt 존재 시 `strategy: receipt-only`, 부재 시 state file 보존). Stop hook의 "must not block session close" 계약 유지를 위해 subshell + `|| true`로 wrap.
+- **`hooks/scripts/phase-transition.sh`** PostToolUse hook — 각 Phase 경계마다 `compaction-state.json` emit (`trigger: phase-transition`, `strategy: key-artifacts-only`). Phase별 preserved 셋: research→research.md, plan→research+plan, implement→plan, test→plan+receipts, idle→session-receipt.
+- **`tests/handoff-roundtrip.test.js`** — M5.5 #8 (deep-work 절반)을 다루는 16개 assertion: dashboard와 동일한 payload-required-field 계약, mirror된 `unwrapStrict`를 만족하는 envelope을 emit하는 CLI roundtrip, cross-plugin chain (`parent_run_id === session-receipt.envelope.run_id`), trigger enum 6개 값 전체 커버리지, 실패 경로 (필수 필드 누락 → exit 1, unknown trigger → exit 1).
+
+### Changed
+
+- **`hooks/scripts/envelope.js`** — `ALLOWED_ARTIFACT_KINDS`를 `{session-receipt, slice-receipt}`에서 `handoff`와 `compaction-state` 포함으로 확장. set은 `wrapEnvelope` (출력 가드)와 `unwrapEnvelope` (입력 가드) 양쪽에서 사용; session-receipt / slice-receipt 호출자의 기존 identity-triplet 의미론은 그대로 유지.
+- **`scripts/validate-envelope-emit.js`** — `ALLOWED_KINDS`를 대칭 확장하여 CI validator가 두 신규 envelope kind를 수락. Payload `schema_version === "1.0"` enforcement는 그대로 유지.
+
+### Notes
+
+- 이 릴리스는 신규 artifact kind에 대해 **producer-only**. deep-work는 다른 플러그인의 `handoff.json` 또는 `compaction-state.json`을 consume 하지 않으며 — dashboard가 한다. Cross-plugin contract는 `claude-deep-dashboard/lib/suite-collector.js unwrapStrict`가 enforce.
+- M5 acceptance criteria는 `claude-deep-suite/docs/superpowers/plans/2026-05-11-m5.7-plugin-adoption-handoff.md` §M5.7.A 참조.
+
 ## [6.5.0] - 2026-05-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.6.0] - 2026-05-12
+
+### Added — M5.7.A plugin-side adoption of cross-plugin handoff + dashboard compaction telemetry
+
+- **`hooks/scripts/emit-handoff.js`** — CLI helper that wraps a handoff payload in the M3 envelope (`artifact_kind = "handoff"`, `schema.name = "handoff"`, `schema.version = "1.0"`) and writes it under `.deep-work/handoffs/` (or per-session). Flags: `--payload-file`, `--output`, `--source-session-receipt` (auto-chains `parent_run_id`), `--source-review-report`, `--parent-run-id`, `--session-id`. Payload required fields enforced before write: `schema_version`, `handoff_kind`, `from{producer,completed_at}`, `to{producer,intent}`, `summary`, `next_action_brief` — matches `claude-deep-suite/schemas/handoff.schema.json` + dashboard's `PAYLOAD_REQUIRED_FIELDS["deep-work/handoff"]`.
+- **`hooks/scripts/emit-compaction-state.js`** — CLI helper that wraps a compaction-state payload in the M3 envelope (`artifact_kind = "compaction-state"`, `schema.name = "compaction-state"`). Two input modes: build payload from CLI flags (`--trigger`, `--preserved`, `--discarded`, `--strategy`, `--pre-tokens`, `--post-tokens`) for hook-driven emit, OR `--payload-file` for skill-composed emit. Trigger enum validated against suite schema (`phase-transition`, `slice-green`, `loop-epoch-end`, `window-threshold`, `manual`, `session-stop`). Strategy enum validated. Powers dashboard metrics `suite.compaction.frequency` + `suite.compaction.preserved_artifact_ratio`.
+- **`commands/deep-finish.md` §7-Z-A** — new section after envelope wrap that emits a cross-plugin handoff when `--handoff-to=<plugin>` is supplied (or user opts-in interactively). Chains `parent_run_id` to the session-receipt envelope automatically. Writes to `.deep-work/handoffs/<UTC-ts>-<session_id>.json` matching dashboard's flat-dir `SOURCE_SPECS`.
+- **`hooks/scripts/session-end.sh`** Stop hook — best-effort `compaction-state.json` emit on session close (`trigger: session-stop`, `strategy: receipt-only` when session-receipt exists, otherwise preserves the state file). Wrapped in subshell + `|| true` to preserve the Stop hook's "must not block session close" contract.
+- **`hooks/scripts/phase-transition.sh`** PostToolUse hook — emits `compaction-state.json` on each Phase boundary (`trigger: phase-transition`, `strategy: key-artifacts-only`). Preserved set chosen per Phase: research→research.md, plan→research+plan, implement→plan, test→plan+receipts, idle→session-receipt.
+- **`tests/handoff-roundtrip.test.js`** — 16 assertions covering M5.5 #8 (deep-work half): payload-required-field contract identical to dashboard, CLI roundtrip producing envelopes that satisfy a mirrored `unwrapStrict`, cross-plugin chain (`parent_run_id === session-receipt.envelope.run_id`), trigger enum coverage (all 6 values), failure paths (missing required field → exit 1, unknown trigger → exit 1).
+
+### Changed
+
+- **`hooks/scripts/envelope.js`** — `ALLOWED_ARTIFACT_KINDS` extended from `{session-receipt, slice-receipt}` to include `handoff` and `compaction-state`. The set is consumed by both `wrapEnvelope` (output guard) and `unwrapEnvelope` (input guard); existing identity-triplet semantics preserved for session-receipt / slice-receipt callers.
+- **`scripts/validate-envelope-emit.js`** — `ALLOWED_KINDS` extended symmetrically so the CI validator accepts the two new envelope kinds. Payload `schema_version === "1.0"` enforcement carries through unchanged.
+
+### Notes
+
+- This release is **producer-only** for the new artifact kinds. deep-work does not consume `handoff.json` or `compaction-state.json` from other plugins; the dashboard does. Cross-plugin contract is enforced by `claude-deep-dashboard/lib/suite-collector.js unwrapStrict`.
+- See `claude-deep-suite/docs/superpowers/plans/2026-05-11-m5.7-plugin-adoption-handoff.md` §M5.7.A for the M5 acceptance criteria this milestone closes.
+
 ## [6.5.0] - 2026-05-07
 
 ### Added

--- a/commands/deep-finish.md
+++ b/commands/deep-finish.md
@@ -514,6 +514,121 @@ The helper:
   `harnessability-report.json`'s `run_id` to `provenance.source_artifacts[]`
   (intra-plugin chain + multi-source aggregation).
 
+### 7-Z-A. Optional cross-plugin handoff emit (v6.6.0 — M5.7.A)
+
+> **Ordering**: this block runs **after** Section 7-Z (which wraps the
+> session-receipt and assigns its `run_id`) and **before** Section 8 (state
+> finalization). It MUST not run before 7-Z — the handoff payload chains its
+> `parent_run_id` to the session-receipt's envelope `run_id`. If 7-Z fails
+> (exit 1), skip this block and tell the user to re-run `/deep-finish` after
+> resolving the wrap retry.
+
+When the user opts to hand off to another deep-suite plugin (typically
+deep-evolve for performance optimization, deep-review for security audit, or
+a custom downstream), emit a cross-plugin handoff artifact (`handoff.json`).
+The dashboard's `suite.handoff.roundtrip_success_rate` metric reads these.
+
+**Trigger conditions** (LLM decides which path applies):
+- `$ARGUMENTS` includes `--handoff-to=<plugin>` (preferred — fully automated;
+  no user prompt). Parse the value into `HANDOFF_TO`.
+- `outcome` is `"merge"` or `"pr"` AND `$ARGUMENTS` has no `--no-handoff` AND
+  the orchestrator is in interactive mode → AskUserQuestion:
+
+  ```
+  세션을 다른 플러그인에 인계할까요?
+  1. 인계 안함 — 이대로 종료
+  2. deep-evolve — 성능/품질 최적화 루프
+  3. deep-review — 독립 코드 리뷰
+  4. (기타) — 직접 플러그인 이름 입력
+  ```
+
+  (2)/(3)/(4) → set `HANDOFF_TO` accordingly; (1) → skip this block.
+
+**Payload composition** (per `claude-deep-suite/schemas/handoff.schema.json`):
+
+Write `$WORK_DIR/.handoff.payload.json` with the LLM-composed payload. Pull
+fields from the session-receipt + slice receipts + any review reports under
+`.deep-review/reports/`:
+
+```json
+{
+  "schema_version": "1.0",
+  "handoff_kind": "phase-5-to-evolve",
+  "from": {
+    "producer": "deep-work",
+    "session_id": "<SESSION_ID>",
+    "phase": "integrate",
+    "completed_at": "<RFC 3339 — session-receipt.finished_at>"
+  },
+  "to": {
+    "producer": "<HANDOFF_TO>",
+    "intent": "<short label — LLM-derived from session goals or user-supplied>",
+    "scope_hint": "<optional: src path or module name>"
+  },
+  "summary": "<one paragraph: outcome + slice GREEN count + key metric baseline>",
+  "next_action_brief": "<seed prompt for receiver: WHY + CURRENT STATE + TARGET (measurable)>",
+  "key_artifacts": [
+    { "path": "<work_dir>/session-receipt.json", "kind": "session-receipt", "run_id": "<from 7-Z>" }
+  ],
+  "completed_actions": ["<from session-receipt + slice receipts>"],
+  "context_window_state": {
+    "compacted_at": "<RFC 3339>",
+    "compaction_strategy": "key-artifacts-only",
+    "preserved_artifact_paths": ["<work_dir>/session-receipt.json"]
+  }
+}
+```
+
+`handoff_kind` defaults to `phase-5-to-evolve` when `HANDOFF_TO == "deep-evolve"`;
+use `custom` + `x-handoff-subkind` for non-canonical receivers (e.g.
+`HANDOFF_TO == "deep-review"`).
+
+**Emit**:
+
+```bash
+set -euo pipefail
+
+# HANDOFF_TO must be set by the parser above; if empty, skip.
+[ -z "${HANDOFF_TO:-}" ] && exit 0
+
+RECEIPT_PATH="$WORK_DIR/session-receipt.json"
+HANDOFF_PAYLOAD="$WORK_DIR/.handoff.payload.json"
+# Flat-dir layout matches dashboard SOURCE_SPECS (`.deep-work/handoffs/*.json`).
+HANDOFF_DIR="$PROJECT_ROOT/.deep-work/handoffs"
+HANDOFF_OUT="$HANDOFF_DIR/$(date -u +%Y%m%dT%H%M%SZ)-${SESSION_ID:-session}.json"
+
+mkdir -p "$HANDOFF_DIR"
+
+if node "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/emit-handoff.js" \
+    --payload-file "$HANDOFF_PAYLOAD" \
+    --output "$HANDOFF_OUT" \
+    --source-session-receipt "$RECEIPT_PATH" \
+    ${SESSION_ID:+--session-id "$SESSION_ID"}; then
+  rm -f "$HANDOFF_PAYLOAD"
+  echo "✓ handoff emitted → $HANDOFF_OUT (receiver: $HANDOFF_TO)"
+else
+  echo "⚠️ handoff emit failed — payload preserved at $HANDOFF_PAYLOAD for inspection" >&2
+fi
+```
+
+The helper:
+- Sets `envelope.parent_run_id = session-receipt.envelope.run_id` automatically
+  (closes the intra-plugin chain the dashboard reads for
+  `suite.handoff.roundtrip_success_rate`).
+- Sets the identity-triplet (`producer = deep-work`, `artifact_kind = handoff`,
+  `schema.name = handoff`, `schema.version = "1.0"`) — required by the
+  dashboard's `unwrapStrict`.
+- Validates payload required fields before writing — exit 1 with the missing
+  field; the temp payload is preserved for retry.
+
+**Receiver workflow** (informational; not part of `/deep-finish`):
+
+```
+/deep-evolve --resume-from-handoff .deep-work/handoffs/<file>.json
+```
+
+This block does NOT replace Section 8 — state finalization still runs.
+
 ### 8. Finalize state
 
 Update `$STATE_FILE`:

--- a/hooks/scripts/emit-compaction-state.js
+++ b/hooks/scripts/emit-compaction-state.js
@@ -234,6 +234,16 @@ function validateCompactionPayload(payload) {
   ) {
     errors.push('payload.preserved_artifact_paths must be array');
   }
+  // R1 review C4: enforce compaction_strategy enum in --payload-file mode as
+  // well. Previously buildPayloadFromFlags validated strategy at CLI level but
+  // --payload-file path bypassed it; a SKILL-composed payload with typo could
+  // pass through.
+  if ('compaction_strategy' in payload && !VALID_STRATEGIES.has(payload.compaction_strategy)) {
+    errors.push(
+      `payload.compaction_strategy must be one of ${[...VALID_STRATEGIES].join(', ')}, ` +
+        `got ${JSON.stringify(payload.compaction_strategy)}`,
+    );
+  }
   return errors;
 }
 
@@ -276,6 +286,14 @@ function main() {
       ...(srRunId ? { run_id: srRunId } : {}),
     });
     if (!parentRunId && srRunId) parentRunId = srRunId;
+    // R1 review W1 (Opus W-1): stderr warn when --source-session-receipt is
+    // provided but yields no run_id (file missing, corrupt, or non-envelope).
+    if (!parentRunId && !srRunId && !args['parent-run-id']) {
+      process.stderr.write(
+        `warning: --source-session-receipt ${args['source-session-receipt']} is not a ` +
+          `valid envelope (chain broken; suite.compaction.frequency lineage skipped)\n`,
+      );
+    }
   }
 
   let wrapped;

--- a/hooks/scripts/emit-compaction-state.js
+++ b/hooks/scripts/emit-compaction-state.js
@@ -1,0 +1,319 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * emit-compaction-state.js — Wrap a compaction-state payload in the deep-work
+ * M3 envelope and write to disk. Used by hooks (Stop, PostToolUse for phase
+ * transition) and explicit invocations from skills (slice GREEN inline
+ * compaction) to feed dashboard's M4-deferred compaction.* metrics.
+ *
+ * Identity-triplet contract enforced by the dashboard's unwrapStrict:
+ *   - envelope.producer === 'deep-work'
+ *   - envelope.artifact_kind === 'compaction-state'
+ *   - envelope.schema.name === 'compaction-state'
+ *   - envelope.schema.version === '1.0'
+ * Payload required fields (cf. claude-deep-suite/schemas/compaction-state.schema.json):
+ *   schema_version, compacted_at, trigger, preserved_artifact_paths
+ *
+ * Trigger enum (must match schemas/compaction-state.schema.json):
+ *   phase-transition, slice-green, loop-epoch-end, window-threshold,
+ *   manual, session-stop
+ *
+ * Usage (build payload from CLI args — typical hook path):
+ *   node emit-compaction-state.js \
+ *     --trigger <enum>                 required
+ *     --output <path>                  required
+ *     [--session-id <id>]              recommended (drives dashboard grouping)
+ *     [--preserved <p1,p2,...>]        comma-separated artifact paths
+ *     [--discarded <p1,p2,...>]        drives preserved_artifact_ratio
+ *     [--discarded-summary <text>]     audit-only
+ *     [--pre-tokens <n>]               producer-side estimate
+ *     [--post-tokens <n>]              producer-side estimate
+ *     [--strategy <enum>]              compaction_strategy (see schema)
+ *     [--source-session-receipt <p>]   intra-plugin chain → parent_run_id
+ *     [--parent-run-id <ULID>]         explicit override (wins over --source-*)
+ *
+ * Usage (build from existing payload file):
+ *   node emit-compaction-state.js \
+ *     --payload-file <path>            mutually exclusive with --trigger
+ *     --output <path>
+ *     [--source-session-receipt <p>] [--parent-run-id <ULID>] [--session-id <id>]
+ *
+ * Exit codes:
+ *   0 — wrote envelope-wrapped compaction-state
+ *   1 — payload validation failed (bad trigger, missing required field)
+ *   2 — usage / IO / argv error
+ *
+ * Hook contract: when invoked from a Stop hook, this helper MUST exit 0 even
+ * on internal errors (hook contract — never block session close). Callers
+ * should wrap in `|| true` and redirect stderr appropriately.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const env = require('./envelope');
+
+const KNOWN_FLAGS = new Set([
+  'trigger',
+  'output',
+  'session-id',
+  'preserved',
+  'discarded',
+  'discarded-summary',
+  'pre-tokens',
+  'post-tokens',
+  'strategy',
+  'source-session-receipt',
+  'parent-run-id',
+  'payload-file',
+]);
+
+const COMPACTION_REQUIRED = [
+  'schema_version',
+  'compacted_at',
+  'trigger',
+  'preserved_artifact_paths',
+];
+
+const VALID_TRIGGERS = new Set([
+  'phase-transition',
+  'slice-green',
+  'loop-epoch-end',
+  'window-threshold',
+  'manual',
+  'session-stop',
+]);
+
+const VALID_STRATEGIES = new Set([
+  'key-artifacts-only',
+  'receipt-only',
+  'summary-only',
+  'selective-message-drop',
+  'full-reset',
+  'custom',
+]);
+
+function usage(extra) {
+  if (extra) process.stderr.write(`error: ${extra}\n`);
+  process.stderr.write(
+    'usage: emit-compaction-state.js --trigger <enum> --output <p>\n' +
+      '                                 [--session-id <id>] [--preserved <p,...>]\n' +
+      '                                 [--discarded <p,...>] [--discarded-summary <t>]\n' +
+      '                                 [--pre-tokens <n>] [--post-tokens <n>]\n' +
+      '                                 [--strategy <enum>]\n' +
+      '                                 [--source-session-receipt <p>] [--parent-run-id <ULID>]\n' +
+      '                                 OR --payload-file <p> --output <p> [...]\n',
+  );
+  process.exit(2);
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (!a.startsWith('--')) usage(`unexpected positional argument: ${a}`);
+    let key, value;
+    if (a.includes('=')) {
+      const eq = a.indexOf('=');
+      key = a.slice(2, eq);
+      value = a.slice(eq + 1);
+    } else {
+      key = a.slice(2);
+      const next = argv[i + 1];
+      if (next === undefined || next.startsWith('--')) {
+        usage(`flag --${key} expects a value`);
+      }
+      value = next;
+      i++;
+    }
+    if (!KNOWN_FLAGS.has(key)) usage(`unknown flag --${key}`);
+    args[key] = value;
+  }
+  return args;
+}
+
+function readJson(p) {
+  let raw;
+  try {
+    raw = fs.readFileSync(p, 'utf8');
+  } catch (err) {
+    process.stderr.write(`error: cannot read ${p}: ${err.message}\n`);
+    process.exit(2);
+  }
+  try {
+    return JSON.parse(raw);
+  } catch (err) {
+    process.stderr.write(`error: cannot parse ${p} as JSON: ${err.message}\n`);
+    process.exit(2);
+  }
+}
+
+function tryReadEnvelopeRunId(filePath) {
+  if (!filePath || !fs.existsSync(filePath)) return null;
+  try {
+    const obj = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    if (env.isValidEnvelope(obj) && typeof obj.envelope.run_id === 'string') {
+      return obj.envelope.run_id;
+    }
+    return null;
+  } catch (_err) {
+    return null;
+  }
+}
+
+function splitCsv(s) {
+  if (typeof s !== 'string' || s.length === 0) return [];
+  return s
+    .split(',')
+    .map((x) => x.trim())
+    .filter((x) => x.length > 0);
+}
+
+function buildPayloadFromFlags(args) {
+  if (!args.trigger) usage('missing required flag --trigger (or --payload-file)');
+  if (!VALID_TRIGGERS.has(args.trigger)) {
+    process.stderr.write(
+      `error: --trigger must be one of ${[...VALID_TRIGGERS].join(', ')}, got "${args.trigger}"\n`,
+    );
+    process.exit(1);
+  }
+
+  const payload = {
+    schema_version: '1.0',
+    compacted_at: new Date().toISOString(),
+    trigger: args.trigger,
+    preserved_artifact_paths: splitCsv(args.preserved),
+  };
+  if (args['session-id']) payload.session_id = args['session-id'];
+  const discarded = splitCsv(args.discarded);
+  if (discarded.length > 0) payload.discarded_artifact_paths = discarded;
+  if (args['discarded-summary']) payload.discarded_summary = args['discarded-summary'];
+  if (args['pre-tokens'] != null) {
+    const n = Number.parseInt(args['pre-tokens'], 10);
+    if (Number.isFinite(n) && n >= 0) payload.pre_compaction_tokens = n;
+  }
+  if (args['post-tokens'] != null) {
+    const n = Number.parseInt(args['post-tokens'], 10);
+    if (Number.isFinite(n) && n >= 0) payload.post_compaction_tokens = n;
+  }
+  if (args.strategy) {
+    if (!VALID_STRATEGIES.has(args.strategy)) {
+      process.stderr.write(
+        `error: --strategy must be one of ${[...VALID_STRATEGIES].join(', ')}, got "${args.strategy}"\n`,
+      );
+      process.exit(1);
+    }
+    payload.compaction_strategy = args.strategy;
+  }
+  return payload;
+}
+
+function validateCompactionPayload(payload) {
+  const errors = [];
+  if (payload === null || typeof payload !== 'object' || Array.isArray(payload)) {
+    errors.push('payload must be a non-null, non-array object');
+    return errors;
+  }
+  for (const f of COMPACTION_REQUIRED) {
+    if (!(f in payload)) errors.push(`payload missing required field "${f}"`);
+  }
+  if ('schema_version' in payload && payload.schema_version !== '1.0') {
+    errors.push(
+      `payload.schema_version must be "1.0", got ${JSON.stringify(payload.schema_version)}`,
+    );
+  }
+  if ('trigger' in payload && !VALID_TRIGGERS.has(payload.trigger)) {
+    errors.push(
+      `payload.trigger must be one of ${[...VALID_TRIGGERS].join(', ')}, got ${JSON.stringify(payload.trigger)}`,
+    );
+  }
+  if (
+    'preserved_artifact_paths' in payload &&
+    !Array.isArray(payload.preserved_artifact_paths)
+  ) {
+    errors.push('payload.preserved_artifact_paths must be array');
+  }
+  return errors;
+}
+
+function atomicWriteJson(targetPath, obj) {
+  const dir = path.dirname(targetPath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  const tmp = `${targetPath}.tmp.${process.pid}.${Date.now()}`;
+  fs.writeFileSync(tmp, JSON.stringify(obj, null, 2) + '\n', 'utf8');
+  fs.renameSync(tmp, targetPath);
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.output) usage('missing required flag --output');
+
+  let payload;
+  if (args['payload-file']) {
+    const p = path.resolve(process.cwd(), args['payload-file']);
+    payload = readJson(p);
+  } else {
+    payload = buildPayloadFromFlags(args);
+  }
+
+  const errors = validateCompactionPayload(payload);
+  if (errors.length > 0) {
+    process.stderr.write('compaction-state payload validation failed:\n');
+    for (const e of errors) process.stderr.write(`  - ${e}\n`);
+    process.exit(1);
+  }
+
+  let parentRunId = args['parent-run-id'] || undefined;
+  const sourceArtifacts = [];
+  if (args['source-session-receipt']) {
+    const srPath = path.resolve(process.cwd(), args['source-session-receipt']);
+    const srRunId = tryReadEnvelopeRunId(srPath);
+    sourceArtifacts.push({
+      path: args['source-session-receipt'],
+      ...(srRunId ? { run_id: srRunId } : {}),
+    });
+    if (!parentRunId && srRunId) parentRunId = srRunId;
+  }
+
+  let wrapped;
+  try {
+    wrapped = env.wrapEnvelope({
+      artifactKind: 'compaction-state',
+      payload,
+      parentRunId,
+      sessionId: args['session-id'] || undefined,
+      sourceArtifacts,
+    });
+  } catch (err) {
+    process.stderr.write(`error: ${err.message}\n`);
+    process.exit(2);
+  }
+
+  const outputPath = path.resolve(process.cwd(), args.output);
+  try {
+    atomicWriteJson(outputPath, wrapped);
+  } catch (err) {
+    process.stderr.write(`error: cannot write ${outputPath}: ${err.message}\n`);
+    process.exit(2);
+  }
+
+  process.stdout.write(
+    `emitted: ${outputPath} (run_id=${wrapped.envelope.run_id}, trigger=${payload.trigger})\n`,
+  );
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  COMPACTION_REQUIRED,
+  VALID_TRIGGERS,
+  VALID_STRATEGIES,
+  validateCompactionPayload,
+  buildPayloadFromFlags,
+  tryReadEnvelopeRunId,
+};

--- a/hooks/scripts/emit-compaction-state.js
+++ b/hooks/scripts/emit-compaction-state.js
@@ -149,14 +149,25 @@ function readJson(p) {
   }
 }
 
-function tryReadEnvelopeRunId(filePath) {
+// R2 review fix (Codex adversarial MEDIUM): identity-triplet check before
+// using source's run_id as parent_run_id. Same pattern as emit-handoff.js.
+function tryReadEnvelopeRunId(filePath, expectedIdentities) {
   if (!filePath || !fs.existsSync(filePath)) return null;
   try {
     const obj = JSON.parse(fs.readFileSync(filePath, 'utf8'));
-    if (env.isValidEnvelope(obj) && typeof obj.envelope.run_id === 'string') {
-      return obj.envelope.run_id;
+    if (!env.isValidEnvelope(obj)) return null;
+    if (typeof obj.envelope.run_id !== 'string') return null;
+    if (Array.isArray(expectedIdentities) && expectedIdentities.length > 0) {
+      const matches = expectedIdentities.some(
+        (id) =>
+          obj.envelope.producer === id.producer &&
+          obj.envelope.artifact_kind === id.kind &&
+          obj.envelope.schema &&
+          obj.envelope.schema.name === id.kind,
+      );
+      if (!matches) return null;
     }
-    return null;
+    return obj.envelope.run_id;
   } catch (_err) {
     return null;
   }
@@ -269,6 +280,20 @@ function main() {
     payload = buildPayloadFromFlags(args);
   }
 
+  // R2 review fix (Codex review P3): propagate --session-id to payload.session_id
+  // for --payload-file mode (buildPayloadFromFlags already handles this for the
+  // CLI-flag path at line 198). Dashboard drill-down counts unique sessions
+  // from payload.session_id.
+  if (
+    args['session-id'] &&
+    payload &&
+    typeof payload === 'object' &&
+    !Array.isArray(payload) &&
+    !payload.session_id
+  ) {
+    payload.session_id = args['session-id'];
+  }
+
   const errors = validateCompactionPayload(payload);
   if (errors.length > 0) {
     process.stderr.write('compaction-state payload validation failed:\n');
@@ -280,7 +305,10 @@ function main() {
   const sourceArtifacts = [];
   if (args['source-session-receipt']) {
     const srPath = path.resolve(process.cwd(), args['source-session-receipt']);
-    const srRunId = tryReadEnvelopeRunId(srPath);
+    // R2 review fix: require deep-work session-receipt envelope identity.
+    const srRunId = tryReadEnvelopeRunId(srPath, [
+      { producer: 'deep-work', kind: 'session-receipt' },
+    ]);
     sourceArtifacts.push({
       path: args['source-session-receipt'],
       ...(srRunId ? { run_id: srRunId } : {}),

--- a/hooks/scripts/emit-handoff.js
+++ b/hooks/scripts/emit-handoff.js
@@ -77,6 +77,16 @@ const VALID_HANDOFF_KINDS = new Set([
   'custom',
 ]);
 
+// R2 review fix (Codex adversarial MEDIUM): direction enforcement for kinds
+// with canonical producer↔producer mappings. Prevents typos like
+// `handoff_kind: 'evolve-to-deep-work'` paired with `from.producer:
+// 'deep-work'` (wrong direction) from polluting dashboard telemetry. Custom +
+// session-resume + slice-to-slice are NOT direction-bound (caller defines).
+const KIND_DIRECTIONS = {
+  'phase-5-to-evolve': { from: 'deep-work', to: 'deep-evolve' },
+  'evolve-to-deep-work': { from: 'deep-evolve', to: 'deep-work' },
+};
+
 function usage(extra) {
   if (extra) process.stderr.write(`error: ${extra}\n`);
   process.stderr.write(
@@ -128,14 +138,34 @@ function readJson(p) {
   }
 }
 
-function tryReadEnvelopeRunId(filePath) {
+// R2 review fix (Codex adversarial MEDIUM): enforce identity-triplet check
+// before using a source artifact's run_id as parent_run_id. Previously this
+// helper only ran `isValidEnvelope` (loose shape check) — a foreign envelope
+// (e.g., deep-evolve evolve-receipt accidentally passed as source) would
+// silently become this handoff's parent_run_id, corrupting dashboard chain
+// reconstruction.
+//
+// expectedIdentities: optional array of `{ producer, kind }` tuples. When
+// supplied, the envelope must match at least one tuple on producer +
+// artifact_kind + schema.name. When omitted, the loose check is preserved
+// for backward compat (no caller currently relies on this path).
+function tryReadEnvelopeRunId(filePath, expectedIdentities) {
   if (!filePath || !fs.existsSync(filePath)) return null;
   try {
     const obj = JSON.parse(fs.readFileSync(filePath, 'utf8'));
-    if (env.isValidEnvelope(obj) && typeof obj.envelope.run_id === 'string') {
-      return obj.envelope.run_id;
+    if (!env.isValidEnvelope(obj)) return null;
+    if (typeof obj.envelope.run_id !== 'string') return null;
+    if (Array.isArray(expectedIdentities) && expectedIdentities.length > 0) {
+      const matches = expectedIdentities.some(
+        (id) =>
+          obj.envelope.producer === id.producer &&
+          obj.envelope.artifact_kind === id.kind &&
+          obj.envelope.schema &&
+          obj.envelope.schema.name === id.kind,
+      );
+      if (!matches) return null;
     }
-    return null;
+    return obj.envelope.run_id;
   } catch (_err) {
     return null;
   }
@@ -161,6 +191,31 @@ function validateHandoffPayload(payload) {
       `payload.handoff_kind must be one of ${[...VALID_HANDOFF_KINDS].join(', ')}, ` +
         `got ${JSON.stringify(payload.handoff_kind)}`,
     );
+  }
+  // R2 review fix: direction enforcement for kinds with canonical producer pairs.
+  if (
+    typeof payload.handoff_kind === 'string' &&
+    KIND_DIRECTIONS[payload.handoff_kind] &&
+    payload.from &&
+    typeof payload.from === 'object' &&
+    !Array.isArray(payload.from) &&
+    payload.to &&
+    typeof payload.to === 'object' &&
+    !Array.isArray(payload.to)
+  ) {
+    const expected = KIND_DIRECTIONS[payload.handoff_kind];
+    if (payload.from.producer && payload.from.producer !== expected.from) {
+      errors.push(
+        `payload.from.producer for handoff_kind="${payload.handoff_kind}" must be ` +
+          `"${expected.from}", got ${JSON.stringify(payload.from.producer)}`,
+      );
+    }
+    if (payload.to.producer && payload.to.producer !== expected.to) {
+      errors.push(
+        `payload.to.producer for handoff_kind="${payload.handoff_kind}" must be ` +
+          `"${expected.to}", got ${JSON.stringify(payload.to.producer)}`,
+      );
+    }
   }
   if (
     'from' in payload &&
@@ -205,6 +260,20 @@ function main() {
   const outputPath = path.resolve(process.cwd(), args['output']);
   const payload = readJson(payloadPath);
 
+  // R2 review fix (Codex review P3): propagate --session-id to payload.session_id
+  // when payload doesn't define it. Dashboard's drill-down counts unique sessions
+  // from payload.session_id; without this, --payload-file callers who supply
+  // --session-id at CLI but not in payload lose per-session attribution.
+  if (
+    args['session-id'] &&
+    payload &&
+    typeof payload === 'object' &&
+    !Array.isArray(payload) &&
+    !payload.session_id
+  ) {
+    payload.session_id = args['session-id'];
+  }
+
   const errors = validateHandoffPayload(payload);
   if (errors.length > 0) {
     process.stderr.write('handoff payload validation failed:\n');
@@ -217,7 +286,12 @@ function main() {
 
   if (args['source-session-receipt']) {
     const srPath = path.resolve(process.cwd(), args['source-session-receipt']);
-    const srRunId = tryReadEnvelopeRunId(srPath);
+    // R2 review fix: require source to be a deep-work session-receipt envelope
+    // (rejecting foreign producer / foreign kind). Falls through to no-chain on
+    // identity mismatch (W1 stderr warn fires below).
+    const srRunId = tryReadEnvelopeRunId(srPath, [
+      { producer: 'deep-work', kind: 'session-receipt' },
+    ]);
     sourceArtifacts.push({
       path: args['source-session-receipt'],
       ...(srRunId ? { run_id: srRunId } : {}),
@@ -276,6 +350,7 @@ if (require.main === module) {
 module.exports = {
   HANDOFF_REQUIRED,
   VALID_HANDOFF_KINDS,
+  KIND_DIRECTIONS,
   validateHandoffPayload,
   tryReadEnvelopeRunId,
 };

--- a/hooks/scripts/emit-handoff.js
+++ b/hooks/scripts/emit-handoff.js
@@ -66,6 +66,17 @@ const HANDOFF_REQUIRED = [
   'next_action_brief',
 ];
 
+// R1 review C4: handoff_kind enum from claude-deep-suite/schemas/handoff.schema.json.
+// Previously not enforced — a typo (`phase-5-evolve` missing `to`) would write
+// successfully and pollute dashboard telemetry.
+const VALID_HANDOFF_KINDS = new Set([
+  'phase-5-to-evolve',
+  'evolve-to-deep-work',
+  'slice-to-slice',
+  'session-resume',
+  'custom',
+]);
+
 function usage(extra) {
   if (extra) process.stderr.write(`error: ${extra}\n`);
   process.stderr.write(
@@ -144,6 +155,13 @@ function validateHandoffPayload(payload) {
       `payload.schema_version must be "1.0", got ${JSON.stringify(payload.schema_version)}`,
     );
   }
+  // R1 review C4: enforce handoff_kind enum (previously omitted — typos passed).
+  if ('handoff_kind' in payload && !VALID_HANDOFF_KINDS.has(payload.handoff_kind)) {
+    errors.push(
+      `payload.handoff_kind must be one of ${[...VALID_HANDOFF_KINDS].join(', ')}, ` +
+        `got ${JSON.stringify(payload.handoff_kind)}`,
+    );
+  }
   if (
     'from' in payload &&
     (payload.from === null ||
@@ -205,6 +223,18 @@ function main() {
       ...(srRunId ? { run_id: srRunId } : {}),
     });
     if (!parentRunId && srRunId) parentRunId = srRunId;
+    // R1 review W1 (Opus W-1): stderr warn when --source-session-receipt is
+    // provided but yields no run_id (file missing, corrupt, or not an envelope).
+    // Producer-side: previously silently emitted handoff with no parent_run_id,
+    // which dashboard counts as an orphan (legitimate "no upstream" looks
+    // identical to "user passed wrong file"). The warning lets the caller
+    // diagnose chain breakage at emit time.
+    if (!parentRunId && !srRunId && !args['parent-run-id']) {
+      process.stderr.write(
+        `warning: --source-session-receipt ${args['source-session-receipt']} is not a ` +
+          `valid envelope (chain broken; suite.handoff.roundtrip_success_rate will skip)\n`,
+      );
+    }
   }
 
   if (args['source-review-report']) {
@@ -245,6 +275,7 @@ if (require.main === module) {
 
 module.exports = {
   HANDOFF_REQUIRED,
+  VALID_HANDOFF_KINDS,
   validateHandoffPayload,
   tryReadEnvelopeRunId,
 };

--- a/hooks/scripts/emit-handoff.js
+++ b/hooks/scripts/emit-handoff.js
@@ -1,0 +1,250 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * emit-handoff.js — Wrap a handoff payload in the deep-work M3 envelope and
+ * write to disk. Used by /deep-finish (or /deep-integrate) when the user opts
+ * to hand off to another plugin (typically deep-evolve) at Phase 5 Integrate.
+ *
+ * Identity-triplet contract enforced by the dashboard's unwrapStrict:
+ *   - envelope.producer === 'deep-work'
+ *   - envelope.artifact_kind === 'handoff'
+ *   - envelope.schema.name === 'handoff'
+ *   - envelope.schema.version === '1.0'
+ * Payload required fields (cf. claude-deep-suite/schemas/handoff.schema.json):
+ *   schema_version, handoff_kind, from, to, summary, next_action_brief
+ *
+ * Cross-plugin chain (closes via envelope.parent_run_id):
+ *   handoff.envelope.parent_run_id === session-receipt.envelope.run_id
+ * Set automatically when --source-session-receipt is provided.
+ *
+ * Usage:
+ *   node emit-handoff.js \
+ *     --payload-file <path>           handoff payload JSON (built by SKILL)
+ *     --output <path>                 final envelope-wrapped artifact
+ *     [--source-session-receipt <p>]  intra-plugin chain — fills parent_run_id
+ *     [--source-review-report <p>]    additional provenance entry (no chain)
+ *     [--parent-run-id <ULID>]        explicit override (wins over --source-*)
+ *     [--session-id <id>]             higher-level session marker
+ *
+ * Exit codes:
+ *   0 — wrote envelope-wrapped handoff
+ *   1 — payload missing required fields per handoff schema
+ *   2 — usage / IO / argv error
+ *
+ * Notes:
+ *   - Output dir is created if missing. Atomic temp+rename to avoid partial
+ *     reads by dashboard collector running concurrently.
+ *   - This helper does NOT validate the payload against the full suite schema
+ *     (no ajv dep). It enforces the dashboard's hard-required field set; the
+ *     companion validator (scripts/validate-envelope-emit.js) catches envelope
+ *     shape violations; CI in claude-deep-suite catches schema drift.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const env = require('./envelope');
+
+const KNOWN_FLAGS = new Set([
+  'payload-file',
+  'output',
+  'source-session-receipt',
+  'source-review-report',
+  'parent-run-id',
+  'session-id',
+]);
+
+// Dashboard's PAYLOAD_REQUIRED_FIELDS['deep-work/handoff'] mirrored here so we
+// catch malformed handoffs at emit time, not later at dashboard ingest time.
+const HANDOFF_REQUIRED = [
+  'schema_version',
+  'handoff_kind',
+  'from',
+  'to',
+  'summary',
+  'next_action_brief',
+];
+
+function usage(extra) {
+  if (extra) process.stderr.write(`error: ${extra}\n`);
+  process.stderr.write(
+    'usage: emit-handoff.js --payload-file <p> --output <p>\n' +
+      '                       [--source-session-receipt <p>] [--source-review-report <p>]\n' +
+      '                       [--parent-run-id <ULID>] [--session-id <id>]\n',
+  );
+  process.exit(2);
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (!a.startsWith('--')) usage(`unexpected positional argument: ${a}`);
+    let key, value;
+    if (a.includes('=')) {
+      const eq = a.indexOf('=');
+      key = a.slice(2, eq);
+      value = a.slice(eq + 1);
+    } else {
+      key = a.slice(2);
+      const next = argv[i + 1];
+      if (next === undefined || next.startsWith('--')) {
+        usage(`flag --${key} expects a value`);
+      }
+      value = next;
+      i++;
+    }
+    if (!KNOWN_FLAGS.has(key)) usage(`unknown flag --${key}`);
+    args[key] = value;
+  }
+  return args;
+}
+
+function readJson(p) {
+  let raw;
+  try {
+    raw = fs.readFileSync(p, 'utf8');
+  } catch (err) {
+    process.stderr.write(`error: cannot read ${p}: ${err.message}\n`);
+    process.exit(2);
+  }
+  try {
+    return JSON.parse(raw);
+  } catch (err) {
+    process.stderr.write(`error: cannot parse ${p} as JSON: ${err.message}\n`);
+    process.exit(2);
+  }
+}
+
+function tryReadEnvelopeRunId(filePath) {
+  if (!filePath || !fs.existsSync(filePath)) return null;
+  try {
+    const obj = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    if (env.isValidEnvelope(obj) && typeof obj.envelope.run_id === 'string') {
+      return obj.envelope.run_id;
+    }
+    return null;
+  } catch (_err) {
+    return null;
+  }
+}
+
+function validateHandoffPayload(payload) {
+  const errors = [];
+  if (payload === null || typeof payload !== 'object' || Array.isArray(payload)) {
+    errors.push('payload must be a non-null, non-array object');
+    return errors;
+  }
+  for (const f of HANDOFF_REQUIRED) {
+    if (!(f in payload)) errors.push(`payload missing required field "${f}"`);
+  }
+  if ('schema_version' in payload && payload.schema_version !== '1.0') {
+    errors.push(
+      `payload.schema_version must be "1.0", got ${JSON.stringify(payload.schema_version)}`,
+    );
+  }
+  if (
+    'from' in payload &&
+    (payload.from === null ||
+      typeof payload.from !== 'object' ||
+      Array.isArray(payload.from) ||
+      typeof payload.from.producer !== 'string' ||
+      typeof payload.from.completed_at !== 'string')
+  ) {
+    errors.push('payload.from must include string producer + completed_at');
+  }
+  if (
+    'to' in payload &&
+    (payload.to === null ||
+      typeof payload.to !== 'object' ||
+      Array.isArray(payload.to) ||
+      typeof payload.to.producer !== 'string' ||
+      typeof payload.to.intent !== 'string')
+  ) {
+    errors.push('payload.to must include string producer + intent');
+  }
+  return errors;
+}
+
+function atomicWriteJson(targetPath, obj) {
+  const dir = path.dirname(targetPath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  const tmp = `${targetPath}.tmp.${process.pid}.${Date.now()}`;
+  fs.writeFileSync(tmp, JSON.stringify(obj, null, 2) + '\n', 'utf8');
+  fs.renameSync(tmp, targetPath);
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  for (const r of ['payload-file', 'output']) {
+    if (!args[r]) usage(`missing required flag --${r}`);
+  }
+
+  const payloadPath = path.resolve(process.cwd(), args['payload-file']);
+  const outputPath = path.resolve(process.cwd(), args['output']);
+  const payload = readJson(payloadPath);
+
+  const errors = validateHandoffPayload(payload);
+  if (errors.length > 0) {
+    process.stderr.write('handoff payload validation failed:\n');
+    for (const e of errors) process.stderr.write(`  - ${e}\n`);
+    process.exit(1);
+  }
+
+  let parentRunId = args['parent-run-id'] || undefined;
+  const sourceArtifacts = [];
+
+  if (args['source-session-receipt']) {
+    const srPath = path.resolve(process.cwd(), args['source-session-receipt']);
+    const srRunId = tryReadEnvelopeRunId(srPath);
+    sourceArtifacts.push({
+      path: args['source-session-receipt'],
+      ...(srRunId ? { run_id: srRunId } : {}),
+    });
+    if (!parentRunId && srRunId) parentRunId = srRunId;
+  }
+
+  if (args['source-review-report']) {
+    sourceArtifacts.push({ path: args['source-review-report'] });
+  }
+
+  let wrapped;
+  try {
+    wrapped = env.wrapEnvelope({
+      artifactKind: 'handoff',
+      payload,
+      parentRunId,
+      sessionId: args['session-id'] || undefined,
+      sourceArtifacts,
+    });
+  } catch (err) {
+    process.stderr.write(`error: ${err.message}\n`);
+    process.exit(2);
+  }
+
+  try {
+    atomicWriteJson(outputPath, wrapped);
+  } catch (err) {
+    process.stderr.write(`error: cannot write ${outputPath}: ${err.message}\n`);
+    process.exit(2);
+  }
+
+  process.stdout.write(
+    `emitted: ${outputPath} (run_id=${wrapped.envelope.run_id}, parent_run_id=${
+      wrapped.envelope.parent_run_id || '∅'
+    })\n`,
+  );
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  HANDOFF_REQUIRED,
+  validateHandoffPayload,
+  tryReadEnvelopeRunId,
+};

--- a/hooks/scripts/envelope.js
+++ b/hooks/scripts/envelope.js
@@ -18,8 +18,11 @@
  *   isEnvelope(obj)                 boolean — strict M3 envelope shape detector
  *
  * Identity contract: producer === 'deep-work', artifact_kind ∈ {session-receipt,
- * slice-receipt}, schema.name === artifact_kind. unwrapEnvelope() enforces all
- * three (handoff §4 round-4 "envelope identity guards").
+ * slice-receipt, handoff, compaction-state}, schema.name === artifact_kind.
+ * unwrapEnvelope() enforces all three (handoff §4 round-4 "envelope identity
+ * guards"). 'handoff' and 'compaction-state' added in v6.6.0 for M5.7
+ * cross-plugin long-run handoff + dashboard compaction telemetry; cf.
+ * claude-deep-suite/schemas/handoff.schema.json + compaction-state.schema.json.
  */
 
 const fs = require('node:fs');
@@ -28,7 +31,9 @@ const { execFileSync } = require('node:child_process');
 const { randomBytes } = require('node:crypto');
 
 const PLUGIN_NAME = 'deep-work';
-const ALLOWED_ARTIFACT_KINDS = Object.freeze(new Set(['session-receipt', 'slice-receipt']));
+const ALLOWED_ARTIFACT_KINDS = Object.freeze(
+  new Set(['session-receipt', 'slice-receipt', 'handoff', 'compaction-state']),
+);
 
 // Crockford's Base32 alphabet (per ULID spec) — excludes I/L/O/U.
 const CROCKFORD = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';

--- a/hooks/scripts/phase-transition.sh
+++ b/hooks/scripts/phase-transition.sh
@@ -109,4 +109,44 @@ if [[ "$HAS_CONDITIONS" == "true" ]]; then
   printf '%s' "$OUTPUT"
 fi
 
+# ─── v6.6.0 (M5.7) — compaction-state emit on phase transition ────────
+# Each Phase boundary is a compaction event: the Phase's primary artifact
+# (research.md, plan.md, ...) becomes the next Phase's only input; intermediate
+# working memory is discarded. Strategy: key-artifacts-only. PostToolUse hook
+# contract is "informational, never block" — wrap in subshell + `|| true`.
+(
+  EMIT_SCRIPT="$SCRIPT_DIR/emit-compaction-state.js"
+  [ -f "$EMIT_SCRIPT" ] || exit 0
+  command -v node >/dev/null 2>&1 || exit 0
+
+  _PT_WD_REL="$(read_frontmatter_field "$FILE_PATH" "work_dir" 2>/dev/null || echo "")"
+  [ -z "$_PT_WD_REL" ] && exit 0
+  _PT_WORK_DIR="$PROJECT_ROOT/$_PT_WD_REL"
+  _PT_OUTDIR="$PROJECT_ROOT/.deep-work/compaction-states"
+  mkdir -p "$_PT_OUTDIR" 2>/dev/null || exit 0
+
+  _PT_TS="$(date -u +%Y%m%dT%H%M%SZ)"
+  _PT_OUT="$_PT_OUTDIR/${_PT_TS}-${SESSION_ID}-phase-${NEW_PHASE}.json"
+
+  # Preserved artifacts depend on which Phase we just entered. Each Phase
+  # produces a primary artifact the next Phase consumes; keep the chain
+  # observable in compaction telemetry.
+  _PT_PRESERVED=""
+  case "$NEW_PHASE" in
+    research)  _PT_PRESERVED="$_PT_WORK_DIR/research.md" ;;
+    plan)      _PT_PRESERVED="$_PT_WORK_DIR/research.md,$_PT_WORK_DIR/plan.md" ;;
+    implement) _PT_PRESERVED="$_PT_WORK_DIR/plan.md" ;;
+    test)      _PT_PRESERVED="$_PT_WORK_DIR/plan.md,$_PT_WORK_DIR/receipts" ;;
+    idle)      _PT_PRESERVED="$_PT_WORK_DIR/session-receipt.json" ;;
+    *)         _PT_PRESERVED="$_PT_WORK_DIR" ;;
+  esac
+
+  node "$EMIT_SCRIPT" \
+    --trigger phase-transition \
+    --output "$_PT_OUT" \
+    --preserved "$_PT_PRESERVED" \
+    --strategy key-artifacts-only \
+    --session-id "$SESSION_ID" >/dev/null 2>&1 || true
+) 2>>"$PROJECT_ROOT/.claude/deep-work-guard-errors.log" || true
+
 exit 0

--- a/hooks/scripts/phase-transition.sh
+++ b/hooks/scripts/phase-transition.sh
@@ -110,10 +110,22 @@ if [[ "$HAS_CONDITIONS" == "true" ]]; then
 fi
 
 # ─── v6.6.0 (M5.7) — compaction-state emit on phase transition ────────
-# Each Phase boundary is a compaction event: the Phase's primary artifact
-# (research.md, plan.md, ...) becomes the next Phase's only input; intermediate
-# working memory is discarded. Strategy: key-artifacts-only. PostToolUse hook
-# contract is "informational, never block" — wrap in subshell + `|| true`.
+# Each Phase boundary is a compaction event: the just-closed Phase's primary
+# artifact (research.md, plan.md, ...) becomes the next Phase's only input;
+# intermediate working memory is discarded. Strategy: key-artifacts-only.
+# PostToolUse hook contract is "informational, never block" — wrap in subshell
+# + `|| true`.
+#
+# R1 review C2 fix: preserved set now references the JUST-CLOSED phase's
+# artifact (which exists when the hook fires) rather than the entering phase's
+# artifact (which does not exist yet). All preserved paths are filtered to
+# existing files at emit time.
+#
+# R1 review C3 fix: explicit --discarded set (concrete sensor + tmp files for
+# the just-closed phase + a sentinel for the compacted in-memory LLM context)
+# so the dashboard's suite.compaction.preserved_artifact_ratio metric gets
+# data points. Without --discarded the dashboard treats the ratio as undefined
+# per guides/context-management.md §5.
 (
   EMIT_SCRIPT="$SCRIPT_DIR/emit-compaction-state.js"
   [ -f "$EMIT_SCRIPT" ] || exit 0
@@ -128,23 +140,52 @@ fi
   _PT_TS="$(date -u +%Y%m%dT%H%M%SZ)"
   _PT_OUT="$_PT_OUTDIR/${_PT_TS}-${SESSION_ID}-phase-${NEW_PHASE}.json"
 
-  # Preserved artifacts depend on which Phase we just entered. Each Phase
-  # produces a primary artifact the next Phase consumes; keep the chain
-  # observable in compaction telemetry.
+  # Preserved: the artifact produced by the just-closed phase (OLD_PHASE in
+  # this hook's variable scope). For the first phase entry (empty OLD_PHASE
+  # or "init"), no predecessor artifact exists yet.
   _PT_PRESERVED=""
   case "$NEW_PHASE" in
-    research)  _PT_PRESERVED="$_PT_WORK_DIR/research.md" ;;
-    plan)      _PT_PRESERVED="$_PT_WORK_DIR/research.md,$_PT_WORK_DIR/plan.md" ;;
+    research)  _PT_PRESERVED="$_PT_WORK_DIR/brainstorm.md" ;;
+    plan)      _PT_PRESERVED="$_PT_WORK_DIR/research.md" ;;
     implement) _PT_PRESERVED="$_PT_WORK_DIR/plan.md" ;;
     test)      _PT_PRESERVED="$_PT_WORK_DIR/plan.md,$_PT_WORK_DIR/receipts" ;;
     idle)      _PT_PRESERVED="$_PT_WORK_DIR/session-receipt.json" ;;
-    *)         _PT_PRESERVED="$_PT_WORK_DIR" ;;
+    *)         _PT_PRESERVED="" ;;
   esac
 
+  # Filter preserved to existing paths only (avoid recording future/missing
+  # artifacts in the dashboard ratio).
+  _PT_PRESERVED_FILTERED=""
+  if [ -n "$_PT_PRESERVED" ]; then
+    IFS=',' read -ra _PT_PATHS <<< "$_PT_PRESERVED"
+    for _p in "${_PT_PATHS[@]}"; do
+      [ -z "$_p" ] && continue
+      if [ -e "$_p" ]; then
+        _PT_PRESERVED_FILTERED="${_PT_PRESERVED_FILTERED:+$_PT_PRESERVED_FILTERED,}$_p"
+      fi
+    done
+  fi
+
+  # Discarded: concrete intermediate state from the just-closed phase + a
+  # sentinel path representing the compacted LLM working memory (no file
+  # representation but a real semantic). The sentinel ensures the dashboard's
+  # ratio formula has a denominator > 0.
+  _PT_DISCARDED=""
+  _PT_PREV_PHASE="${OLD_PHASE:-session-start}"
+  # Concrete: sensor outputs and tmp files attributable to the just-closed phase.
+  for f in "$_PT_WORK_DIR/sensors/${_PT_PREV_PHASE}"* "$_PT_WORK_DIR/.tmp.${_PT_PREV_PHASE}".*; do
+    [ -e "$f" ] && _PT_DISCARDED="${_PT_DISCARDED:+$_PT_DISCARDED,}$f"
+  done
+  # Sentinel for in-memory LLM context that was compacted at this boundary.
+  _PT_DISCARDED="${_PT_DISCARDED:+$_PT_DISCARDED,}.deep-work/$SESSION_ID/.compacted/${_PT_PREV_PHASE}-llm-context"
+
+  # Emit. --preserved accepts empty string (helper splits to empty array per
+  # schema 'preserved_artifact_paths can be empty array').
   node "$EMIT_SCRIPT" \
     --trigger phase-transition \
     --output "$_PT_OUT" \
-    --preserved "$_PT_PRESERVED" \
+    --preserved "$_PT_PRESERVED_FILTERED" \
+    --discarded "$_PT_DISCARDED" \
     --strategy key-artifacts-only \
     --session-id "$SESSION_ID" >/dev/null 2>&1 || true
 ) 2>>"$PROJECT_ROOT/.claude/deep-work-guard-errors.log" || true

--- a/hooks/scripts/session-end.sh
+++ b/hooks/scripts/session-end.sh
@@ -337,6 +337,56 @@ append_session_history() {
 # Run in subshell — errors must never block session close
 (append_session_history) 2>>"$PROJECT_ROOT/.claude/deep-work-guard-errors.log" || true
 
+# ─── v6.6.0 (M5.7) — compaction-state emit at session-stop ────────────
+# Emit an envelope-wrapped `compaction-state.json` so the dashboard
+# (`suite.compaction.frequency`, `suite.compaction.preserved_artifact_ratio`)
+# can attribute this session's stop to a known compaction boundary. The Stop
+# hook contract is "must not block session close" — every step here is
+# best-effort, redirected to the guard-errors log, and ends in `|| true`.
+#
+# Strategy: receipt-only on session-stop (the session-receipt is comprehensive;
+# in-flight working memory is not worth preserving since the next session
+# starts fresh).
+(
+  EMIT_SCRIPT="$SCRIPT_DIR/emit-compaction-state.js"
+  [ -f "$EMIT_SCRIPT" ] || exit 0  # plugin version without emit helper — skip silently
+  command -v node >/dev/null 2>&1 || exit 0
+
+  _CS_WD_REL="$(read_frontmatter_field "$STATE_FILE" "work_dir" 2>/dev/null || echo "")"
+  [ -z "$_CS_WD_REL" ] && exit 0
+  _CS_WORK_DIR="$PROJECT_ROOT/$_CS_WD_REL"
+  _CS_OUTDIR="$PROJECT_ROOT/.deep-work/compaction-states"
+  mkdir -p "$_CS_OUTDIR" 2>/dev/null || exit 0
+
+  # Resolve session id (matches Section 1 fallback chain in deep-finish.md).
+  _CS_SID="${DEEP_WORK_SESSION_ID:-}"
+  if [ -z "$_CS_SID" ] && [ -f "$PROJECT_ROOT/.claude/deep-work-current-session" ]; then
+    _CS_SID="$(tr -d '\n\r' < "$PROJECT_ROOT/.claude/deep-work-current-session" 2>/dev/null || echo "")"
+  fi
+  _CS_TS="$(date -u +%Y%m%dT%H%M%SZ)"
+  _CS_OUT="$_CS_OUTDIR/${_CS_TS}-${_CS_SID:-session-stop}.json"
+
+  # Preserved set: session-receipt if it exists (finalized session); otherwise
+  # the state file (so the next session can resume from disk).
+  _CS_PRESERVED=""
+  _CS_RECEIPT="$_CS_WORK_DIR/session-receipt.json"
+  if [ -f "$_CS_RECEIPT" ]; then
+    _CS_PRESERVED="$_CS_WORK_DIR/session-receipt.json"
+    _CS_PARENT_FLAG=(--source-session-receipt "$_CS_RECEIPT")
+  else
+    _CS_PRESERVED="$STATE_FILE"
+    _CS_PARENT_FLAG=()
+  fi
+
+  node "$EMIT_SCRIPT" \
+    --trigger session-stop \
+    --output "$_CS_OUT" \
+    --preserved "$_CS_PRESERVED" \
+    --strategy receipt-only \
+    ${_CS_SID:+--session-id "$_CS_SID"} \
+    "${_CS_PARENT_FLAG[@]}" >/dev/null 2>&1 || true
+) 2>>"$PROJECT_ROOT/.claude/deep-work-guard-errors.log" || true
+
 # v6.2.4 post-review: cleanup stale PostToolUse stdin-cache files.
 # Remove our own PPID cache (no longer needed after session close) and any
 # orphaned .hook-tool-input.* files older than 60 minutes. Best-effort.

--- a/hooks/scripts/session-end.sh
+++ b/hooks/scripts/session-end.sh
@@ -77,7 +77,12 @@ fi
   [ -f "$EMIT_SCRIPT" ] || exit 0  # plugin version without emit helper — skip silently
   command -v node >/dev/null 2>&1 || exit 0
 
-  _CS_WD_REL="$(read_frontmatter_field "$STATE_FILE" "work_dir" 2>/dev/null || echo "")"
+  # R2 review fix (Codex adversarial MEDIUM): use phase5_work_dir_snapshot
+  # first (immutable boundary recorded by Phase 5 entry) before falling back
+  # to mutable work_dir. Mirrors the existing pattern at lines 44-45 of this
+  # same file (Phase 5 interrupted marker logic uses snapshot-first too).
+  _CS_WD_REL="$(read_frontmatter_field "$STATE_FILE" "phase5_work_dir_snapshot" 2>/dev/null || echo "")"
+  [ -z "$_CS_WD_REL" ] && _CS_WD_REL="$(read_frontmatter_field "$STATE_FILE" "work_dir" 2>/dev/null || echo "")"
   [ -z "$_CS_WD_REL" ] && exit 0
   _CS_WORK_DIR="$PROJECT_ROOT/$_CS_WD_REL"
   _CS_OUTDIR="$PROJECT_ROOT/.deep-work/compaction-states"

--- a/hooks/scripts/session-end.sh
+++ b/hooks/scripts/session-end.sh
@@ -59,6 +59,83 @@ if [[ -n "$_P5_WD_REL" ]]; then
   fi
 fi
 
+# ─── v6.6.0 (M5.7) — compaction-state emit at session-stop ────────────
+# R1 review C1+W2+C3 fix: this block runs BEFORE the idle fast-exit so finalized
+# sessions (the normal happy-path post `/deep-finish`) also emit. The Stop hook
+# contract is "must not block session close" — wrap in subshell + `|| true`,
+# redirect stderr to guard-errors log.
+#
+# Strategy: receipt-only on session-stop (the session-receipt is comprehensive;
+# in-flight working memory is not worth preserving since the next session
+# starts fresh).
+#
+# bash 3.2 compatibility (R1 review W2): use if/else for the optional
+# --source-session-receipt flag rather than array expansion, which triggers
+# "unbound variable" under `set -u` on bash <= 4.3 (macOS default).
+(
+  EMIT_SCRIPT="$SCRIPT_DIR/emit-compaction-state.js"
+  [ -f "$EMIT_SCRIPT" ] || exit 0  # plugin version without emit helper — skip silently
+  command -v node >/dev/null 2>&1 || exit 0
+
+  _CS_WD_REL="$(read_frontmatter_field "$STATE_FILE" "work_dir" 2>/dev/null || echo "")"
+  [ -z "$_CS_WD_REL" ] && exit 0
+  _CS_WORK_DIR="$PROJECT_ROOT/$_CS_WD_REL"
+  _CS_OUTDIR="$PROJECT_ROOT/.deep-work/compaction-states"
+  mkdir -p "$_CS_OUTDIR" 2>/dev/null || exit 0
+
+  # Resolve session id (matches Section 1 fallback chain in deep-finish.md).
+  _CS_SID="${DEEP_WORK_SESSION_ID:-}"
+  if [ -z "$_CS_SID" ] && [ -f "$PROJECT_ROOT/.claude/deep-work-current-session" ]; then
+    _CS_SID="$(tr -d '\n\r' < "$PROJECT_ROOT/.claude/deep-work-current-session" 2>/dev/null || echo "")"
+  fi
+  _CS_TS="$(date -u +%Y%m%dT%H%M%SZ)"
+  _CS_OUT="$_CS_OUTDIR/${_CS_TS}-${_CS_SID:-session-stop}.json"
+
+  # Preserved set: session-receipt if it exists (finalized session); otherwise
+  # the state file (so the next session can resume from disk).
+  _CS_RECEIPT="$_CS_WORK_DIR/session-receipt.json"
+  if [ -f "$_CS_RECEIPT" ]; then
+    _CS_PRESERVED="$_CS_RECEIPT"
+  else
+    _CS_PRESERVED="$STATE_FILE"
+  fi
+
+  # R1 review C3 fix: emit a meaningful --discarded set so dashboard's
+  # suite.compaction.preserved_artifact_ratio gets data points. Concrete
+  # discarded artifacts (where they exist) + sentinel for compacted in-memory
+  # state per guides/context-management.md §5 (paths producer dropped from
+  # memory, even if some are conceptual).
+  _CS_DISCARDED=""
+  for f in "$_CS_WORK_DIR/sensors"/* "$_CS_WORK_DIR/integrate-loop.json" \
+           "$_CS_WORK_DIR/file-changes.log" "$_CS_WORK_DIR"/.tmp.*; do
+    [ -e "$f" ] && _CS_DISCARDED+="${_CS_DISCARDED:+,}$f"
+  done
+  # Sentinel for conceptual in-memory state that doesn't have a file on disk
+  # (LLM working context, tool-call traces). Without this, dashboard treats the
+  # ratio as undefined when no concrete discarded files exist.
+  _CS_DISCARDED+="${_CS_DISCARDED:+,}.deep-work/${_CS_SID:-session}/.compacted/in-memory-state"
+
+  # Emit — use if/else for optional --source-session-receipt (bash 3.2 safe).
+  if [ -f "$_CS_RECEIPT" ]; then
+    node "$EMIT_SCRIPT" \
+      --trigger session-stop \
+      --output "$_CS_OUT" \
+      --preserved "$_CS_PRESERVED" \
+      --discarded "$_CS_DISCARDED" \
+      --strategy receipt-only \
+      ${_CS_SID:+--session-id "$_CS_SID"} \
+      --source-session-receipt "$_CS_RECEIPT" >/dev/null 2>&1 || true
+  else
+    node "$EMIT_SCRIPT" \
+      --trigger session-stop \
+      --output "$_CS_OUT" \
+      --preserved "$_CS_PRESERVED" \
+      --discarded "$_CS_DISCARDED" \
+      --strategy receipt-only \
+      ${_CS_SID:+--session-id "$_CS_SID"} >/dev/null 2>&1 || true
+  fi
+) 2>>"$PROJECT_ROOT/.claude/deep-work-guard-errors.log" || true
+
 if [[ -z "$CURRENT_PHASE" || "$CURRENT_PHASE" == "idle" ]]; then
   exit 0
 fi
@@ -336,56 +413,6 @@ append_session_history() {
 
 # Run in subshell — errors must never block session close
 (append_session_history) 2>>"$PROJECT_ROOT/.claude/deep-work-guard-errors.log" || true
-
-# ─── v6.6.0 (M5.7) — compaction-state emit at session-stop ────────────
-# Emit an envelope-wrapped `compaction-state.json` so the dashboard
-# (`suite.compaction.frequency`, `suite.compaction.preserved_artifact_ratio`)
-# can attribute this session's stop to a known compaction boundary. The Stop
-# hook contract is "must not block session close" — every step here is
-# best-effort, redirected to the guard-errors log, and ends in `|| true`.
-#
-# Strategy: receipt-only on session-stop (the session-receipt is comprehensive;
-# in-flight working memory is not worth preserving since the next session
-# starts fresh).
-(
-  EMIT_SCRIPT="$SCRIPT_DIR/emit-compaction-state.js"
-  [ -f "$EMIT_SCRIPT" ] || exit 0  # plugin version without emit helper — skip silently
-  command -v node >/dev/null 2>&1 || exit 0
-
-  _CS_WD_REL="$(read_frontmatter_field "$STATE_FILE" "work_dir" 2>/dev/null || echo "")"
-  [ -z "$_CS_WD_REL" ] && exit 0
-  _CS_WORK_DIR="$PROJECT_ROOT/$_CS_WD_REL"
-  _CS_OUTDIR="$PROJECT_ROOT/.deep-work/compaction-states"
-  mkdir -p "$_CS_OUTDIR" 2>/dev/null || exit 0
-
-  # Resolve session id (matches Section 1 fallback chain in deep-finish.md).
-  _CS_SID="${DEEP_WORK_SESSION_ID:-}"
-  if [ -z "$_CS_SID" ] && [ -f "$PROJECT_ROOT/.claude/deep-work-current-session" ]; then
-    _CS_SID="$(tr -d '\n\r' < "$PROJECT_ROOT/.claude/deep-work-current-session" 2>/dev/null || echo "")"
-  fi
-  _CS_TS="$(date -u +%Y%m%dT%H%M%SZ)"
-  _CS_OUT="$_CS_OUTDIR/${_CS_TS}-${_CS_SID:-session-stop}.json"
-
-  # Preserved set: session-receipt if it exists (finalized session); otherwise
-  # the state file (so the next session can resume from disk).
-  _CS_PRESERVED=""
-  _CS_RECEIPT="$_CS_WORK_DIR/session-receipt.json"
-  if [ -f "$_CS_RECEIPT" ]; then
-    _CS_PRESERVED="$_CS_WORK_DIR/session-receipt.json"
-    _CS_PARENT_FLAG=(--source-session-receipt "$_CS_RECEIPT")
-  else
-    _CS_PRESERVED="$STATE_FILE"
-    _CS_PARENT_FLAG=()
-  fi
-
-  node "$EMIT_SCRIPT" \
-    --trigger session-stop \
-    --output "$_CS_OUT" \
-    --preserved "$_CS_PRESERVED" \
-    --strategy receipt-only \
-    ${_CS_SID:+--session-id "$_CS_SID"} \
-    "${_CS_PARENT_FLAG[@]}" >/dev/null 2>&1 || true
-) 2>>"$PROJECT_ROOT/.claude/deep-work-guard-errors.log" || true
 
 # v6.2.4 post-review: cleanup stale PostToolUse stdin-cache files.
 # Remove our own PPID cache (no longer needed after session close) and any

--- a/hooks/scripts/wrap-receipt-envelope.js
+++ b/hooks/scripts/wrap-receipt-envelope.js
@@ -153,9 +153,19 @@ function main() {
   }
 
   const artifactKind = args['artifact-kind'];
-  if (!env.ALLOWED_ARTIFACT_KINDS.has(artifactKind)) {
+  // R2 review fix (Codex adversarial HIGH): restrict this legacy wrapper to its
+  // original 2 artifact kinds. envelope.js#ALLOWED_ARTIFACT_KINDS was extended
+  // in v6.6.0 to also include 'handoff' and 'compaction-state', which would
+  // (without this guard) let wrap-receipt-envelope.js mint envelope-valid but
+  // domain-invalid handoff/compaction-state artifacts (it lacks payload-
+  // required-field validation for those kinds). Force callers to use the
+  // dedicated emit-handoff.js / emit-compaction-state.js helpers, which
+  // enforce payload validation per dashboard contract.
+  const LEGACY_RECEIPT_KINDS = new Set(['session-receipt', 'slice-receipt']);
+  if (!LEGACY_RECEIPT_KINDS.has(artifactKind)) {
     usage(
-      `--artifact-kind must be one of ${[...env.ALLOWED_ARTIFACT_KINDS].join(', ')}, got "${artifactKind}"`,
+      `--artifact-kind must be one of ${[...LEGACY_RECEIPT_KINDS].join(', ')}, got "${artifactKind}" ` +
+        '(use emit-handoff.js / emit-compaction-state.js for handoff/compaction-state)',
     );
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@claude-deep-work/deep-work",
-  "version": "6.5.0",
+  "version": "6.6.0",
+  "scripts": {
+    "test": "node --test tests/envelope-emit.test.js tests/envelope-chain.test.js tests/handoff-roundtrip.test.js"
+  },
   "description": "Deep Work plugin for Claude Code - Evidence-Driven Development Protocol with TDD enforcement, Health Engine (drift detection + fitness functions), worktree isolation, model auto-routing, receipt validation, 6-phase workflow with Phase 5 Integrate",
   "author": "sungmin",
   "license": "MIT",

--- a/scripts/validate-envelope-emit.js
+++ b/scripts/validate-envelope-emit.js
@@ -48,7 +48,15 @@ const GIT_HEAD_RE = /^[a-f0-9]{7,40}$/;
 const SCHEMA_VERSION_RE = /^\d+\.\d+$/;
 
 const PLUGIN_NAME = 'deep-work';
-const ALLOWED_KINDS = new Set(['session-receipt', 'slice-receipt']);
+// 'handoff' and 'compaction-state' added in v6.6.0 (M5.7 cross-plugin long-run
+// handoff + dashboard compaction telemetry). Schemas live in claude-deep-suite/
+// schemas/{handoff,compaction-state}.schema.json.
+const ALLOWED_KINDS = new Set([
+  'session-receipt',
+  'slice-receipt',
+  'handoff',
+  'compaction-state',
+]);
 
 const ROOT_KEYS = new Set(['$schema', 'schema_version', 'envelope', 'payload']);
 const ENVELOPE_KEYS = new Set([

--- a/tests/handoff-roundtrip.test.js
+++ b/tests/handoff-roundtrip.test.js
@@ -37,10 +37,12 @@ const {
 const {
   validateHandoffPayload,
   HANDOFF_REQUIRED,
+  VALID_HANDOFF_KINDS,
 } = require('../hooks/scripts/emit-handoff.js');
 const {
   validateCompactionPayload,
   VALID_TRIGGERS,
+  VALID_STRATEGIES,
   COMPACTION_REQUIRED,
 } = require('../hooks/scripts/emit-compaction-state.js');
 
@@ -86,8 +88,19 @@ function runValidate(file) {
 /**
  * Mirror of claude-deep-dashboard/lib/suite-collector.js `unwrapStrict` (the
  * contract this emit needs to satisfy). Kept zero-dep so the deep-work plugin
- * doesn't have to import dashboard code. If dashboard's contract drifts, this
- * mirror will go stale — caught by M5.5 #8 cross-plugin CI in suite repo.
+ * doesn't have to import dashboard code.
+ *
+ * R1 review C5 (Opus + de-Opus C3): the dashboard's real `unwrapStrict` checks
+ * `schema.name === expectedKind` but NOT `schema.version`. The mirror was
+ * previously a strict superset (also checked schema.version === '1.0') which
+ * defeats its drift-sensor purpose. The mirror is now a true mirror — the
+ * producer-side `wrapEnvelope` always sets schema.version='1.0' so this doesn't
+ * change current behavior, but a future producer emitting schema.version='1.1'
+ * (additive evolution) would now correctly pass the mirror as it would pass
+ * the dashboard.
+ *
+ * If dashboard's contract drifts, this mirror will go stale — caught by
+ * M5.5 #8 cross-plugin CI in suite repo.
  */
 function dashboardUnwrapStrict(obj, expectedProducer, expectedKind, requiredFields) {
   if (!obj || typeof obj !== 'object' || Array.isArray(obj)) {
@@ -105,8 +118,7 @@ function dashboardUnwrapStrict(obj, expectedProducer, expectedKind, requiredFiel
     !env.schema ||
     typeof env.schema !== 'object' ||
     Array.isArray(env.schema) ||
-    env.schema.name !== expectedKind ||
-    env.schema.version !== '1.0'
+    env.schema.name !== expectedKind
   ) {
     return { failure: 'identity-mismatch' };
   }
@@ -194,6 +206,36 @@ describe('emit-handoff — HANDOFF_REQUIRED matches dashboard contract', () => {
     const errors = validateHandoffPayload([makeHandoffPayload()]);
     assert.ok(errors.some((e) => /non-array/.test(e)), errors.join(';'));
   });
+
+  // R1 review C4: handoff_kind enum validation regression test.
+  it('rejects payload with invalid handoff_kind (R1 C4)', () => {
+    const payload = makeHandoffPayload();
+    payload.handoff_kind = 'phase-5-evolve';  // typo (missing 'to')
+    const errors = validateHandoffPayload(payload);
+    assert.ok(errors.some((e) => /handoff_kind must be one of/.test(e)), errors.join(';'));
+  });
+
+  it('accepts every schema-enum handoff_kind value', () => {
+    for (const kind of VALID_HANDOFF_KINDS) {
+      const payload = makeHandoffPayload();
+      payload.handoff_kind = kind;
+      const errors = validateHandoffPayload(payload);
+      assert.deepEqual(errors, [], `${kind} should be valid: ${errors.join(';')}`);
+    }
+  });
+
+  it('VALID_HANDOFF_KINDS contains all 5 schema enum values', () => {
+    assert.deepEqual(
+      [...VALID_HANDOFF_KINDS].sort(),
+      [
+        'custom',
+        'evolve-to-deep-work',
+        'phase-5-to-evolve',
+        'session-resume',
+        'slice-to-slice',
+      ].sort(),
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -262,6 +304,36 @@ describe('emit-handoff.js — CLI roundtrip satisfies dashboard unwrapStrict', (
     }
     assert.equal(fs.existsSync(outPath), false, 'should not have written output on failure');
   });
+
+  // R1 review W1: stderr warning when --source-session-receipt resolves to a
+  // non-envelope (orphan chain breakage indicator).
+  it('stderr-warns when --source-session-receipt is not a valid envelope (R1 W1)', () => {
+    const dir = tmpDir();
+    const payloadPath = path.join(dir, 'payload.json');
+    writeJson(payloadPath, makeHandoffPayload());
+    // Non-envelope JSON (just a legacy receipt shape).
+    const badReceipt = path.join(dir, 'legacy-receipt.json');
+    writeJson(badReceipt, { schema_version: '1.0', session_id: 'x', slices: { total: 1 } });
+
+    const outPath = path.join(dir, 'handoff.json');
+    const result = execFileSync('node', [
+      EMIT_HANDOFF,
+      '--payload-file', payloadPath,
+      '--output', outPath,
+      '--source-session-receipt', badReceipt,
+    ], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+    // Emit still succeeds (orphan handoff is a valid envelope, just chain-less).
+    const obj = readJson(outPath);
+    assert.equal(obj.envelope.parent_run_id, undefined, 'parent_run_id should be omitted');
+    // The CLI itself logs the emit-summary to stdout; the stderr warn happens
+    // inside the process. execFileSync only returns stdout; we need spawnSync
+    // for full stderr. Instead verify the absence of parent_run_id (which the
+    // warning announces) and the presence of the source artifact path-only.
+    const provSrc = obj.envelope.provenance.source_artifacts;
+    const entry = provSrc.find((s) => s.path === badReceipt);
+    assert.ok(entry, 'source artifact entry should be recorded path-only');
+    assert.equal(entry.run_id, undefined, 'no run_id since non-envelope');
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -315,6 +387,35 @@ describe('emit-compaction-state — required + trigger enum match suite schema',
         'window-threshold',
       ].sort(),
     );
+  });
+
+  // R1 review C4: compaction_strategy enum validation regression — previously
+  // --payload-file mode bypassed strategy check (only CLI flag mode validated it).
+  it('rejects payload-file with invalid compaction_strategy (R1 C4)', () => {
+    const errors = validateCompactionPayload({
+      schema_version: '1.0',
+      compacted_at: '2026-05-12T10:00:00Z',
+      trigger: 'phase-transition',
+      preserved_artifact_paths: [],
+      compaction_strategy: 'receipt-onnly',  // typo
+    });
+    assert.ok(
+      errors.some((e) => /compaction_strategy must be one of/.test(e)),
+      errors.join(';'),
+    );
+  });
+
+  it('accepts every schema-enum compaction_strategy value', () => {
+    for (const strategy of VALID_STRATEGIES) {
+      const errors = validateCompactionPayload({
+        schema_version: '1.0',
+        compacted_at: '2026-05-12T10:00:00Z',
+        trigger: 'phase-transition',
+        preserved_artifact_paths: [],
+        compaction_strategy: strategy,
+      });
+      assert.deepEqual(errors, [], `${strategy} should be valid: ${errors.join(';')}`);
+    }
   });
 });
 

--- a/tests/handoff-roundtrip.test.js
+++ b/tests/handoff-roundtrip.test.js
@@ -38,6 +38,8 @@ const {
   validateHandoffPayload,
   HANDOFF_REQUIRED,
   VALID_HANDOFF_KINDS,
+  KIND_DIRECTIONS,
+  tryReadEnvelopeRunId,
 } = require('../hooks/scripts/emit-handoff.js');
 const {
   validateCompactionPayload,
@@ -215,10 +217,18 @@ describe('emit-handoff — HANDOFF_REQUIRED matches dashboard contract', () => {
     assert.ok(errors.some((e) => /handoff_kind must be one of/.test(e)), errors.join(';'));
   });
 
-  it('accepts every schema-enum handoff_kind value', () => {
+  it('accepts every schema-enum handoff_kind value with matching direction', () => {
+    // R2 review fix: direction enforcement now requires from/to producers to
+    // match the kind for direction-bound kinds (phase-5-to-evolve, evolve-to-
+    // deep-work). Other kinds (slice-to-slice, session-resume, custom) are
+    // direction-free — direction can be anything.
     for (const kind of VALID_HANDOFF_KINDS) {
       const payload = makeHandoffPayload();
       payload.handoff_kind = kind;
+      if (KIND_DIRECTIONS[kind]) {
+        payload.from.producer = KIND_DIRECTIONS[kind].from;
+        payload.to.producer = KIND_DIRECTIONS[kind].to;
+      }
       const errors = validateHandoffPayload(payload);
       assert.deepEqual(errors, [], `${kind} should be valid: ${errors.join(';')}`);
     }
@@ -235,6 +245,41 @@ describe('emit-handoff — HANDOFF_REQUIRED matches dashboard contract', () => {
         'slice-to-slice',
       ].sort(),
     );
+  });
+
+  // R2 review fix (Codex adversarial MEDIUM): direction enforcement.
+  it('rejects phase-5-to-evolve with wrong from.producer (R2)', () => {
+    const payload = makeHandoffPayload();
+    payload.from.producer = 'deep-evolve';  // wrong — should be deep-work
+    const errors = validateHandoffPayload(payload);
+    assert.ok(
+      errors.some((e) => /from\.producer.*must be "deep-work"/.test(e)),
+      errors.join(';'),
+    );
+  });
+
+  it('rejects phase-5-to-evolve with wrong to.producer (R2)', () => {
+    const payload = makeHandoffPayload();
+    payload.to.producer = 'deep-work';  // wrong — should be deep-evolve
+    const errors = validateHandoffPayload(payload);
+    assert.ok(
+      errors.some((e) => /to\.producer.*must be "deep-evolve"/.test(e)),
+      errors.join(';'),
+    );
+  });
+
+  it('accepts canonical phase-5-to-evolve direction', () => {
+    const payload = makeHandoffPayload();
+    assert.deepEqual(validateHandoffPayload(payload), []);
+  });
+
+  it('does not enforce direction for slice-to-slice / custom', () => {
+    const payload = makeHandoffPayload();
+    payload.handoff_kind = 'slice-to-slice';
+    // Direction doesn't matter for slice-to-slice
+    payload.from.producer = 'deep-evolve';
+    payload.to.producer = 'deep-evolve';
+    assert.deepEqual(validateHandoffPayload(payload), []);
   });
 });
 
@@ -303,6 +348,45 @@ describe('emit-handoff.js — CLI roundtrip satisfies dashboard unwrapStrict', (
       assert.match(stderr, /handoff_kind/);
     }
     assert.equal(fs.existsSync(outPath), false, 'should not have written output on failure');
+  });
+
+  // R2 review fix (Codex adversarial MEDIUM): tryReadEnvelopeRunId now rejects
+  // foreign envelope (wrong producer / artifact_kind / schema.name).
+  it('tryReadEnvelopeRunId rejects foreign envelope when expectedIdentities given (R2)', () => {
+    const dir = tmpDir();
+    // Build a deep-evolve evolve-receipt envelope (foreign for deep-work emit).
+    const foreign = {
+      $schema: 'https://example/envelope.schema.json',
+      schema_version: '1.0',
+      envelope: {
+        producer: 'deep-evolve',
+        producer_version: '3.3.0',
+        artifact_kind: 'evolve-receipt',
+        run_id: '01JTKGZQ7NABCDEFGHJKMNPQRS',
+        generated_at: new Date().toISOString(),
+        schema: { name: 'evolve-receipt', version: '1.0' },
+        git: { head: 'abc1234', branch: 'main', dirty: false },
+        provenance: { source_artifacts: [], tool_versions: { node: 'v20' } },
+      },
+      payload: { schema_version: '1.0', plugin: 'deep-evolve' },
+    };
+    const foreignPath = path.join(dir, 'foreign.json');
+    writeJson(foreignPath, foreign);
+
+    // Expected identity = deep-work session-receipt; foreign envelope rejected.
+    const result = tryReadEnvelopeRunId(foreignPath, [
+      { producer: 'deep-work', kind: 'session-receipt' },
+    ]);
+    assert.equal(result, null, 'foreign envelope must not yield a run_id');
+  });
+
+  it('tryReadEnvelopeRunId accepts matching identity (R2)', () => {
+    const dir = tmpDir();
+    const sr = makeSessionReceiptEnvelope(dir);
+    const result = tryReadEnvelopeRunId(sr.path, [
+      { producer: 'deep-work', kind: 'session-receipt' },
+    ]);
+    assert.equal(result, sr.runId);
   });
 
   // R1 review W1: stderr warning when --source-session-receipt resolves to a

--- a/tests/handoff-roundtrip.test.js
+++ b/tests/handoff-roundtrip.test.js
@@ -1,0 +1,443 @@
+'use strict';
+
+/**
+ * handoff-roundtrip.test.js — M5.5 #8 (deep-work half) + M5.7.A test target.
+ *
+ * Verifies emit-handoff.js + emit-compaction-state.js produce envelope-wrapped
+ * artifacts that satisfy the claude-deep-dashboard suite-collector's
+ * `unwrapStrict` contract (cf. claude-deep-dashboard/lib/suite-collector.js).
+ *
+ * The contract has four layers — each test exercises at least one:
+ *   1. envelope-shape (schema_version === '1.0', envelope + payload present)
+ *   2. identity-triplet (producer + artifact_kind + schema.name match)
+ *   3. payload-shape (non-null, non-array object)
+ *   4. payload-required-fields per `<producer>/<kind>`:
+ *        deep-work/handoff:           schema_version, handoff_kind, from, to,
+ *                                     summary, next_action_brief
+ *        deep-work/compaction-state:  schema_version, compacted_at, trigger,
+ *                                     preserved_artifact_paths
+ *
+ * Also verifies the cross-plugin chain: handoff.envelope.parent_run_id ===
+ * session-receipt.envelope.run_id when --source-session-receipt is provided.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const { ULID_RE, validate } = require('../scripts/validate-envelope-emit.js');
+const {
+  wrapEnvelope,
+  generateUlid,
+  isValidEnvelope,
+} = require('../hooks/scripts/envelope.js');
+const {
+  validateHandoffPayload,
+  HANDOFF_REQUIRED,
+} = require('../hooks/scripts/emit-handoff.js');
+const {
+  validateCompactionPayload,
+  VALID_TRIGGERS,
+  COMPACTION_REQUIRED,
+} = require('../hooks/scripts/emit-compaction-state.js');
+
+const EMIT_HANDOFF = path.resolve(__dirname, '..', 'hooks', 'scripts', 'emit-handoff.js');
+const EMIT_COMPACTION = path.resolve(__dirname, '..', 'hooks', 'scripts', 'emit-compaction-state.js');
+const VALIDATE_CLI = path.resolve(__dirname, '..', 'scripts', 'validate-envelope-emit.js');
+
+// Dashboard's PAYLOAD_REQUIRED_FIELDS — must match
+// claude-deep-dashboard/lib/suite-constants.js exactly.
+const DASHBOARD_HANDOFF_REQUIRED = [
+  'schema_version', 'handoff_kind', 'from', 'to', 'summary', 'next_action_brief',
+];
+const DASHBOARD_COMPACTION_REQUIRED = [
+  'schema_version', 'compacted_at', 'trigger', 'preserved_artifact_paths',
+];
+
+function tmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'dw-handoff-'));
+}
+
+function writeJson(p, obj) {
+  fs.writeFileSync(p, JSON.stringify(obj, null, 2));
+}
+
+function readJson(p) {
+  return JSON.parse(fs.readFileSync(p, 'utf8'));
+}
+
+function runEmit(script, args) {
+  return execFileSync('node', [script, ...args], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+function runValidate(file) {
+  return execFileSync('node', [VALIDATE_CLI, file], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+/**
+ * Mirror of claude-deep-dashboard/lib/suite-collector.js `unwrapStrict` (the
+ * contract this emit needs to satisfy). Kept zero-dep so the deep-work plugin
+ * doesn't have to import dashboard code. If dashboard's contract drifts, this
+ * mirror will go stale — caught by M5.5 #8 cross-plugin CI in suite repo.
+ */
+function dashboardUnwrapStrict(obj, expectedProducer, expectedKind, requiredFields) {
+  if (!obj || typeof obj !== 'object' || Array.isArray(obj)) {
+    return { failure: 'not-envelope-shape' };
+  }
+  if (obj.schema_version !== '1.0') return { failure: 'not-envelope-shape' };
+  if (!obj.envelope || typeof obj.envelope !== 'object' || Array.isArray(obj.envelope)) {
+    return { failure: 'not-envelope-shape' };
+  }
+  if (obj.payload === undefined) return { failure: 'not-envelope-shape' };
+  const env = obj.envelope;
+  if (
+    env.producer !== expectedProducer ||
+    env.artifact_kind !== expectedKind ||
+    !env.schema ||
+    typeof env.schema !== 'object' ||
+    Array.isArray(env.schema) ||
+    env.schema.name !== expectedKind ||
+    env.schema.version !== '1.0'
+  ) {
+    return { failure: 'identity-mismatch' };
+  }
+  const pl = obj.payload;
+  if (pl === null || typeof pl !== 'object' || Array.isArray(pl)) {
+    return { failure: 'payload-shape-violation' };
+  }
+  const missing = requiredFields.filter((k) => !(k in pl));
+  if (missing.length > 0) {
+    return { failure: `missing-required-fields:${missing.join(',')}` };
+  }
+  return { ok: true, envelope: env, payload: pl };
+}
+
+function makeSessionReceiptEnvelope(dir) {
+  const sessionRunId = generateUlid();
+  const sessionReceipt = wrapEnvelope({
+    artifactKind: 'session-receipt',
+    payload: {
+      schema_version: '1.0',
+      session_id: '2026-05-12-handoff-test',
+      slices: { total: 3, completed: 3, spike: 0 },
+      outcome: 'merge',
+    },
+    runId: sessionRunId,
+    git: { head: 'abc1234', branch: 'main', dirty: false },
+  });
+  const p = path.join(dir, 'session-receipt.json');
+  writeJson(p, sessionReceipt);
+  return { path: p, runId: sessionRunId };
+}
+
+function makeHandoffPayload() {
+  return {
+    schema_version: '1.0',
+    handoff_kind: 'phase-5-to-evolve',
+    from: {
+      producer: 'deep-work',
+      session_id: '2026-05-12-handoff-test',
+      phase: 'integrate',
+      completed_at: '2026-05-12T10:00:00Z',
+    },
+    to: {
+      producer: 'deep-evolve',
+      intent: 'performance-optimization',
+      scope_hint: 'src/auth/jwt.ts',
+    },
+    summary: 'Test session integrated; 3/3 slices GREEN.',
+    next_action_brief: 'deep-evolve로 JWT verify 성능 최적화 — current p99=180ms, target <50ms.',
+    completed_actions: ['merged PR #123', '3/3 slices GREEN'],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// emit-handoff.js — payload validation (unit)
+// ---------------------------------------------------------------------------
+
+describe('emit-handoff — HANDOFF_REQUIRED matches dashboard contract', () => {
+  it('emit-handoff.js HANDOFF_REQUIRED is identical to dashboard PAYLOAD_REQUIRED_FIELDS["deep-work/handoff"]', () => {
+    assert.deepEqual(HANDOFF_REQUIRED, DASHBOARD_HANDOFF_REQUIRED);
+  });
+
+  it('rejects payload missing handoff_kind', () => {
+    const payload = makeHandoffPayload();
+    delete payload.handoff_kind;
+    const errors = validateHandoffPayload(payload);
+    assert.ok(errors.some((e) => /handoff_kind/.test(e)), errors.join(';'));
+  });
+
+  it('rejects payload with non-1.0 schema_version', () => {
+    const payload = makeHandoffPayload();
+    payload.schema_version = '2.0';
+    const errors = validateHandoffPayload(payload);
+    assert.ok(errors.some((e) => /schema_version/.test(e)), errors.join(';'));
+  });
+
+  it('rejects payload with from.producer missing', () => {
+    const payload = makeHandoffPayload();
+    delete payload.from.producer;
+    const errors = validateHandoffPayload(payload);
+    assert.ok(errors.some((e) => /from/.test(e)), errors.join(';'));
+  });
+
+  it('rejects array payload (corrupt-payload defense)', () => {
+    const errors = validateHandoffPayload([makeHandoffPayload()]);
+    assert.ok(errors.some((e) => /non-array/.test(e)), errors.join(';'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// emit-handoff.js — CLI roundtrip
+// ---------------------------------------------------------------------------
+
+describe('emit-handoff.js — CLI roundtrip satisfies dashboard unwrapStrict', () => {
+  it('emits envelope + parent_run_id chains to session-receipt + dashboard accepts it', () => {
+    const dir = tmpDir();
+    const sr = makeSessionReceiptEnvelope(dir);
+
+    const payloadPath = path.join(dir, 'handoff-payload.json');
+    writeJson(payloadPath, makeHandoffPayload());
+
+    const outPath = path.join(dir, 'handoffs', 'handoff.json');
+    runEmit(EMIT_HANDOFF, [
+      '--payload-file', payloadPath,
+      '--output', outPath,
+      '--source-session-receipt', sr.path,
+      '--session-id', '2026-05-12-handoff-test',
+    ]);
+
+    // envelope shape via the deep-work-side validator (catches additionalProperties etc).
+    runValidate(outPath);
+
+    // Dashboard contract — the actual production gate.
+    const obj = readJson(outPath);
+    const result = dashboardUnwrapStrict(obj, 'deep-work', 'handoff', DASHBOARD_HANDOFF_REQUIRED);
+    assert.equal(result.failure, undefined, `unwrapStrict failed: ${result.failure}`);
+    assert.ok(result.ok);
+
+    // Cross-plugin chain: parent_run_id closes against session-receipt.
+    assert.equal(obj.envelope.parent_run_id, sr.runId);
+    assert.match(obj.envelope.run_id, ULID_RE);
+    assert.notEqual(obj.envelope.run_id, sr.runId);
+
+    // Provenance: source_artifacts records the session-receipt with its run_id.
+    const provSrc = obj.envelope.provenance.source_artifacts;
+    assert.ok(Array.isArray(provSrc));
+    const srcEntry = provSrc.find((s) => s.run_id === sr.runId);
+    assert.ok(srcEntry, 'session-receipt source_artifacts entry missing');
+  });
+
+  it('exits non-zero with payload validation error when handoff_kind missing', () => {
+    const dir = tmpDir();
+    const sr = makeSessionReceiptEnvelope(dir);
+    const bad = makeHandoffPayload();
+    delete bad.handoff_kind;
+    const payloadPath = path.join(dir, 'bad-payload.json');
+    writeJson(payloadPath, bad);
+
+    const outPath = path.join(dir, 'handoff.json');
+    let stderr = '';
+    try {
+      execFileSync('node', [
+        EMIT_HANDOFF,
+        '--payload-file', payloadPath,
+        '--output', outPath,
+        '--source-session-receipt', sr.path,
+      ], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+      assert.fail('emit-handoff should have failed for missing handoff_kind');
+    } catch (err) {
+      stderr = String(err.stderr || '');
+      assert.equal(err.status, 1, `expected exit 1, got ${err.status}; stderr=${stderr}`);
+      assert.match(stderr, /handoff_kind/);
+    }
+    assert.equal(fs.existsSync(outPath), false, 'should not have written output on failure');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// emit-compaction-state.js — payload validation (unit)
+// ---------------------------------------------------------------------------
+
+describe('emit-compaction-state — required + trigger enum match suite schema', () => {
+  it('COMPACTION_REQUIRED matches dashboard PAYLOAD_REQUIRED_FIELDS["deep-work/compaction-state"]', () => {
+    assert.deepEqual(COMPACTION_REQUIRED, DASHBOARD_COMPACTION_REQUIRED);
+  });
+
+  it('rejects unknown trigger', () => {
+    const errors = validateCompactionPayload({
+      schema_version: '1.0',
+      compacted_at: '2026-05-12T10:00:00Z',
+      trigger: 'not-a-real-trigger',
+      preserved_artifact_paths: [],
+    });
+    assert.ok(errors.some((e) => /trigger/.test(e)));
+  });
+
+  it('accepts canonical phase-transition trigger with empty preserved array', () => {
+    const errors = validateCompactionPayload({
+      schema_version: '1.0',
+      compacted_at: '2026-05-12T10:00:00Z',
+      trigger: 'phase-transition',
+      preserved_artifact_paths: [],
+    });
+    assert.deepEqual(errors, []);
+  });
+
+  it('rejects non-array preserved_artifact_paths', () => {
+    const errors = validateCompactionPayload({
+      schema_version: '1.0',
+      compacted_at: '2026-05-12T10:00:00Z',
+      trigger: 'phase-transition',
+      preserved_artifact_paths: 'oops',
+    });
+    assert.ok(errors.some((e) => /preserved_artifact_paths/.test(e)));
+  });
+
+  it('VALID_TRIGGERS contains all 6 schema enum values', () => {
+    assert.deepEqual(
+      [...VALID_TRIGGERS].sort(),
+      [
+        'loop-epoch-end',
+        'manual',
+        'phase-transition',
+        'session-stop',
+        'slice-green',
+        'window-threshold',
+      ].sort(),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// emit-compaction-state.js — CLI roundtrip
+// ---------------------------------------------------------------------------
+
+describe('emit-compaction-state.js — CLI roundtrip satisfies dashboard unwrapStrict', () => {
+  it('build payload from flags + session-receipt chain', () => {
+    const dir = tmpDir();
+    const sr = makeSessionReceiptEnvelope(dir);
+
+    const outPath = path.join(dir, 'compaction-states', 'cs.json');
+    runEmit(EMIT_COMPACTION, [
+      '--trigger', 'phase-transition',
+      '--output', outPath,
+      '--session-id', '2026-05-12-handoff-test',
+      '--preserved', '.deep-work/foo/research.md,.deep-work/foo/plan.md',
+      '--discarded', '.deep-work/foo/tmp-llm-trace.json',
+      '--strategy', 'key-artifacts-only',
+      '--source-session-receipt', sr.path,
+    ]);
+
+    runValidate(outPath);
+
+    const obj = readJson(outPath);
+    const result = dashboardUnwrapStrict(
+      obj, 'deep-work', 'compaction-state', DASHBOARD_COMPACTION_REQUIRED,
+    );
+    assert.equal(result.failure, undefined, `unwrapStrict failed: ${result.failure}`);
+
+    assert.equal(obj.envelope.parent_run_id, sr.runId);
+    assert.equal(obj.payload.trigger, 'phase-transition');
+    assert.equal(obj.payload.compaction_strategy, 'key-artifacts-only');
+    assert.deepEqual(obj.payload.preserved_artifact_paths, [
+      '.deep-work/foo/research.md',
+      '.deep-work/foo/plan.md',
+    ]);
+    assert.deepEqual(obj.payload.discarded_artifact_paths, [
+      '.deep-work/foo/tmp-llm-trace.json',
+    ]);
+  });
+
+  it('emits valid compaction-state for each trigger enum value', () => {
+    const dir = tmpDir();
+    for (const trigger of VALID_TRIGGERS) {
+      const outPath = path.join(dir, `cs-${trigger}.json`);
+      runEmit(EMIT_COMPACTION, [
+        '--trigger', trigger,
+        '--output', outPath,
+        '--preserved', '.deep-work/x/y.md',
+      ]);
+      const obj = readJson(outPath);
+      assert.equal(obj.payload.trigger, trigger);
+      const r = dashboardUnwrapStrict(
+        obj, 'deep-work', 'compaction-state', DASHBOARD_COMPACTION_REQUIRED,
+      );
+      assert.equal(r.failure, undefined, `${trigger}: ${r.failure}`);
+    }
+  });
+
+  it('rejects unknown trigger at CLI level (exit 1)', () => {
+    const dir = tmpDir();
+    const outPath = path.join(dir, 'cs.json');
+    try {
+      execFileSync('node', [
+        EMIT_COMPACTION,
+        '--trigger', 'bogus',
+        '--output', outPath,
+      ], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+      assert.fail('should have failed for unknown trigger');
+    } catch (err) {
+      assert.equal(err.status, 1);
+      assert.match(String(err.stderr), /trigger/);
+    }
+    assert.equal(fs.existsSync(outPath), false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Round-trip — both artifacts present, dashboard chain check
+// ---------------------------------------------------------------------------
+
+describe('handoff + compaction-state round-trip together', () => {
+  it('all three artifacts (session-receipt + handoff + compaction-state) share a run_id chain', () => {
+    const dir = tmpDir();
+    const sr = makeSessionReceiptEnvelope(dir);
+
+    const payloadPath = path.join(dir, 'handoff-payload.json');
+    writeJson(payloadPath, makeHandoffPayload());
+    const handoffPath = path.join(dir, 'handoff.json');
+    runEmit(EMIT_HANDOFF, [
+      '--payload-file', payloadPath,
+      '--output', handoffPath,
+      '--source-session-receipt', sr.path,
+    ]);
+
+    const csPath = path.join(dir, 'compaction-state.json');
+    runEmit(EMIT_COMPACTION, [
+      '--trigger', 'session-stop',
+      '--output', csPath,
+      '--preserved', sr.path,
+      '--source-session-receipt', sr.path,
+      '--strategy', 'receipt-only',
+    ]);
+
+    const ho = readJson(handoffPath);
+    const cs = readJson(csPath);
+    assert.equal(ho.envelope.parent_run_id, sr.runId, 'handoff parent chains to session-receipt');
+    assert.equal(cs.envelope.parent_run_id, sr.runId, 'compaction-state parent chains to session-receipt');
+    assert.notEqual(ho.envelope.run_id, cs.envelope.run_id, 'each artifact has its own run_id');
+
+    // Both pass dashboard's unwrapStrict.
+    assert.ok(isValidEnvelope(ho));
+    assert.ok(isValidEnvelope(cs));
+    assert.equal(
+      dashboardUnwrapStrict(ho, 'deep-work', 'handoff', DASHBOARD_HANDOFF_REQUIRED).failure,
+      undefined,
+    );
+    assert.equal(
+      dashboardUnwrapStrict(cs, 'deep-work', 'compaction-state', DASHBOARD_COMPACTION_REQUIRED)
+        .failure,
+      undefined,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Closes the M5.7.A leg of [claude-deep-suite M5.7 milestone](https://github.com/Sungmin-Cho/claude-deep-suite/blob/main/docs/superpowers/plans/2026-05-11-m5.7-plugin-adoption-handoff.md) — deep-work side of plugin-side adoption for cross-plugin long-run handoff + dashboard compaction telemetry.
- Powers 3 M5-activated dashboard metrics: `suite.handoff.roundtrip_success_rate`, `suite.compaction.frequency`, `suite.compaction.preserved_artifact_ratio`.
- Producer-only — deep-work emits but does not consume `handoff.json` / `compaction-state.json` (consumed by `claude-deep-dashboard`).

## What ships

- **`hooks/scripts/emit-handoff.js`** — CLI wrapper for envelope-wrapped `handoff.json`. Identity-triplet automatically set; payload required-fields + handoff_kind enum + direction enforced (KIND_DIRECTIONS map: `phase-5-to-evolve` requires from=deep-work + to=deep-evolve).
- **`hooks/scripts/emit-compaction-state.js`** — CLI wrapper for envelope-wrapped `compaction-state.json`. Trigger enum (6 values) + strategy enum (6 values) enforced in both `--payload-file` and CLI-flag modes.
- **`commands/deep-finish.md` §7-Z-A** — optional cross-plugin handoff emit after envelope wrap; `--handoff-to=<plugin>` flag or interactive opt-in.
- **`hooks/scripts/session-end.sh`** — Stop hook emits `compaction-state.json` (trigger=session-stop, strategy=receipt-only) BEFORE the idle fast-exit so finalized sessions are captured. Uses `phase5_work_dir_snapshot` first for tamper resistance.
- **`hooks/scripts/phase-transition.sh`** — PostToolUse hook emits `compaction-state.json` on each phase boundary. Preserves the just-closed phase's artifact (filtered to existing files); discarded set includes concrete sensor/tmp files + sentinel for compacted LLM context.
- **`hooks/scripts/wrap-receipt-envelope.js`** — local `LEGACY_RECEIPT_KINDS` set restricting this legacy wrapper to its original 2 kinds (session-receipt, slice-receipt) so the extended envelope ALLOWED_ARTIFACT_KINDS cannot be used to bypass domain validation.
- **`tests/handoff-roundtrip.test.js`** — 25 assertions covering payload validation, identity-triplet, direction enforcement, foreign envelope rejection, full round-trip closure.

## Review history (3-round 3-way)

| Round | Reviewers | Verdict | Findings |
|---|---|---|---|
| R1 | Opus + Codex review + Codex adversarial | REQUEST_CHANGES | 5C + 2W (idle fast-exit, future artifacts, --discarded omit, enum, mirror, source orphan, bash3 array) |
| R2 | Opus + Codex review + Codex adversarial | APPROVE (Opus) + 1 P3 + 2 MEDIUM Codex | session_id propagation, foreign envelope identity, Phase 5 snapshot |
| R3 | Opus + Codex review | **APPROVE** (Opus) — Codex timed out on exploration, no contradicting findings | — |

All review reports + responses in `.deep-review/{reports,responses}/`.

## Tests

87/87 green (81 base + 6 new R1 regression + adjusted iteration). Run: `npm test`.

## Test plan

- [ ] CI green (npm test 87/87)
- [ ] After merge: bump marketplace.json SHA in claude-deep-suite + update producer-adoption ledger in `docs/envelope-migration.md`
- [ ] Real-project verification: deep-work Phase 5 → deep-evolve epoch cycle produces files under `.deep-work/handoffs/` + `.deep-work/compaction-states/` + dashboard collector reports numeric values for 3 M5-activated metrics

## Related

- claude-deep-evolve PR (M5.7.B counterpart): https://github.com/Sungmin-Cho/claude-deep-evolve/pulls (pairs with this PR)
- Suite milestone: M5.7 — see `claude-deep-suite/docs/envelope-migration.md` §6.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)