### PR TITLE
[codex] restore deep-work skill entry alias

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "deep-work",
   "version": "6.7.1",
-  "description": "Evidence-Driven Development Protocol — 24 user-invocable skill-based entry surfaces (cross-platform: Claude Code slash + Codex / Copilot CLI / Gemini CLI / SDK), 3-layer architecture with Skill-based phase dispatch, computational enforcement (worktree guard + phase transition injection), TDD enforcement, and receipt validation",
+  "description": "Evidence-Driven Development Protocol — 24 command-equivalent skill surfaces plus a skill-native deep-work entry alias (cross-platform: Claude Code skills + Codex / Copilot CLI / Gemini CLI / SDK), 3-layer architecture with Skill-based phase dispatch, computational enforcement (worktree guard + phase transition injection), TDD enforcement, and receipt validation",
   "author": {
     "name": "sungmin"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -35,7 +35,7 @@
       "Write"
     ],
     "defaultPrompt": [
-      "$deep-work:deep-work-orchestrator \"build this feature\"",
+      "$deep-work:deep-work \"build this feature\"",
       "$deep-work:deep-status",
       "$deep-work:deep-finish"
     ],

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Current version: 6.7.1.
 
 - Codex manifest: `.codex-plugin/plugin.json`
 - Claude Code manifest: `.claude-plugin/plugin.json`
-- User-invocable skills: `skills/deep-*/SKILL.md`
+- User-invocable skills: `skills/*/SKILL.md`
 - Hooks: `hooks/hooks.json` and `hooks/scripts/`
 - Agents: `agents/`
 - Release history: `CHANGELOG.md` and `CHANGELOG.ko.md`

--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -25,11 +25,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 추가
+
+- **`skills/deep-work/SKILL.md`** — Claude, Codex 및 기타 skill 호출자가 내부 `deep-work-orchestrator` 이름을 알 필요 없이 `$deep-work:deep-work "task"`로 시작할 수 있도록 primary `deep-work` skill entry alias를 복구. alias는 모든 인자를 `deep-work-orchestrator`로 그대로 전달한다.
+- **`tests/skill-entry-alias.test.js`** — skill-only entrypoint 계약을 고정: `commands/deep-work.md` wrapper 없이 `deep-work` skill이 `$ARGUMENTS`를 보존해 `deep-work-orchestrator`로 위임해야 한다.
+
+### 변경
+
+- Codex plugin default prompt의 첫 진입점을 `$deep-work:deep-work "build this feature"`로 변경.
+- Manifest/package 설명에서 entry alias를 Codex-only가 아니라 Claude/Codex skill-native 표면으로 정리.
+
 ## [6.7.0] - 2026-05-18 (24 commands → user-invocable skills: cross-platform — suite-wide migration 완성)
 
-### Changed — 24 slash command 을 `user-invocable: true` skill 로 승격
+### Changed — 24 command-equivalent 표면을 `user-invocable: true` skill 로 승격
 
