### PR TITLE
ci(m5.5): add ubuntu+macos cross-platform test matrix

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deep-work",
-  "version": "6.6.0",
+  "version": "6.6.1",
   "description": "Evidence-Driven Development Protocol — 3-layer architecture with Skill-based phase dispatch, computational enforcement (worktree guard + phase transition injection), TDD enforcement, and receipt validation",
   "author": {
     "name": "sungmin"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,37 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    name: tests (${{ matrix.os }})
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Show bash version (M5.5 #4 — bash 3.2 visibility)
+        run: bash --version
+
+      - name: Run envelope + handoff round-trip tests
+        run: npm test
+
+      - name: Run bash regression scripts (phase-guard / migrate / notify / recommender)
+        run: |
+          bash hooks/scripts/test/test-no-notification-trigger.sh
+          bash hooks/scripts/test/test-recommender-integration.sh
+          bash hooks/scripts/test/test-v6.4.2-regression.sh

--- a/hooks/scripts/test/test-v6.4.2-regression.sh
+++ b/hooks/scripts/test/test-v6.4.2-regression.sh
@@ -38,7 +38,10 @@ result=$(node "$REPO_ROOT/scripts/migrate-profile-v2-to-v3.js" "$tmp/p.yaml" 2>&
 echo "$result" | grep -q '"migrated":\s*true' || fail "v3 마이그레이션 실행 안 됨: $result"
 grep -q "plan: main" "$tmp/p.yaml" || fail "v3 마이그레이션 후 plan: main 사라짐"
 # chmod 600 검증 (macOS / Linux 양쪽)
-mode=$(stat -f '%A' "$tmp/p.yaml" 2>/dev/null || stat -c '%a' "$tmp/p.yaml" 2>/dev/null || echo "unknown")
+# NOTE: GNU stat 의 `-f` 는 "filesystem status" 라서 macOS BSD 의 `-f format` 과 의미가
+# 다르고 exit 0 으로 fall-through 하지 않는다. GNU `-c '%a'` 를 먼저 시도해야
+# Linux 에서 mode 가 multi-line FS stats 로 오염되지 않는다 (M5.5 #4 CI 매트릭스에서 적발).
+mode=$(stat -c '%a' "$tmp/p.yaml" 2>/dev/null || stat -f '%A' "$tmp/p.yaml" 2>/dev/null || echo "unknown")
 [[ "$mode" == "600" ]] || fail "v3 파일 권한이 0o600이 아님: $mode"
 pass "v3 마이그레이션 model_routing.plan 보존 + chmod 600"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-deep-work/deep-work",
-  "version": "6.6.0",
+  "version": "6.6.1",
   "scripts": {
     "test": "node --test tests/envelope-emit.test.js tests/envelope-chain.test.js tests/handoff-roundtrip.test.js"
   },


### PR DESCRIPTION
## Summary
- New `.github/workflows/tests.yml` runs `npm test` (87 envelope + handoff round-trip assertions) **and** the 3 bash regression scripts in `hooks/scripts/test/` on `ubuntu-latest` + `macos-latest`.
- `bash --version` is printed up front so failures clearly identify the bash 3.2 vs GNU 4+ leg.
- Closes **M5.5 #4** (deep-work side). See `claude-deep-suite/docs/superpowers/plans/2026-05-12-m5.5-remaining-tests-handoff.md` §2 #4.

## Why
`session-end.sh` empty-array-under-`set -u` regression (M5.7 R1 W2) leaked from local dev to production because nothing exercised macOS bash 3.2 in CI. This matrix closes that gap.

## Local verification on macOS bash 3.2.57 (this branch's baseline)
- `npm test` — **87/87 green**
- `bash hooks/scripts/test/test-no-notification-trigger.sh` — green
- `bash hooks/scripts/test/test-recommender-integration.sh` — 9/9 green
- `bash hooks/scripts/test/test-v6.4.2-regression.sh` — 6/6 green

## Test plan
- [ ] CI green on `ubuntu-latest`
- [ ] CI green on `macos-latest`
- [ ] `bash --version` step shows `3.2.x` on macOS leg

🤖 Generated with [Claude Code](https://claude.com/claude-code)