-- **Category A (7)**: `commands/` 의 얇은 `Skill()` 래퍼 삭제. 매칭 skill 본문에 `user-invocable: true` 한 줄 추가 (본문은 변경 없음). 대상: `deep-brainstorm`, `deep-research`, `deep-plan`, `deep-implement`, `deep-test`, `deep-integrate`, `deep-work-orchestrator`. 슬래시 진입이 wrapper command 를 거치지 않고 skill 본문으로 직접 흐른다 — orchestrator 의 5-phase dispatch 는 변경 없음.
+- **Category A (7)**: `commands/` 의 얇은 `Skill()` 래퍼 삭제. 매칭 skill 본문에 `user-invocable: true` 한 줄 추가 (본문은 변경 없음). 대상: `deep-brainstorm`, `deep-research`, `deep-plan`, `deep-implement`, `deep-test`, `deep-integrate`, `deep-work-orchestrator`. Skill invocation 이 wrapper command 를 거치지 않고 skill 본문으로 직접 흐른다 — orchestrator 의 5-phase dispatch 는 변경 없음.
 - **Category B (17)**: `skills/<verb>/SKILL.md` 신규 작성. `user-invocable: true` frontmatter + `## Invocation` / `## Inputs (skill args)` / `## Prerequisites` head sections 추가. 본문은 cross-reference path 재타깃팅만 적용하고 byte-단위 보존. 기존 `commands/<verb>.md` 삭제. 대상: `deep-assumptions`, `deep-cleanup`, `deep-debug`, `deep-finish` (660 lines — suite 단일 최대), `deep-fork`, `deep-history`, `deep-insight`, `deep-mutation-test`, `deep-phase-review`, `deep-receipt`, `deep-report`, `deep-resume`, `deep-sensor-scan`, `deep-slice`, `deep-status` (receipt/history/report/assumptions sub-page 의 hub), `drift-check`, `solid-review`.
 - **`commands/` 디렉토리 제거**. `package.json` `files` 필드에서 `commands/` 빠짐.
 - **deep-status hub sub-page 재타깃팅**: §6/§7/§8/§9 의 "Read the `/deep-X` command file and follow its logic inline" 문장이 "Read `skills/deep-X/SKILL.md` and follow its logic inline" 로 바뀜 — hub-spoke inline-dispatch 패턴 보존. 4 sub-skill (`deep-receipt` / `deep-history` / `deep-report` / `deep-assumptions`) 의 `참조처:` 라인도 `skills/deep-status/SKILL.md` §X 로 retargeting.
@@ -45,8 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Migration — 호출자별
 
-- **Claude Code 사용자**: zero-touch. 24개 슬래시 명령 모두 그대로 동작 (예: `/deep-work`, `/deep-status --history`, `/deep-finish --skip-integrate`) — `commands/*.md` 래퍼 대신 `user-invocable: true` skill 로 routing.
-- **Cross-platform 호출자**: 슬래시 대신 `Skill({ skill: "deep-work:<verb>", args: "..." })` 호출. 24 표면 모두 동일하게 응답. 예: `Skill({ skill: "deep-work:deep-finish", args: "--skip-integrate --handoff-to=deep-wiki" })`.
+- **Claude Code / cross-platform skill 호출자**: `Skill({ skill: "deep-work:<verb>", args: "..." })` 또는 host별 동등한 skill invocation 문법으로 호출. 24 표면 모두 동일하게 응답. 예: `Skill({ skill: "deep-work:deep-finish", args: "--skip-integrate --handoff-to=deep-wiki" })`.
 - **`$ARGUMENTS` 보존**: `$ARGUMENTS` 분기를 가진 본문 (특히 `deep-finish` 의 flag 다수, `deep-fork` 의 session-id + `--from-phase`, `deep-status` 의 flag matrix, `deep-insight` / `drift-check` / `solid-review` 의 target arg, `deep-assumptions` 의 subcommand) 은 byte-단위 보존됨 — `Skill()` 의 `args` 필드가 slash 호출과 동일하게 `$ARGUMENTS` 로 매핑됨.
 - **`phase-guard.sh` 손대지 않음** — Phase 5 enforcement 가 이미 `skills/deep-integrate/` 경로를 hardcode (v6.5 부터). Phase 5 dispatch 변경 없음.
 - **`BUG_REVIEW_REPORT.md` leave-as-is** — historical audit 산출물로 v6.5.x line 번호에 pin 되어 있음. historical accuracy 보호.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`skills/deep-work/SKILL.md`** — restored the primary `deep-work` skill entry alias so Claude, Codex, and other skill callers can invoke `$deep-work:deep-work "task"` instead of knowing the internal `deep-work-orchestrator` name. The alias forwards all arguments to `deep-work-orchestrator`.
+- **`tests/skill-entry-alias.test.js`** — pins the skill-only entrypoint contract: no `commands/deep-work.md` wrapper is required, and the `deep-work` skill delegates to `deep-work-orchestrator` with `$ARGUMENTS` preserved.
+
+### Changed
+
+- Codex plugin default prompt now uses `$deep-work:deep-work "build this feature"` as the first-run entrypoint.
+- Manifest/package descriptions now describe the entry alias as skill-native for Claude and Codex, not Codex-only.
+
 ## [6.7.1] — 2026-05-18 (Codex-native plugin manifest and AGENTS guide)
 
 ### Added
@@ -27,9 +37,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [6.7.0] - 2026-05-18 (24 commands → user-invocable skills: cross-platform — suite-wide migration completion)
 
-### Changed — 24 slash commands promoted to `user-invocable: true` skills
+### Changed — 24 command-equivalent surfaces promoted to `user-invocable: true` skills
 
-- **Category A (7)**: thin `Skill()` wrappers under `commands/` deleted; the matching skill bodies gain `user-invocable: true` in frontmatter (no body changes). Targets: `deep-brainstorm`, `deep-research`, `deep-plan`, `deep-implement`, `deep-test`, `deep-integrate`, `deep-work-orchestrator`. Slash entry now flows directly to the skill bodies instead of through a wrapper command — orchestrator's 5-phase dispatch unchanged.
+- **Category A (7)**: thin `Skill()` wrappers under `commands/` deleted; the matching skill bodies gain `user-invocable: true` in frontmatter (no body changes). Targets: `deep-brainstorm`, `deep-research`, `deep-plan`, `deep-implement`, `deep-test`, `deep-integrate`, `deep-work-orchestrator`. Skill invocation now flows directly to the skill bodies instead of through a wrapper command — orchestrator's 5-phase dispatch unchanged.
 - **Category B (17)**: new `skills/<verb>/SKILL.md` files created with `user-invocable: true` frontmatter + new `## Invocation` / `## Inputs (skill args)` / `## Prerequisites` head sections; bodies preserved byte-for-byte except internal cross-reference path retargeting. Old `commands/<verb>.md` files deleted. Targets: `deep-assumptions`, `deep-cleanup`, `deep-debug`, `deep-finish` (660 lines — single largest in the suite), `deep-fork`, `deep-history`, `deep-insight`, `deep-mutation-test`, `deep-phase-review`, `deep-receipt`, `deep-report`, `deep-resume`, `deep-sensor-scan`, `deep-slice`, `deep-status` (hub of receipt/history/report/assumptions sub-pages), `drift-check`, `solid-review`.
 - **`commands/` directory removed**. `package.json` `files` field updated to drop `commands/`.
 - **deep-status hub sub-page retargeting**: §6/§7/§8/§9 lines that previously read "Read the `/deep-X` command file and follow its logic inline" now read "Read `skills/deep-X/SKILL.md` and follow its logic inline" — preserving the inline-dispatch hub-spoke pattern. The 4 sub-skill files (`deep-receipt` / `deep-history` / `deep-report` / `deep-assumptions`) also have their `참조처:` lines retargeted to `skills/deep-status/SKILL.md` §X.
@@ -45,8 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Migration — for callers
 
-- **Claude Code users**: zero-touch. All 24 slash commands continue to work (e.g., `/deep-work`, `/deep-status --history`, `/deep-finish --skip-integrate`) — they now route through `user-invocable: true` skills instead of `commands/*.md` wrappers.
-- **Cross-platform callers**: invoke via `Skill({ skill: "deep-work:<verb>", args: "..." })` instead of slash. All 24 surfaces respond uniformly. Example: `Skill({ skill: "deep-work:deep-finish", args: "--skip-integrate --handoff-to=deep-wiki" })`.
+- **Claude Code / cross-platform skill callers**: invoke via `Skill({ skill: "deep-work:<verb>", args: "..." })` or the host's equivalent skill invocation syntax. All 24 surfaces respond uniformly. Example: `Skill({ skill: "deep-work:deep-finish", args: "--skip-integrate --handoff-to=deep-wiki" })`.
 - **`$ARGUMENTS` preservation**: bodies that branch on `$ARGUMENTS` (notably `deep-finish` flags, `deep-fork` session-id + `--from-phase`, `deep-status` flag matrix, `deep-insight` / `drift-check` / `solid-review` target args, `deep-assumptions` subcommands) are preserved byte-for-byte — `args` field of `Skill()` is mapped to `$ARGUMENTS` identically to slash invocation.
 - **`phase-guard.sh` untouched** — already hardcodes `skills/deep-integrate/` for Phase 5 enforcement (since v6.5). Phase 5 dispatch unchanged.
 - **`BUG_REVIEW_REPORT.md` left as-is** — historical audit artifact pinned to v6.5.x line numbers; preserving historical accuracy.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,6 @@ deep-work/
 ├── .claude-plugin/plugin.json
 ├── .codex-plugin/plugin.json    # plugin manifest
 ├── package.json                   # npm manifest (files field controls distribution scope)
-├── commands/                      # slash commands (thin wrappers + utilities)
 ├── agents/                        # Claude Code subagents
 │   └── session-recommender.md    # session-init recommendation sub-agent
 ├── hooks/
@@ -70,10 +69,11 @@ deep-work/
 │   └── scripts/
 │       ├── phase-guard.sh                    # entry point — dispatches to phase-guard-core
 │       ├── phase-guard-core.js               # denylist regex engine
-│       ├── wrap-receipt-envelope.js          # M3 envelope writer (called from agents + commands)
+│       ├── wrap-receipt-envelope.js          # M3 envelope writer (called from agents + skills)
 │       ├── verify-delegated-receipt.sh       # post-hoc receipt validation
 │       └── verify-receipt-core.js            # 8-item validation module
 ├── skills/
+│   ├── deep-work/                 # primary entry alias for Claude/Codex skill callers
 │   ├── deep-work-orchestrator/   # initialization + auto-flow
 │   ├── deep-brainstorm/          # Phase 0
 │   ├── deep-research/            # Phase 1
@@ -179,7 +179,7 @@ Any change to the `payload` shape requires a corresponding bump in `schemas/payl
 
 | Question | Answer |
 |---|---|
-| How do I add a new slash command? | New `.md` under `commands/` — auto-discovered |
+| How do I add a new user entrypoint? | New `user-invocable: true` skill under `skills/<name>/SKILL.md` |
 | How do I add a new skill? | New directory under `skills/<name>/` with `SKILL.md` + `references/` |
 | How do I add a new subagent? | New `agents/<name>.md` (frontmatter + prompt) |
 | How do I bypass `phase-guard`? | Set the matching `CLAUDE_ALLOW_<family>` env var (per-family override) — never disable globally |

--- a/README.ko.md
+++ b/README.ko.md
@@ -23,7 +23,7 @@ deep-work는 [deep-review](https://github.com/Sungmin-Cho/claude-deep-review)와
 
 ## Codex 호환성
 
-이번 릴리스는 `.codex-plugin/plugin.json` Codex 네이티브 플러그인 메타데이터와 `AGENTS.md` Codex 프로젝트 가이드를 포함합니다. Claude Code 매니페스트는 `.claude-plugin/plugin.json`에 그대로 유지되며, 기존 `claude-deep-suite` marketplace namespace를 유지해 기존 설치 키를 보존하면서 Codex는 suite의 `.agents/plugins/marketplace.json`을 읽습니다.
+이번 릴리스는 `.codex-plugin/plugin.json` Codex 네이티브 플러그인 메타데이터와 `AGENTS.md` Codex 프로젝트 가이드를 포함합니다. Claude Code 매니페스트는 `.claude-plugin/plugin.json`에 그대로 유지되며, Claude/Codex skill 호출자의 primary entrypoint는 `$deep-work:deep-work "task"`입니다. 기존 `claude-deep-suite` marketplace namespace를 유지해 기존 설치 키를 보존하면서 Codex는 suite의 `.agents/plugins/marketplace.json`을 읽습니다.
 
 ## v6.5.0 새 기능
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ deep-work also produces receipts and health reports consumed by [deep-review](ht
 
 ## Codex Compatibility
 
-This release includes native Codex plugin metadata in `.codex-plugin/plugin.json` and a Codex project guide in `AGENTS.md`. The Claude Code manifest remains in `.claude-plugin/plugin.json`, and the unchanged `claude-deep-suite` marketplace namespace lets existing installs keep their plugin keys while Codex reads the suite's `.agents/plugins/marketplace.json`.
+This release includes native Codex plugin metadata in `.codex-plugin/plugin.json` and a Codex project guide in `AGENTS.md`. The Claude Code manifest remains in `.claude-plugin/plugin.json`, and the primary skill-native entrypoint is `$deep-work:deep-work "task"` for Claude/Codex skill callers. The unchanged `claude-deep-suite` marketplace namespace lets existing installs keep their plugin keys while Codex reads the suite's `.agents/plugins/marketplace.json`.
 
 ## What's New in v6.5.0
 

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "@claude-deep-work/deep-work",
   "version": "6.7.1",
   "scripts": {
-    "test": "node --test tests/envelope-emit.test.js tests/envelope-chain.test.js tests/handoff-roundtrip.test.js tests/phase-guard-denylist.test.js tests/phase-guard-golden.test.js"
+    "test": "node --test tests/envelope-emit.test.js tests/envelope-chain.test.js tests/handoff-roundtrip.test.js tests/phase-guard-denylist.test.js tests/phase-guard-golden.test.js tests/skill-entry-alias.test.js"
   },
-  "description": "Deep Work plugin for Claude Code (cross-platform via 24 user-invocable skills) - Evidence-Driven Development Protocol with TDD enforcement, Health Engine (drift detection + fitness functions), worktree isolation, model auto-routing, receipt validation, 6-phase workflow with Phase 5 Integrate",
+  "description": "Deep Work plugin for Claude Code and Codex (cross-platform via 24 command-equivalent skills plus deep-work entry alias) - Evidence-Driven Development Protocol with TDD enforcement, Health Engine (drift detection + fitness functions), worktree isolation, model auto-routing, receipt validation, 6-phase workflow with Phase 5 Integrate",
   "author": "sungmin",
   "license": "MIT",
   "repository": {

--- a/skills/deep-work/SKILL.md
+++ b/skills/deep-work/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: deep-work
+description: "Use when the user invokes /deep-work \"task\", uses cross-platform Skill({ skill: \"deep-work:deep-work\", args: \"task\" }) or $deep-work:deep-work \"task\", asks to start a new deep-work session, or requests the primary Evidence-Driven Development auto-flow entry point. This is a compatibility alias for deep-work-orchestrator and preserves the historical /deep-work entry name."
+user-invocable: true
+---
+
+# Deep Work Entry Alias
+
+This skill preserves the historical `/deep-work <task>` entrypoint name for
+Codex and other skill-based callers.
+
+Forward the invocation to `deep-work-orchestrator` with the same `$ARGUMENTS`
+and follow that skill's instructions exactly:
+
+```text
+Skill("deep-work-orchestrator", args="$ARGUMENTS")
+```

--- a/tests/skill-entry-alias.test.js
+++ b/tests/skill-entry-alias.test.js
@@ -1,0 +1,17 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const test = require('node:test');
+
+const repoRoot = path.resolve(__dirname, '..');
+const skillPath = path.join(repoRoot, 'skills', 'deep-work', 'SKILL.md');
+const commandPath = path.join(repoRoot, 'commands', 'deep-work.md');
+
+test('deep-work skill alias is the primary skill-only entrypoint', () => {
+  assert.equal(fs.existsSync(commandPath), false, 'commands/deep-work.md should not be required');
+
+  const skill = fs.readFileSync(skillPath, 'utf8');
+  assert.match(skill, /^name: deep-work$/m);
+  assert.match(skill, /^user-invocable: true$/m);
+  assert.match(skill, /Skill\("deep-work-orchestrator", args="\$ARGUMENTS"\)/);
+});


### PR DESCRIPTION
## Summary
- Restore a skill-native `$deep-work:deep-work` entry alias that delegates to `deep-work-orchestrator` with `$ARGUMENTS` preserved.
- Update Claude/Codex manifests and docs so the primary entrypoint is not Codex-only.
- Add a regression test proving `commands/deep-work.md` is not required for the skill-only entrypoint.

## Test Plan
- `node -e "for (const f of ['.codex-plugin/plugin.json','.claude-plugin/plugin.json','package.json']) JSON.parse(require('fs').readFileSync(f,'utf8')); console.log('json ok')"`
- `git diff --check HEAD~1..HEAD`
- `npm test`
