### PR TITLE
docs: concise CHANGELOG, evergreen README, add CONTRIBUTING/SECURITY

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,9 @@
 Evidence-Driven Development Protocol for structured agent work. The plugin
 remains Claude Code compatible while also exposing native Codex plugin metadata.
 
-Current version: 6.7.1.
+To check the current version: `jq -r .version .claude-plugin/plugin.json`
+
+> 📄 **Docs maintenance**: this repo's documentation follows `docs/DOCS_RULE.md` (local maintainer guide — single-source-of-truth rules for README / CHANGELOG / this file).
 
 ## Runtime Surfaces
 

--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -2,1159 +2,642 @@
 
 # Changelog
 
-All notable changes to the Deep Work plugin will be documented in this file.
+Deep Work 플러그인의 모든 주요 변경 사항을 이 파일에 기록합니다.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+형식은 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)를 따르며,
+이 프로젝트는 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)을 준수합니다.
 
 ## [Unreleased]
 
 ## [6.9.0] — 2026-05-21 (deep-memory v0.1.0 consumer 통합 — Phase 1 recall + Phase 5 harvest 추천)
 
-### 추가
+### Added
 
-- **`skills/deep-research/SKILL.md` — Deep-Memory Brief Context 서브섹션** (Cross-Plugin Context 블록, Harnessability + Evolve Insights와 동급). `.deep-memory/latest-brief.md` 가 프로젝트 루트에 존재하면 brief 를 **verbatim** 으로 `research.md` 의 새 `## Cross-project Memory` 섹션에 인용 (heading hierarchy +2 shift 로 deep-memory render 보존). 부재 시 research artifact 는 deep-memory-agnostic 유지 — runtime context 에만 한 줄 안내 emit, **`research.md` 에는 아무것도 쓰지 않음** (privacy invariant). `/deep-memory-brief` 는 **자동 호출 금지** — recall 은 사용자 주도. Provenance 토큰 (`mem-<ULID>`, Crockford-base32 uppercase, I/L/O/U 제외) 을 새 `cross_project_memory.cited_memory_ids[]` state 필드로 추출.
-- **`skills/deep-integrate/SKILL.md` — `/deep-memory-harvest` 추천** Phase 5 LLM 프롬프트 규칙 (§3-2) 과 결정적 B-fallback 리스트 (§3-4) 에 추가. Gate 조건: `deep-memory ∈ plugins.installed`, `session.changes.files_changed > 0`, `loop.already_executed` 에 `deep-memory` 부재. Installation suggestion 경로는 다른 형제 플러그인 관례를 그대로 따름.
-- **`skills/deep-integrate/detect-plugins.sh`** — `TARGETS` enumeration 에 `deep-memory` 추가. Phase 5 harvest gate 의 `plugins.installed`/`plugins.missing` 신호가 deep-memory 존재를 올바르게 보고하도록. `detect-plugins.test.js` 의 regression test 가 present→installed[] / absent→missing[] 을 검증.
-- **`docs/deep-memory-integration-handoff.md`** — 본 PR 의 spec-of-record (`docs/` 는 평상시 gitignored 라 force-add). deep-memory spec §14.2 의 6 가지 consumer item 중 5 개 landed, item 5 (`/deep-memory feedback`) 은 `cited_memory_ids[]` forward-compat 필드를 남긴 채 Phase 4+ joint PR 로 deferred.
-- **`tests/deep-memory-integration.test.js`** — 12 개의 fixture-based contract 테스트. 모든 문서화된 invariant 를 pin: spec doc 구조, SKILL 섹션 wording, state-field schema, harvest gate 언어, ULID provenance 정규식 (character-class + length + Crockford-uppercase 분리 검증 포함), absent-brief privacy 경계, stale-warning wording, heading-shift +2 rule, 0-byte brief, non-empty no-ULID brief, 그리고 pre-fix wording 이 SKILL 에 silently 재진입하지 못하도록 방어하는 `assert.doesNotMatch(/또는 부재 안내/)`.
+- Phase 1 Research recall: `.deep-memory/latest-brief.md`가 존재하면 brief를 `research.md`의 새 `## Cross-project Memory` 섹션에 verbatim으로 인용하고, 부재 시에는 아무것도 쓰지 않습니다(privacy invariant). `/deep-memory-brief`는 절대 자동 호출하지 않습니다. 인용된 memory ID(`mem-<ULID>`)는 `cross_project_memory.cited_memory_ids[]` state 필드로 캡처됩니다.
+- Phase 5 Integrate는 `deep-memory`가 설치되어 있고 세션이 파일을 변경했을 때 `/deep-memory-harvest`를 추천합니다. `skills/deep-integrate/detect-plugins.sh`가 `plugins.installed`/`plugins.missing`에 deep-memory를 enumerate합니다.
+- `docs/deep-memory-integration-handoff.md`가 보류된 `/deep-memory feedback` hook을 향후 joint PR용으로 기록합니다.
+- `tests/deep-memory-integration.test.js`가 문서화된 invariant(privacy 경계, ULID 정규식, heading-shift rule, edge case)를 고정합니다.
 
-### 변경
+### Changed
 
-- **Research artifact schema** — additive `cross_project_memory` 블록 (`brief_path`, `brief_mtime`, `brief_stale`, `cited_memory_ids[]`) 을 research state frontmatter 에 기록. 4 개 필드 모두 brief 부재 시 `null` / `[]` 기본값 — deep-memory 를 설치하지 않은 프로젝트에 forward-compat.
-- **`.gitignore`** — `.deep-memory/` 를 프로젝트 루트에서 ignore (deep-memory 는 `~/.deep-memory/` 하위에 자체 persistence 관리; 프로젝트별 brief 는 on-demand regenerate).
-- Version 6.8.0 → 6.9.0 — package 및 plugin manifest 전체 동기화 (minor 릴리스).
-
-### 검증
-
-- `npm test`: 850 / 850 pass (137 suites) — baseline 837 + 13 신규 (5 graceful/cited + 1 detect-plugins regression + 3 stale/heading/empty + 1 R1-Y1 length-isolated + 1 R1-Y2 contract + 1 R2-N1 negative + 1 R2-N2 non-empty).
-- 3 라운드 `/deep-review-loop` 수렴: 라운드 1 REQUEST_CHANGES (🔴 1 / 🟡 3 / ℹ️ 2) → 라운드 2 CONCERN (🟡 1 / ℹ️ 2) → 라운드 3 APPROVE (§3.A.1 자연 수렴). 7 개 actionable finding 모두 ACCEPT + 6 Respond commit 으로 수정; 1 개 info DEFER (R2-N3 — `.git` worktree-as-file wording, defensible as-is).
-- 리포트는 `.deep-review/reports/` 와 `.deep-review/responses/` 에 보관 (gitignored; author-local).
+- Research artifact 스키마에 additive `cross_project_memory` 블록 추가 — brief 부재 시 null/empty로 기본 설정(forward-compatible).
 
 ## [6.8.0] — 2026-05-19 (Plan-quality contract 강제 + CI 견고화 + receipt-tracker 안정성)
 
-### 추가
+### Changed
 
-- **`tests/plan-quality-contract.test.js`** — 실행 가능한 `deep-plan` slice contract를 고정하고 planning/implementation reference에 legacy `Task N:` 행이 돌아오는 것을 차단. 또한 (신규 4번째 블록) `skills/shared/references/review-gate.md`를 v6.7 필수 슬라이스 계약에 고정하여 review gate가 contract와 silently 이탈하지 못하도록 함.
-- **`tests/ci-workflow-contract.test.js`** — GitHub Actions advisory `shellcheck` 스텝의 모양 (이름, `continue-on-error: true`, 대상, 심각도, `npm test` 이후 순서, 바이너리 누락 graceful skip)을 고정.
-- **`hooks/scripts/file-tracker-lock-timeout.test.js`** — receipt-tracker stale-lock recovery contract에 대한 end-to-end 회귀 테스트: Phase 1 (lock 점유 시) canonical receipt + pending sidecar 상태 검증; Phase 2 (lock 해제 후 두 번째 호출) drain된 파일과 새 파일 모두 canonical `changes.files_modified`에 반영되는지 검증.
-
-### 변경
-
-- **Plan slice format (v6.7 executable steps)** — S/M/L slice 모두 `steps` 필드를 필수화 (`S: 2-4`, `M: 3-7`, `L: 5-12`)하고, 모든 code-changing step에 exact file path와 code sketch 또는 function signature 수준의 구현 세부를 요구.
-- **Planning references and templates** — `planning-guide.md`, `implementation-guide.md`, `plan-templates.md`, `plan-template-existing.md`, `plan-template-zerobase.md`가 `depends_on`, `code_sketch`, `failing_test`, `verification_cmd`, `expected_output`을 포함한 `SLICE-NNN` slice checklist 형식으로 정리됨.
-- **Completeness Policy** — `Write tests for the above`, `failing_test` red signal 누락, exact `expected_output` fragment 누락을 금지 패턴에 추가.
-- **Contract validation scope** — stale M/L/XL 문구를 모든 S/M/L slice 대상으로 갱신.
-- **Plan review-gate를 v6.7 필수 슬라이스 계약과 정렬** — `skills/shared/references/review-gate.md`가 더 이상 `expected_output`을 "권장"으로 표시하지 않으며, `steps`/`expected_output` 누락을 `testability`/`buildability`/`code_completeness` 평가에서 면제하던 v5.8 하위 호환 fallback도 제거. 모든 비-인라인 S/M/L slice에 대해 5개 필수 필드 (`failing_test`, `verification_cmd`, `expected_output`, `code_sketch`, `steps`)를 요구하도록 문구 수정 — 인라인 plan 및 legacy/resume 입력은 좁게 한정된 예외.
-- **Advisory shellcheck CI 스텝** — `hooks/scripts/**/*.sh`에 대해 `shellcheck --severity=warning --external-sources` 실행, non-blocking (`continue-on-error: true`). 게이트 변경 없음.
-- **`npm test` 발견 범위를 6개 명시적 subtree 글로브로 확장** — 기존 6파일 명시 형식을 `node --test --test-concurrency=1 hooks/**/*.test.js tests/**/*.test.js skills/**/*.test.js sensors/**/*.test.js templates/**/*.test.js scripts/**/*.test.js` 로 교체. 느린 CI 러너에서 timing-sensitive 테스트가 안정되도록 직렬 실행. 글로브 지원을 위해 CI Node 버전을 20에서 22 (LTS)로 bump (`--test` positional args의 glob 지원은 Node 21.0.0에서 도입되었고 20.x로 back-port된 적이 없음). `health/**/*.test.js`는 별도 `npm run test:health` 스크립트로 분리 — 단독 실행 시 64/64 통과하나 GitHub-hosted 러너에서 다른 suite와 interleave될 때 `health/health-check.test.js:236` ("overall timeout enforcement") 의 사전 존재하는 event-loop leak이 노출됨; 본 leak은 follow-up으로 추적. 발견되는 테스트들은 여전히 POSIX-only (`bash` 직접 호출 + `/tmp` hardcode)이므로 Windows 실행을 활성화하는 것은 아님; ubuntu+macos CI 매트릭스에서 대부분의 suite가 안정적으로 실행되도록 함이 목적.
-- **Receipt-tracker lock-timeout 견고화** — `hooks/scripts/file-tracker.sh`의 pre-lock 무조건 receipt 초기화 블록 복원 + `O_CREAT | O_EXCL` (`fs.writeFileSync` `flag: 'wx'`) 적용으로 동시 writer race 안전 보장. in-lock update가 stale lock에 의해 타임아웃되어도 single-write slice가 canonical `SLICE-NNN.json`을 유지. pending-changes sidecar는 `file-tracker.sh`의 다음 lock-acquire 성공에서 drain됨 (session-end은 현재 pending-changes를 sweep하지 않음 — 향후 개선 과제).
-- 6.7.1 → 6.8.0으로 package 및 plugin manifest 버전을 minor release로 bump.
-
-### 검증
-
-- `npm test`: 901 / 901 pass (150 suites). 3개 contract suite가 신규 표면을 고정 (`plan-quality-contract`, `ci-workflow-contract`, `file-tracker-lock-timeout`).
-- 3-way deep-review (Claude Opus + Codex review + Codex adversarial)가 3개 라운드 반복 실행됨; round-3 fix commit이 모든 round-2 발견을 해소했고 round 3이 round-3 fix 범위에 대해 APPROVE로 수렴; O1 alignment commit이 round 3에서 제기된 범위 외 발견 1건을 해소.
+- 모든 비-인라인 S/M/L slice는 `failing_test`, `verification_cmd`, `expected_output`, `code_sketch`, `steps`를 선언해야 합니다. Plan review gate가 이 contract와 정렬됨(누락 필드에 대한 "권장" 헷지나 하위 호환 fallback 없음).
+- Planning 참조와 템플릿을 `SLICE-NNN` 체크리스트(`depends_on`, `code_sketch`, `failing_test`, `verification_cmd`, `expected_output`)로 전환. `steps`는 필수(S: 2-4, M: 3-7, L: 5-12)이며 정확한 파일 경로 포함.
+- Completeness Policy를 확장하여 모호한 지시, 누락된 red signal, 누락된 정확한 `expected_output` 조각을 거부.
+- non-blocking `shellcheck` advisory 스텝이 `hooks/scripts/**/*.sh`를 lint; 재귀 `node --test` 글로브 발견을 위해 CI Node 20 → 22 (LTS) bump.
+- Receipt-tracker 견고화: pre-lock receipt 초기화를 `O_CREAT | O_EXCL`로 복원하여 in-lock update가 타임아웃되어도 single-write slice가 canonical `SLICE-NNN.json`을 유지; pending changes는 다음 lock acquire 시 drain.
 
 ## [6.7.1] — 2026-05-18 (Codex-native plugin manifest and AGENTS guide)
 
-### 추가
+### Added
 
-- **`.codex-plugin/plugin.json`** — Claude Code manifest 와 동일한 skill/hook 표면을 가리키는 Codex 네이티브 플러그인 manifest. 기존 `claude-deep-*` repository identity 는 유지.
-- **`AGENTS.md`** — Codex 프로젝트 가이드. runtime surface, 검증 명령, downstream suite marketplace 갱신 요구사항을 명시.
-- **`skills/deep-work/SKILL.md`** — Claude, Codex 및 기타 skill 호출자가 내부 `deep-work-orchestrator` 이름을 알 필요 없이 `$deep-work:deep-work "task"`로 시작할 수 있도록 primary `deep-work` skill entry alias를 복구. alias는 모든 인자를 `deep-work-orchestrator`로 그대로 전달한다.
-- **`tests/skill-entry-alias.test.js`** — skill-only entrypoint 계약을 고정: `commands/deep-work.md` wrapper 없이 `deep-work` skill이 `$ARGUMENTS`를 보존해 `deep-work-orchestrator`로 위임해야 한다.
-
-### 변경
-
-- patch release 로 package/plugin manifest 버전을 6.7.0 → 6.7.1 로 동기화.
-- README 문서에 기존 Claude Code 표면과 함께 Codex 호환성을 명시.
-- Codex plugin default prompt의 첫 진입점을 `$deep-work:deep-work "build this feature"`로 변경.
-- Manifest/package 설명에서 entry alias를 Codex-only가 아니라 Claude/Codex skill-native 표면으로 정리.
-
-### 검증
-
-- 릴리스 전 repository 검증을 실행. 정확한 명령 출력은 PR 체크리스트 참조.
-
-## [6.7.0] - 2026-05-18 (24 commands → user-invocable skills: cross-platform — suite-wide migration 완성)
-
-### Changed — 24 command-equivalent 표면을 `user-invocable: true` skill 로 승격
-
-- **Category A (7)**: `commands/` 의 얇은 `Skill()` 래퍼 삭제. 매칭 skill 본문에 `user-invocable: true` 한 줄 추가 (본문은 변경 없음). 대상: `deep-brainstorm`, `deep-research`, `deep-plan`, `deep-implement`, `deep-test`, `deep-integrate`, `deep-work-orchestrator`. Skill invocation 이 wrapper command 를 거치지 않고 skill 본문으로 직접 흐른다 — orchestrator 의 5-phase dispatch 는 변경 없음.
-- **Category B (17)**: `skills/<verb>/SKILL.md` 신규 작성. `user-invocable: true` frontmatter + `## Invocation` / `## Inputs (skill args)` / `## Prerequisites` head sections 추가. 본문은 cross-reference path 재타깃팅만 적용하고 byte-단위 보존. 기존 `commands/<verb>.md` 삭제. 대상: `deep-assumptions`, `deep-cleanup`, `deep-debug`, `deep-finish` (660 lines — suite 단일 최대), `deep-fork`, `deep-history`, `deep-insight`, `deep-mutation-test`, `deep-phase-review`, `deep-receipt`, `deep-report`, `deep-resume`, `deep-sensor-scan`, `deep-slice`, `deep-status` (receipt/history/report/assumptions sub-page 의 hub), `drift-check`, `solid-review`.
-- **`commands/` 디렉토리 제거**. `package.json` `files` 필드에서 `commands/` 빠짐.
-- **deep-status hub sub-page 재타깃팅**: §6/§7/§8/§9 의 "Read the `/deep-X` command file and follow its logic inline" 문장이 "Read `skills/deep-X/SKILL.md` and follow its logic inline" 로 바뀜 — hub-spoke inline-dispatch 패턴 보존. 4 sub-skill (`deep-receipt` / `deep-history` / `deep-report` / `deep-assumptions`) 의 `참조처:` 라인도 `skills/deep-status/SKILL.md` §X 로 retargeting.
-- **CLAUDE.md:133** 재타깃팅: `commands/deep-finish.md §7-Z` → `skills/deep-finish/SKILL.md §7-Z` (`wrap-receipt-envelope.js` 의 caller naming).
-- **`hooks/scripts/wrap-receipt-envelope.js`** JSDoc 갱신: caller naming `deep-finish.md, agents/implement-slice-worker.md` → `skills/deep-finish/SKILL.md §7-Z, agents/implement-slice-worker.md`.
-- **`skills/deep-work-orchestrator/SKILL.md`** 내부 참조 retargeting: `Read \`/deep-finish\`` → `Read \`skills/deep-finish/SKILL.md\``; `\`deep-resume.md\`가 사용` → `\`skills/deep-resume/SKILL.md\`가 사용`. orchestrator 의 `Skill("deep-X", args=...)` dispatch 는 `user-invocable: true` 등록 덕분에 skill 본문으로 정상 resolve.
-
-### Rationale — cross-platform parity 가 suite-wide migration 을 완성
-
-- 슬래시 커맨드는 Claude Code 전용; user-invocable skill 은 **Codex / Copilot CLI / Gemini CLI / Agent SDK** 에서 `Skill({ skill: "deep-work:<verb>", args: "..." })` 형태로 동작.
-- 본 PR 은 suite-wide command→skill 마이그레이션의 **4번째이자 최종** installment: deep-docs v1.3.0 (pilot, 1 command) → deep-evolve v3.4.0 (2nd, 1 command + `$ARGUMENTS`) → deep-wiki v1.6.0 (3rd, 5 commands) → **deep-work v6.7.0 (4th, 24 commands)**. 4개 installment 모두 동일한 mechanical 패턴 사용 — frontmatter `user-invocable: true`, `## Invocation` + `## Inputs (skill args)` + `## Prerequisites` head sections, body byte-보존, cross-ref sed retargeting — 3개 선행 PR 에서 검증됨.
-- 24개 atomic 전환 (부분 전환 아님) 이 필요한 이유: `deep-status` 가 4 sub-skill 을 inline body Read 로 dispatch 하는 hub 이므로 부분 전환 시 hub-spoke graph 가 깨짐. 24개 중 절반 (Category A, 7) 은 1-line frontmatter 변경 + wrapper 삭제이므로 실제 신규 skill 저작 분량은 17개.
-
-### Migration — 호출자별
-
-- **Claude Code / cross-platform skill 호출자**: `Skill({ skill: "deep-work:<verb>", args: "..." })` 또는 host별 동등한 skill invocation 문법으로 호출. 24 표면 모두 동일하게 응답. 예: `Skill({ skill: "deep-work:deep-finish", args: "--skip-integrate --handoff-to=deep-wiki" })`.
-- **`$ARGUMENTS` 보존**: `$ARGUMENTS` 분기를 가진 본문 (특히 `deep-finish` 의 flag 다수, `deep-fork` 의 session-id + `--from-phase`, `deep-status` 의 flag matrix, `deep-insight` / `drift-check` / `solid-review` 의 target arg, `deep-assumptions` 의 subcommand) 은 byte-단위 보존됨 — `Skill()` 의 `args` 필드가 slash 호출과 동일하게 `$ARGUMENTS` 로 매핑됨.
-- **`phase-guard.sh` 손대지 않음** — Phase 5 enforcement 가 이미 `skills/deep-integrate/` 경로를 hardcode (v6.5 부터). Phase 5 dispatch 변경 없음.
-- **`BUG_REVIEW_REPORT.md` leave-as-is** — historical audit 산출물로 v6.5.x line 번호에 pin 되어 있음. historical accuracy 보호.
-
-### Tests
-
-- 기존 177개 `node:test` assertion 모두 PASS 유지: `envelope-emit`, `envelope-chain`, `handoff-roundtrip`, `phase-guard-denylist`, `phase-guard-golden`. 5개 test 파일 중 어느 것도 `commands/*` 경로를 참조하지 않음 (변환 전 검증). 테스트 변경 불필요.
-- 전체 plugin (CHANGELOG / BUG_REVIEW_REPORT / docs/ / node_modules / .git 제외) 에서 `grep -rn 'commands/deep-\|commands/drift\|commands/solid'` 결과 **0 hits** — 변환 완료 후.
-
-## [6.6.3] - 2026-05-12
-
-### Added — M5.5 #3 hook golden test + M5.5.X (§9) phase-guard 강화 롤업
-
-- **`tests/phase-guard-golden.test.js`** — fixture 기반 golden test (M5.5 #3). `tests/fixtures/golden/<name>.input.json` + `<name>.expected.json` 페어를 로드하여 `phase-guard.sh` 의 exit code + decision + reason 정규식을 검증한다. 초기 corpus 8개: idle allow, implement slice scope (in/out), 4개 non-implement denylist family (rm-rf / npm-publish / curl-pipe-shell / sql-destructive), override pass-through. 한쪽만 커밋된 fixture(`.input` 또는 `.expected` 누락) 는 로더에서 즉시 throw.
-- **`hooks/scripts/test-helpers/run-phase-guard.js`** — 공유 `scrubHostEnv()` + `runPhaseGuard()` + `parseGuardOutput()` 헬퍼 (§9.2 W-R2.2). `tests/phase-guard-denylist.test.js` 에 인라인으로 들어있던 host-env scrub (`DEEP_WORK_SESSION_ID` / `DEEP_WORK_ROOT` / `CLAUDE_PROJECT_DIR`) 을 한 곳으로 모아, 형제 hook 테스트가 호스트-env 격리를 무료로 상속받도록 한다.
-- **`tests/phase-guard-denylist.test.js` §9.3 추가** — 7건의 신규 단언:
-  - `NON_IMPLEMENT_DANGEROUS` 코퍼스가 `phase-guard-core.js` `DANGEROUS_NON_IMPLEMENT_PATTERNS` 의 모든 `family:` 를 커버한다는 pre-flight 단언.
-  - per-family override 루프 (5 family × research phase) — 모든 `CLAUDE_ALLOW_<FAMILY>=1` 환경변수를 end-to-end 로 검증, override field 의 오타를 CI 에서 잡는다.
-  - Override fall-through 합성 테스트 (`CLAUDE_ALLOW_RM_RF=1 + 'rm -rf foo && cp x.txt /etc/host.conf'`) — override env 는 denylist 만 억제하고 file-write 게이트는 그대로 적용된다는 계약을 핀.
+- `.codex-plugin/plugin.json` — Claude Code manifest와 같은 skill·hook 표면을 가리키는 Codex-native manifest.
+- `AGENTS.md` — runtime surface, 검증, downstream suite marketplace 업데이트를 다루는 Codex 프로젝트 가이드.
+- 내부 orchestrator 이름을 몰라도 `$deep-work:deep-work "task"`로 호출할 수 있도록 primary `deep-work` skill alias 복구.
 
 ### Changed
 
-- **`hooks/scripts/phase-guard-core.js`** — §9.1 비-implement 분기 진입부의 코멘트 블록 확장: (a) 게이트 순서, (b) load-bearing ordering 근거, (c) override-env 의미 (denylist 만 억제, file-write 그대로), (d) `phase-guard.sh` Phase 5 의 cross-coverage.
-- **`hooks/scripts/phase-guard-core.js`** — §9.3 I-R3.1 `DANGEROUS_NON_IMPLEMENT_PATTERNS` docblock 에 의도된 scope 누락(`DELETE FROM`, `DROP DATABASE`, 대체 shell 파이프, `yarn publish`, 디스크 레벨 명령) 명시.
-- **`hooks/scripts/{phase-guard-hardening,phase5-guard,worktree-guard,multi-session,input-parsing-e2e}.test.js`** — §9.2 마이그레이션: 인라인 `{ ...process.env, ... }` 스프레드를 공유 헬퍼의 `scrubHostEnv()` 로 교체.
+- Manifest/package description이 entry alias를 Claude와 Codex 모두에 대한 skill-native로 기술; README가 Codex 호환성을 명시.
 
-### Notes
-
-- 본 PR 은 `claude-deep-suite/docs/superpowers/plans/2026-05-12-m5.5-remaining-tests-handoff.md` §9 "Suggested rollup PR" 에 명시된 M5.5 #3 (deep-work 측) + M5.5.X (§9.1 + §9.2 + §9.3) 롤업이다. deep-evolve / deep-wiki 의 M5.5 #3 과 deep-review / deep-wiki / deep-evolve 의 #5 는 별도 PR.
-- 테스트 수: **162 → 177** (+15: golden 8 + §9.3 7). npm test 런타임 ~29s on macOS bash 3.2.
-
-## [6.6.2] - 2026-05-12
-
-### Added — M5.5 #7 non-implement dangerous-command denylist (PR #28, 3 리뷰 라운드)
-
-- **`tests/phase-guard-denylist.test.js`** — Phase 5 read-mostly allowlist (7 spec family) + non-implement denylist (5 family × 4 phase + 컨트롤 + 회귀 가드) 를 검증하는 162-단언 phase-guard 계약 테스트.
-- **`hooks/scripts/phase-guard-core.js`** — `DANGEROUS_NON_IMPLEMENT_PATTERNS` (5 family: rm-rf, npm-publish, kubectl-destructive, sql-destructive, curl-pipe-shell) + `matchDangerousNonImplement()` + research/plan/test/brainstorm Bash 진입부의 denylist 게이트. 각 family 는 `CLAUDE_ALLOW_<FAMILY>=1` 환경변수 override 를 가진다.
-- **R3 regex 수정**: W-R3.1 (SQL TRUNCATE 단일 문자 버그) + W-R3.2 (kubectl `--all-namespaces` false-positive).
-
-## [6.6.1] - 2026-05-12
-
-### Added — M5.5 #4 cross-platform CI matrix (PR #27)
-
-- **`.github/workflows/tests.yml`** — `os: [ubuntu-latest, macos-latest]` × `node-version: '20'` 매트릭스로 `npm test` + 3 개 bash 회귀 스크립트 실행.
-- **`hooks/scripts/test/test-v6.4.2-regression.sh` §2** — cross-platform `stat` fallback (`stat -c '%a' || stat -f '%A'`). 새 ubuntu 레그가 첫 실행에서 BSD/GNU 차이를 즉시 검출.
-
-## [6.6.0] - 2026-05-12
-
-### Added — M5.7.A 플러그인측 cross-plugin handoff + dashboard compaction telemetry 채택
-
-- **`hooks/scripts/emit-handoff.js`** — handoff payload를 M3 envelope으로 wrap하여 (`artifact_kind = "handoff"`, `schema.name = "handoff"`, `schema.version = "1.0"`) `.deep-work/handoffs/` 또는 세션별 디렉토리에 기록하는 CLI 헬퍼. 플래그: `--payload-file`, `--output`, `--source-session-receipt` (자동 `parent_run_id` chain), `--source-review-report`, `--parent-run-id`, `--session-id`. write 전 payload required 필드 enforce: `schema_version`, `handoff_kind`, `from{producer,completed_at}`, `to{producer,intent}`, `summary`, `next_action_brief` — `claude-deep-suite/schemas/handoff.schema.json` + dashboard `PAYLOAD_REQUIRED_FIELDS["deep-work/handoff"]`와 일치.
-- **`hooks/scripts/emit-compaction-state.js`** — compaction-state payload를 M3 envelope으로 wrap하는 CLI 헬퍼 (`artifact_kind = "compaction-state"`, `schema.name = "compaction-state"`). 두 입력 모드: hook-driven용 CLI 플래그 (`--trigger`, `--preserved`, `--discarded`, `--strategy`, `--pre-tokens`, `--post-tokens`) 또는 skill 합성용 `--payload-file`. Trigger enum을 suite schema 기준으로 검증 (`phase-transition`, `slice-green`, `loop-epoch-end`, `window-threshold`, `manual`, `session-stop`). Strategy enum 검증. Dashboard 메트릭 `suite.compaction.frequency` + `suite.compaction.preserved_artifact_ratio`를 구동.
-- **`commands/deep-finish.md` §7-Z-A** — envelope wrap 후 새 섹션이 `--handoff-to=<plugin>` 지정 시 (또는 사용자가 인터랙티브로 opt-in 시) cross-plugin handoff를 emit. session-receipt envelope에 `parent_run_id`를 자동 chain. dashboard flat-dir `SOURCE_SPECS`에 맞게 `.deep-work/handoffs/<UTC-ts>-<session_id>.json`로 기록.
-- **`hooks/scripts/session-end.sh`** Stop hook — 세션 종료 시 best-effort로 `compaction-state.json` emit (`trigger: session-stop`, session-receipt 존재 시 `strategy: receipt-only`, 부재 시 state file 보존). Stop hook의 "must not block session close" 계약 유지를 위해 subshell + `|| true`로 wrap.
-- **`hooks/scripts/phase-transition.sh`** PostToolUse hook — 각 Phase 경계마다 `compaction-state.json` emit (`trigger: phase-transition`, `strategy: key-artifacts-only`). Phase별 preserved 셋: research→research.md, plan→research+plan, implement→plan, test→plan+receipts, idle→session-receipt.
-- **`tests/handoff-roundtrip.test.js`** — M5.5 #8 (deep-work 절반)을 다루는 16개 assertion: dashboard와 동일한 payload-required-field 계약, mirror된 `unwrapStrict`를 만족하는 envelope을 emit하는 CLI roundtrip, cross-plugin chain (`parent_run_id === session-receipt.envelope.run_id`), trigger enum 6개 값 전체 커버리지, 실패 경로 (필수 필드 누락 → exit 1, unknown trigger → exit 1).
+## [6.7.0] — 2026-05-18 (24 commands → user-invocable skills: cross-platform)
 
 ### Changed
 
-- **`hooks/scripts/envelope.js`** — `ALLOWED_ARTIFACT_KINDS`를 `{session-receipt, slice-receipt}`에서 `handoff`와 `compaction-state` 포함으로 확장. set은 `wrapEnvelope` (출력 가드)와 `unwrapEnvelope` (입력 가드) 양쪽에서 사용; session-receipt / slice-receipt 호출자의 기존 identity-triplet 의미론은 그대로 유지.
-- **`scripts/validate-envelope-emit.js`** — `ALLOWED_KINDS`를 대칭 확장하여 CI validator가 두 신규 envelope kind를 수락. Payload `schema_version === "1.0"` enforcement는 그대로 유지.
+- 24개 command-equivalent 표면이 모두 `skills/` 아래 `user-invocable: true` skill로 전환; `commands/` 디렉토리 제거 및 `package.json` `files`에서 제외.
+- Skill 호출이 skill body로 직접 흐름(`Skill({ skill: "deep-work:<verb>", args: "..." })`) — Claude Code뿐 아니라 Codex / Copilot CLI / Gemini CLI / Agent SDK에서도 동작; orchestrator의 5-phase dispatch는 불변.
+- `$ARGUMENTS`로 분기하는 body(`deep-finish` 플래그, `deep-fork`, `deep-status` 플래그 매트릭스 등)는 byte-for-byte 보존.
 
-### Notes
-
-- 이 릴리스는 신규 artifact kind에 대해 **producer-only**. deep-work는 다른 플러그인의 `handoff.json` 또는 `compaction-state.json`을 consume 하지 않으며 — dashboard가 한다. Cross-plugin contract는 `claude-deep-dashboard/lib/suite-collector.js unwrapStrict`가 enforce.
-- M5 acceptance criteria는 `claude-deep-suite/docs/superpowers/plans/2026-05-11-m5.7-plugin-adoption-handoff.md` §M5.7.A 참조.
-
-## [6.5.0] - 2026-05-07
+## [6.6.3] — 2026-05-12
 
 ### Added
-- **M3 cross-plugin envelope 채택** — `session-receipt.json` 와 `receipts/SLICE-*.json` 양쪽 (claude-deep-suite Phase 2 priority #3; cf. `claude-deep-suite/docs/envelope-migration.md` §1). 두 artifact 모두 `{ schema_version: "1.0", envelope: { producer, producer_version, artifact_kind, run_id, generated_at, schema, git, provenance, [parent_run_id], [session_id] }, payload: { ... legacy receipt body ... } }` 형식으로 emit.
-- **`hooks/scripts/envelope.js`** — 공유 zero-dep envelope 라이브러리: MSB-first ULID 생성기 (Crockford Base32, 26-char), `detectGit()` head/branch/dirty 감지 + safe `0000000` fallback, `loadProducerVersion()` 모듈 path 기준 resolve (handoff §4 literal-cwd-resolve), `wrapEnvelope()` builder, `unwrapEnvelope()` reader 와 full identity guard (producer / artifact_kind / schema.name) + corrupt-payload defense.
-- **`hooks/scripts/wrap-receipt-envelope.js`** — markdown agent prompt (`agents/implement-slice-worker.md`, `commands/deep-finish.md`) 에서 호출하는 CLI 헬퍼. `--source-evolve-insights`, `--source-harnessability`, `--source-artifacts-glob` 으로 cross-plugin / intra-plugin chain 추출 (envelope 인 evolve-insights 의 `run_id` 를 `parent_run_id` 로 자동 채우고, slice receipt 와 harnessability `run_id` 를 `provenance.source_artifacts[]` 에 누적).
-- **`scripts/validate-envelope-emit.js`** — suite envelope schema 를 미러링한 zero-dep self-test validator. root / envelope / git / schema / provenance / source_artifacts 모든 nested object 에 `additionalProperties: false`, ULID Crockford alphabet 강제 (I/L/O/U 거부), SemVer 2.0.0 strict, RFC 3339, kebab-case, `schema.name === artifact_kind` identity, payload non-null/non-array object 에 `schema_version: "1.0"` 보존.
-- **`tests/envelope-emit.test.js`** + **`tests/envelope-chain.test.js`** + **fixtures (`sample-session-receipt.json`, `sample-slice-receipt.json`)** — ULID/SemVer/RFC3339 패턴, identity guard, corrupt-payload defense, `parent_run_id` cross-plugin chain (session-receipt.envelope.parent_run_id === consumed evolve-insights.envelope.run_id), intra-plugin chain (session-receipt 의 `provenance.source_artifacts[]` 가 모든 SLICE-*.json `run_id` 를 aggregate) 50+ assertion.
+
+- `tests/phase-guard-golden.test.js` — `phase-guard.sh`용 fixture 기반 golden test(8 시나리오: idle allow, implement slice scope in/out, 4개 non-implement denylist family, override pass-through).
+- 공유 `scrubHostEnv()` / `runPhaseGuard()` / `parseGuardOutput()` 테스트 헬퍼; family별 `CLAUDE_ALLOW_<FAMILY>` override 루프와 override fall-through 합성 assertion.
 
 ### Changed
-- **`agents/implement-slice-worker.md`** — slice receipt 생성 프로토콜이 legacy body 를 `$WORK_DIR/receipts/.SLICE-NNN.payload.json` 에 먼저 쓰고, `node ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/wrap-receipt-envelope.js --artifact-kind slice-receipt ...` 로 final envelope-wrapped `SLICE-NNN.json` 을 emit. Payload 의 `schema_version` 은 literal string `"1.0"` 이어야 한다.
-- **`commands/deep-finish.md`** — Section 2 가 session-receipt body 를 `$WORK_DIR/.session-receipt.payload.json` 에 쓴다. Section 2-1 (quality fields) 과 Section 7 (outcome/outcome_ref) 가 같은 temp file 을 갱신. 새 Section 7-Z 가 outcome 결정 후 정확히 한 번 envelope wrap 을 수행하므로 `envelope.run_id` 가 세션당 한 번만 생성된다. Cross-plugin chain 은 `.deep-evolve/<session>/evolve-insights.json` 과 `.deep-dashboard/harnessability-report.json` 에서 auto-detect.
-- **`hooks/scripts/verify-delegated-receipt-runner.js`** — slice receipt loader 가 `unwrapEnvelope()` 를 호출하므로 verify-receipt-core 는 envelope 여부와 관계없이 legacy body 를 본다. Identity mismatch 는 descriptive error 로 throw.
-- **`hooks/scripts/validate-receipt.sh`** — `json_field` 헬퍼가 M3 envelope 감지 후 `.payload` 에서 읽고, full identity guard 를 unwrap 전에 적용. Legacy receipt 는 top-level pass-through.
-- **`hooks/scripts/session-end.sh`** — slice receipt aggregation loop 가 foreign envelope (producer/artifact_kind/schema.name mismatch) 를 `slices_total` 카운트 전에 skip.
-- **`hooks/scripts/receipt-migration.js`** — envelope-wrapped receipt 를 already-migrated 로 인식 (no-op). Legacy v0 → v1.0 lift 는 top-level legacy receipt 에만 적용.
-- **`skills/deep-integrate/gather-signals.sh`** — `read_json_safe` 가 optional `expected_producer` / `expected_artifact_kind` 를 받아 matching envelope 는 `.payload` 를 반환, foreign envelope 는 `null` (handoff §4 round-4 defense-in-depth). deep-work session-receipt, deep-docs last-scan, deep-dashboard harnessability-report, deep-evolve evolve-insights, deep-wiki index 모두 적용. deep-review/deep-evolve/deep-wiki Phase 2 priority #4–#6 forward-compat.
-- **`skills/deep-research/SKILL.md`** — Cross-Plugin Context (Harnessability + Evolve Insights) 가 envelope 감지 + identity guard 절차를 명시. legacy fallback 으로 forward-compat 유지.
-- **`commands/deep-receipt.md`** / **`commands/deep-status.md`** / **`commands/deep-report.md`** — receipt read 지침에 envelope-aware unwrap 규칙 (identity guard + payload extraction; legacy pass-through 유지) 명시.
 
-### Notes
-- Suite-side 갱신 (claude-deep-suite `marketplace.json` SHA bump, `payload-registry/deep-work/{session,slice}-receipt/v1.0.schema.json` placeholder → authoritative shape, adoption ledger 갱신) 은 본 PR 범위 밖. claude-deep-suite handoff §1 에 따라 Phase 2 plugin PR 은 plugin repo 만 수정하고, suite-side 작업은 Phase 3 에서 일괄 처리.
+- `phase-guard-core.js`의 gate 순서, override-env 의미론(denylist만 억제, file-write는 여전히 적용), 의도적 scope 생략에 대한 문서 확장.
+
+## [6.6.2] — 2026-05-12
+
+### Added
+
+- `phase-guard-core.js`에 non-implement dangerous-command denylist 5개 family(rm-rf, npm-publish, kubectl-destructive, sql-destructive, curl-pipe-shell) — 각 family에 `CLAUDE_ALLOW_<FAMILY>=1` override; research/plan/test/brainstorm Bash 진입에 게이트 적용.
+
+### Fixed
+
+- SQL `TRUNCATE` 단일 문자 매칭 버그와 kubectl `--all-namespaces` false-positive.
+
+## [6.6.1] — 2026-05-12
+
+### Added
+
+- 크로스 플랫폼 CI 매트릭스(`ubuntu-latest` + `macos-latest`) — `npm test`와 bash 회귀 스크립트 실행.
+
+### Fixed
+
+- 회귀 스크립트의 크로스 플랫폼 `stat` fallback(`stat -c '%a' || stat -f '%A'`).
+
+## [6.6.0] — 2026-05-12
+
+### Added
+
+- `hooks/scripts/emit-handoff.js` — handoff payload를 M3 envelope으로 감싸 `.deep-work/handoffs/`에 기록하고 session receipt에 `parent_run_id`를 자동 체인.
+- `hooks/scripts/emit-compaction-state.js` — compaction-state payload를 M3 envelope으로 감쌈(trigger/strategy enum 검증); dashboard compaction 메트릭에 사용.
+- `--handoff-to=<plugin>` 제공 시 `deep-finish`가 cross-plugin handoff emit.
+- Stop hook과 phase-transition hook이 세션 종료 시 및 각 phase 경계에서 best-effort `compaction-state.json` emit.
+
+### Changed
+
+- `ALLOWED_ARTIFACT_KINDS`를 envelope 라이브러리와 CI validator 전반에서 `handoff`와 `compaction-state`로 확장.
+
+## [6.5.0] — 2026-05-07
+
+### Added
+
+- M3 cross-plugin envelope 채택: `session-receipt.json`과 `receipts/SLICE-*.json`이 `{ schema_version, envelope, payload }`로 emit되며, session receipt의 `parent_run_id`가 consumed `evolve-insights.json`으로 체인되고 `provenance.source_artifacts[]`가 slice run ID를 aggregate.
+- `hooks/scripts/envelope.js` — zero-dep envelope 라이브러리(ULID 생성기, git 감지, identity guard와 corrupt-payload defense를 갖춘 `wrapEnvelope`/`unwrapEnvelope`).
+- `hooks/scripts/wrap-receipt-envelope.js` — cross-plugin/intra-plugin chain 추출 플래그를 갖춘 payload wrap CLI 헬퍼.
+- `scripts/validate-envelope-emit.js` — suite envelope 스키마를 미러링한 zero-dep self-test validator.
+
+### Changed
+
+- 내부 reader와 cross-plugin consumer가 envelope을 감지하고 identity guard를 적용한 뒤 `.payload`로 unwrap; legacy non-envelope receipt는 pass-through(forward-compatible).
 
 ## [6.4.2] — 2026-04-29
 
 ### Added
-- **Profile schema v3** — `interactive_each_session` 배열로 매 세션 묻는 항목을 사용자별 customize. `defaults.*`로 자동 적용 값 분리.
-- **session-recommender sub-agent** — sonnet 기본, task description + workspace meta + capability를 입력받아 fenced JSON 추천. allowlist `^(haiku|sonnet|opus)$`.
-- **`--no-ask` flag** — ask + 추천 모두 skip (가장 빠른 경로). `--profile=X --no-ask`로 v6.4.x "이대로 진행" 등가물.
-- **`--recommender=MODEL` / `--no-recommender` flags** — 추천 모델 override / skip.
-- **State file `recommendations` field** — 옵셔널, phase-guard enforcement에 영향 없음.
-- **State file 권한 600** — multi-user 환경 안내 README 추가.
-- **`scripts/load-v3-profile.js`** — v3 schema profile loader (orchestrator §1-3-3).
-- **`scripts/parse-deep-work-flags.js`** — CLI flag parser with allowlists (PROFILE_NAME / RECOMMENDER / EXEC / TDD / RESUME_FROM).
-- **`scripts/detect-capability.js`** + **`scripts/format-ask-options.js`** — environment capability detection + AskUserQuestion option formatter.
-- **`scripts/migrate-profile-v2-to-v3.js`** — profile v2→v3 마이그레이션 헬퍼: atomic write + `flock` + idempotent + `.v2-backup` + rollback 절차.
-- **`scripts/recommender-input.js`** + **`scripts/recommender-parser.js`** — session-recommender 입력 정제 및 출력 파서 (5-key 검증).
-- **`agents/session-recommender.md`** — 세션 초기화 추천 sub-agent (기본 sonnet).
+
+- Profile schema v3 + `interactive_each_session` — 매 세션 묻는 항목을 사용자별로 제어, `defaults.*`는 자동 적용.
+- `session-recommender` sub-agent(기본 sonnet)가 task와 workspace에서 최적 `team_mode` / `start_phase` / `tdd_mode` / `git` / `model_routing`을 추론.
+- 새 플래그: `--no-ask`(ask + recommender 모두 skip, 가장 빠른 경로), `--recommender=MODEL`, `--no-recommender`.
+- 멀티 유저 환경용 state-file 권한 가이드(600).
 
 ### Changed
-- **`--profile=X` 의미 유지** — v6.4.x와 동일하게 ask 단계 진행 (silent regression 방지). 기존 빠른 경로 사용자는 `--no-ask` 추가 필요.
-- **Profile v2 → v3 자동 마이그레이션** — atomic write + `flock` + idempotent + `.v2-backup` 백업 + rollback 절차 README.
-- **Orchestrator §1-3 통합** — 단일 confirm 폐기 → 항목별 ask N번 + LLM 추천. ask/추천은 in-memory only, §1-9 state 생성 시점에 atomic 직렬화.
-- **Assumption auto-adjust → recommender 순서** — auto-adjust 결과가 recommender 입력 `current_defaults`에 반영.
+
+- `--profile=X`가 이제 ask 단계를 거침(이전 빠른 경로는 `--no-ask` 추가).
+- Profile v2 → v3 자동 마이그레이션: atomic write + flock + idempotent + `.v2-backup` + rollback.
 
 ### Fixed
-- **플래그 파서 shell injection**: `parse-deep-work-flags`가 quoted 단일 문자열 `$ARGUMENTS`를 수락 — shell 메타문자가 allowlist 검사 전에 평가되지 않음 (orchestrator §1-3-1 호출 패턴).
-- **v6.4.1 `git_branch` 프로필 호환성**: `migrate-profile-v2-to-v3`가 `git_branch: <bool>` (v6.4.1 스키마)을 unsupported schema로 거부하는 대신 `defaults.git.use_branch`로 변환.
-- **capability 감지 오탐**: orchestrator §1-4-2가 `IS_GIT` 환경 변수 대신 `git rev-parse --is-inside-work-tree` + `git worktree list`를 사용 — 일반 git 저장소에서 비-git으로 오탐되던 문제 수정.
-- **`--profile=X`가 로더에 전달되지 않던 문제**: `--profile=X`가 이제 `DEEP_WORK_INITIAL_PRESET` 환경 변수를 통해 `load-v3-profile.js`로 전달됨 (migrate-profile 호출과 동등).
-- **preset 레벨 설정이 묵시적으로 누락**: `loadV3Profile`이 이제 `project_type`, `cross_model_preference`, `auto_update`를 반환 (기존에는 누락되어 zero-base / cross-model / auto-update 설정이 조용히 손실됨).
+
+- 플래그 파서의 shell injection(quoted single-string `$ARGUMENTS`가 allowlist 검사 전에 평가되지 않음).
+- v6.4.1 `git_branch:` 프로필을 거부하지 않고 변환.
+- 정상 git repo의 capability 감지 false negative(`git rev-parse`/`git worktree list` 사용).
+- `--profile=X`가 profile loader로 전달됨; preset 수준 설정(`project_type`, `cross_model_preference`, `auto_update`)이 더 이상 silently 누락되지 않음.
 
 ### Removed
-- **알림 시스템 전면 제거** — `hooks/scripts/notify.sh` (195 lines), `hooks/scripts/notify-parse.test.js` (125 lines), `skills/shared/references/notification-guide.md` (59 lines) 삭제. Phase skill 5개 + `multi-session.test.js` notify.sh 가드 정리. **Note**: `assumption-engine.{js,test.js}`의 `notification` 변수는 assumption auto-adjust 결과 메시지(자체 어휘)이며 외부 알림과 무관한 동음이의어 — 보존됨.
 
-### Breaking Changes (Patch bump이지만 명시 필수)
+- 알림 시스템 완전 제거 — `notify.sh`, 그 테스트, 알림 가이드 삭제 및 phase skill에서 notify 가드 정리.
 
-- **알림 webhook 사용자**: notify.sh + slack/discord/telegram/webhook 통합이 본 릴리스로 끊김. 사용자 결정에 따라 patch bump으로 진행하지만, webhook 외부 통합이 활성인 경우는 본 릴리스 직전 manual fork/backport 필요.
-- **자동 스크립트로 `--profile=X`만 사용한 사용자**: v6.4.2부터 `--profile=X`는 ask 단계를 진행함 (silent regression 회피 목적). 기존 동작을 유지하려면 `--profile=X --no-ask` 추가.
-- **Profile schema v2 → v3 자동 마이그레이션**: 보존되는 정보 손실은 없으나 `notifications.url` 등은 회수 불가능. `.v2-backup`은 보존됨 (rollback 가능).
+### Breaking
 
-### Migration
+- Slack/Discord/Telegram/webhook 통합이 severed됨; 활성 webhook 사용자는 업그레이드 전 v6.4.1을 fork해야 함.
+- bare `--profile=X`에 의존하는 자동화 스크립트는 이전 동작 유지를 위해 `--no-ask`를 추가해야 함.
+- Profile v2 → v3 자동 마이그레이션은 `notifications.url` 같은 복구 불가 필드를 잃음(rollback용 `.v2-backup` 보존).
 
-- v6.4.x → v6.4.2 첫 호출 시 자동 마이그레이션 + 1회 안내. 알림 webhook 외부 통합이 있으면 본 릴리스로 끊김.
-- Rollback: `mv .claude/deep-work-profile.yaml.v2-backup .claude/deep-work-profile.yaml` (project-local).
+## [6.4.1] — 2026-04-26
 
-### Spec & Plan
+### Changed
 
-- Design: `docs/superpowers/specs/2026-04-29-deep-work-flexible-init-design.md`
-- Plan: `docs/superpowers/plans/2026-04-29-deep-work-flexible-init.md`
-
-## [6.4.1] - 2026-04-26
-
-### 변경
-- **Harness Engineering hardening**: SessionStart sensor detection이 느린 `npx --no-install` probe를 기본으로 쓰지 않고, 로컬 `node_modules/.bin` 및 빠른 PATH lookup을 사용하여 tool 미설치 환경에서도 hook timeout 안에 안정적으로 종료됩니다.
-- **Phase 1 Health Engine 연결**: `deep-research`에 부모 세션 소유 topology 감지, fitness 제안, health report, baseline, unresolved required issue 기록 흐름을 명시했습니다. `health-check` CLI는 기본적으로 `.deep-review/fitness.json`을 자동 로드하고 `--fitness` / `--no-fitness`를 지원합니다.
-- **Health report schema 정렬**: `/deep-status`와 `/deep-receipt`가 실제 producer 경로인 `health_report.drift.*`, `health_report.fitness.*`를 읽도록 정리했습니다.
-
-### Fixed
-- **`multi-session.test.js:507` lint guard false-positive**. 제외 regex 가 `multi-session.test.js` 자기 자신만 면제하여 `phase5-guard.test.js` 의 정당한 테스트 픽스처 8건(legacy-path 코드 경로 검증을 위한 의도된 `deep-work.local.md` 참조)이 "active code에 하드코딩된 레거시 경로"로 오탐. Regex 를 `multi-session\.test\.js` → `\.test\.js` 로 확장하여 모든 테스트 파일을 제외 — 테스트 파일은 legacy behavior 검증을 위해 해당 경로가 정당하게 필요하므로. `node --test hooks/scripts/*.test.js` 결과 이제 428/428 pass (이전 427/428, v6.3.1 Excluded 섹션에 known failure로 기재됐던 건).
-- **Receipt sensor validation 호환성**: Parent receipt 검증이 빈/임의 `sensor_results`, `fail`, `timeout`, 근거 없는 `not_applicable`은 거부하면서도, 문서화된 `sensor_results.ecosystem` 메타데이터와 legacy delegated `skipped` 상태는 허용합니다.
-- **Health Check CLI root parsing**: `--fitness <file>` 및 `--fitness=<file>` 옵션 값을 positional project root로 오인하지 않도록 수정했습니다.
-
-## [6.4.0] - 2026-04-23
-
-### 변경 — Breaking
-- **`model_routing.{research, implement, test}="main"` 제거**. 기존 state 파일은 load 시 `"sonnet"`으로 자동 마이그레이션. `model_routing.plan="main"`은 유지 (Plan phase는 대화형 메인 세션 실행 유지).
-- **`team_mode` 의미론 단일화** — 병렬도만 의미 (solo=1, team=N). 메인 세션 inline 실행은 숨겨진 default가 아닌 명시적 escape hatch.
-
-### 추가
-- `agents/` 아래 3개 Claude Code subagent:
-  - `research-codebase-worker` — 기존 코드베이스 리서치 (read-only tool allowlist)
-  - `research-zerobase-worker` — 신규 프로젝트 리서치, web 접근 (WebSearch/WebFetch/Context7 MCP)
-  - `implement-slice-worker` — TDD 강제 slice cluster 구현
-- `hooks/scripts/verify-delegated-receipt.sh` + `verify-receipt-core.js` — 8개 항목 post-hoc receipt 검증 (scope, baseline chain, TDD hard-fail, verification output advisory)
-- §5.6a Rollback Protocol — verify-receipt 실패 시 `git reset --hard <delegation_snapshot>`
-- §5.5a inline escape hatches — 자동 라우팅 (spike, trivial inline plan) + `--exec=<inline|delegate>` CLI override + `active_cluster_takeover` state 필드 기반 debug takeover
-- `scripts/validate-agents.sh` — agents/*.md 정적 검증
-
-### 수정
-- `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` 미설정 시 `team_mode=team` → solo 로의 silent fallback (원 버그)
-- 단일 `git_before` baseline을 multi-slice receipt에서 재사용하던 문제 → per-slice `git_before_slice`/`git_after_slice` (F1)
-- Path-filtered diff가 out-of-scope 편집을 가리던 문제 → unfiltered union-scope 검사 (F2)
-- Zero-base subagent가 Write/Edit/Bash + web 접근을 상속하던 security 문제 → 명시적 read-only tool allowlist (F3 security)
-
-### 마이그레이션
-`docs/migrations/v6.4.0.md` 참조.
-
-## v6.3.1 — 2026-04-21
+- SessionStart 센서 감지가 느린 `npx --no-install` probe를 피하고 로컬 `node_modules/.bin` + PATH 조회를 사용하여 missing-tool 환경이 hook 타임아웃 내에 완료.
+- Phase 1 Health Engine wiring을 `deep-research`에 문서화; `health-check` CLI가 `.deep-review/fitness.json`을 자동 로드(`--fitness` / `--no-fitness` override).
+- `/deep-status`와 `/deep-receipt`가 `health_report.drift.*` / `health_report.fitness.*` 실제 producer 경로를 읽음.
 
 ### Fixed
 
-- **Phase skill body echo 버그** — `Skill("deep-*")` 호출 시 SKILL.md 본문의 markdown 템플릿이 사용자에게 노출된 뒤 phase 작업(예: brainstorm의 명확화 질문)이 수행되지 않고 대화가 종료되는 현상. 브레인스톰의 명확화 질문 누락 및 리서치/플랜의 분석 단계 누락을 모두 해결.
-- **Exit Gate pause/resume 회귀** (F1) — phase skill이 완료 시 current_phase를 다음 phase로 미리 전환하던 기존 동작이 Exit Gate "일시정지" 선택 시 `/deep-resume` 재개 경로에서 Exit Gate를 건너뛰고 다음 phase로 자동 진입하는 문제를 야기. current_phase 변경 주체를 Orchestrator로 일원화하여 해결.
+- 테스트 fixture의 lint guard false-positive(예외를 한 파일에서 모든 `*.test.js`로 확장).
+- Parent receipt 검증이 empty/arbitrary 센서 결과, `fail`, `timeout`, 미지원 `not_applicable`을 거부하되 문서화된 메타데이터는 수용.
+- Health Check CLI가 `--fitness <file>`을 positional project root로 오인하지 않음.
+
+## [6.4.0] — 2026-04-23
+
+### Changed
+
+- **Breaking**: `model_routing.{research,implement,test}="main"` 제거(로드 시 `"sonnet"`로 자동 마이그레이션); `model_routing.plan="main"`은 보존.
+- **Breaking**: `team_mode` 의미론을 병렬도만으로 통일(solo=1, team=N); 메인 세션 inline 실행은 명시적 escape hatch.
 
 ### Added
 
-- **4계층 echo 방어** (5개 phase skill 공통):
-  1. `> [!IMPORTANT]` admonition 블록 — skill body echo 금지 + Pre-checks 예외 허용
-  2. 템플릿 외부 분리 — `skills/shared/templates/{brainstorm,research}-template.md` + `plan-template-{existing,zerobase}.md` (2-mode 분기)
-  3. First Action 서브섹션 — phase 진입 시 즉시 수행할 가시 첫 동작 명시
-  4. Section 3 실행 순서 안전장치
-- **Phase Exit Gate × 5** — 각 phase 완료 시 AskUserQuestion으로 "진행 / 재실행 / 일시정지" 선택. "진행" 선택 시 즉시 다음 skill 호출.
-- **완료-Marker 감지 분기** — 모든 5개 phase skill Section 1에서 `*_completed_at` 필드 감지 시 Orchestrator로 제어 반환 (Exit Gate 재표시).
+- `agents/` 아래 서브에이전트 3개: `research-codebase-worker`(read-only), `research-zerobase-worker`(read-only + 웹 접근), `implement-slice-worker`(TDD 강제).
+- `verify-delegated-receipt.sh` + `verify-receipt-core.js` — 8항목 post-hoc receipt 검증.
+- verify-receipt 실패 시 rollback 프로토콜(`git reset --hard <snapshot>`); inline escape hatch(auto-routing, `--exec=<inline|delegate>`, debug takeover).
+- `scripts/validate-agents.sh` — `agents/*.md` 정적 sanity check.
 
-### Changed
+### Fixed
 
-- **current_phase 변경 주체 일원화**: Brainstorm/Implement phase skill이 Section 3에서 직접 변경하던 동작 제거. 모든 phase의 current_phase 변경을 Orchestrator Exit Gate "진행" 분기로 이관.
-- Orchestrator §1-11 문구: "자동 흐름을 시작합니다..." → "각 phase 완료 시 진행 확인을 받으며 순차 실행합니다..."
-- `review-approval-workflow.md`: Exit Gate와의 관계 명시.
+- experimental-teams 환경변수 누락 시 `team_mode=team`이 solo로 silently fallback.
+- 멀티 slice receipt에서 단일 `git_before` baseline 재사용 → per-slice baseline.
+- Path-filtered diff가 out-of-scope 편집을 숨김 → unfiltered union-scope check.
+- Zero-base 서브에이전트가 Write/Edit/Bash + 웹 접근을 상속 → 명시적 read-only tool allowlist.
 
-### Excluded
+## [6.3.1] — 2026-04-21
 
-- Phase 5 Integrate는 이미 interactive loop이므로 Exit Gate 적용 대상에서 제외.
-- Hook 스크립트 로직 변경 없음. `node --test hooks/scripts/*.test.js` 결과: 397/398 pass. 1 pre-existing failure (`multi-session.test.js:507` - phase5-guard.test.js fixture와의 lint 충돌)는 main 브랜치에도 존재하며 v6.3.1과 무관.
+### Fixed
 
-### Added (v6.3.1 NW5 integrity check + NO3 data preservation)
+- Phase skill body echo 버그 — `Skill("deep-*")`가 SKILL.md 템플릿을 노출하고 phase 작업(brainstorm 명확화 질문, research/plan 분석)을 건너뛰던 현상 해결.
+- Exit Gate pause/resume 회귀 — `current_phase` 변경을 orchestrator로 일원화하여 "일시정지" 선택 시 `/deep-resume`에서 Exit Gate를 재표시(다음 phase 자동 진입 방지).
 
-- **Approval integrity hash** — Research/Plan approval 시점의 `sha256(research.md/plan.md)`를 `research_approved_hash` / `plan_approved_hash`로 state에 기록. `/deep-resume` Resume fast-path가 현재 파일 hash와 비교하여 out-of-band 편집(일시정지 중 외부 편집기 수정 등)을 자동 감지 — 불일치 시 **data preservation + in-place review** 경로 발동 (NO3): 편집된 문서를 `$WORK_DIR/{research,plan}.v{N}-edit.md`로 백업 + approval state invalidate + Skill 재호출 스킵하고 Review+Approval workflow 직접 진입. 편집 내용이 보존된 채 재검토되어 사용자 편집이 유실되지 않음. 필드 부재 시(pre-v6.3.1 세션 또는 재실행 후 재승인 전)는 Skill 재실행이 safer default.
-- **Backup filename collision 방지 (NP3)**: orchestrator가 생성하는 hash mismatch backup은 `-edit` 접미사를 사용하여 deep-plan/deep-research skill의 자체 backup(`v{N}.md`)과 파일명 충돌 방지.
+### Added
 
-### Known Limitations (v6.3.2 예정)
+- 5개 phase skill 공통 4계층 echo 방어(admonition 블록, 외부 템플릿, 명시적 First Action, 실행 순서 안전장치).
+- 각 5개 phase의 Phase Exit Gate(진행 / 재실행 / 일시정지) — AskUserQuestion.
+- 완료-marker 감지: `*_completed_at` 필드 존재 시 phase skill이 orchestrator로 제어 반환.
+- Approval integrity hash(`research_approved_hash` / `plan_approved_hash`)로 `/deep-resume`가 out-of-band 편집을 감지하고 편집 문서를 `{research,plan}.v{N}-edit.md`로 백업 후 재검토.
+- Backup 파일명 충돌 방지(`-edit` 접미사 vs. skill 자체 `v{N}.md`).
 
-- **Hash mismatch recovery의 plan-specific validation 부재**: NO3 data preservation 경로는 generic Review+Approval workflow를 실행하나, `deep-plan` 고유 validation(Completeness Policy, Contract Negotiation, Phase Review Gate)는 스킵됨. Out-of-band 편집이 `TBD` 같은 placeholder를 추가한 뒤 승인되는 경로는 현재 가드 불충분. Workaround: Exit Gate option 2 "재실행/수정"을 사용하면 skill 재실행으로 모든 validation 적용됨. v6.3.2에서 in-place review에도 phase-specific validation hook 추가 예정.
-- **Backup write-failure fail-safe 부재**: NO3 backup 복사 실패 시(권한/디스크 full 등) state 변경을 중단하는 가드 없음. 희귀 edge case이며 data는 여전히 원본 research.md/plan.md에 남아있음. v6.3.2에서 backup 실패 시 state 변경 중단 + 사용자 알림 가드 추가 예정.
+### Known limitations
+
+- Hash-mismatch 복구가 plan-specific validation(Completeness Policy, Contract Negotiation, Phase Review Gate) 없이 generic review/approval flow를 실행; 전체 validation은 Exit Gate "재실행"으로 적용. Backup write 실패가 아직 state 변경을 중단하지 않음.
 
 ## [6.3.0] — 2026-04-18
 
-### 추가됨
-- **Phase 5 "Integrate"** — Phase 4(Test) 완료 후 호출되는 skippable 단계. `deep-review`, `deep-docs`, `deep-wiki`, `deep-dashboard`, `deep-evolve` 플러그인 아티팩트를 읽어 AI가 최대 3개의 다음 단계를 추천하면 사용자가 선택·실행한다. 대화형 루프 (최대 5라운드). 설계 문서: `docs/superpowers/specs/2026-04-18-phase5-integrate-design.md`.
-- `/deep-integrate` 커맨드: Phase 5 수동 재진입용.
-- `--skip-integrate` 플래그: Phase 5 건너뛰고 `/deep-finish`로 직행.
-- `skills/deep-integrate/` 신규 스킬 + 헬퍼 스크립트(`detect-plugins.sh`, `gather-signals.sh`, `phase5-finalize.sh`, `phase5-record-error.sh`), JSON 스키마, L6 snapshot fixture.
-- `phase5_work_dir_snapshot` state 필드 — Phase 5 진입 시점의 work_dir을 불변 snapshot으로 기록. phase-guard가 이 값을 enforcement 기준으로 사용하므로 런타임에 state file의 `work_dir`이 변조돼도 boundary가 유지된다.
-- `phase5-finalize.sh` helper — state file의 `phase5_completed_at`만 atomically 기록. state file 경로가 현재 세션과 일치하는지 검증하며, Phase 5 중 state 수정은 이 helper 경유만 허용된다.
-- `phase5-record-error.sh` helper — `/deep-finish --skip-integrate` 경로에서 `integrate-loop.json`의 `terminated_by`를 `"error"`로 기록. Stop-hook의 `interrupted` 마킹과 함께 belt-and-suspenders.
-- Stop-hook: 세션 중단 시 `integrate-loop.json`에 `terminated_by: "interrupted"` 기록.
+### Added
 
-### 변경됨
-- `deep-work-orchestrator`가 Phase 4(Test) 완료 후 Phase 5로 dispatch한다. Phase 5 에러 시 `/deep-finish`에 `--skip-integrate`를 전달하여 state machine이 정상 종료되도록 한다.
-- `/deep-finish`: `integrate-loop.json` 부재 시 `/deep-integrate` 힌트. `--skip-integrate`는 Phase 5 중단 prompt를 우회하고 `phase5-record-error.sh`를 defensively 호출한다.
-- **`phase-guard.sh` Phase 5 mode 도입** (초기 계획 "phase-guard 변경 없음"은 보안 검토 결과 뒤집혔음). `current_phase=idle + phase5_entered_at + !phase5_completed_at` 상태에서 다음을 강제:
-  - `Write/Edit/MultiEdit/NotebookEdit`: 대상 경로가 snapshot `$WORK_DIR` 하위여야 함. state file 직접 수정은 차단 — `phase5-finalize.sh`만 허용.
-  - `Bash`: **allowlist-only (default-deny)**. 첫 command token(env 변수 prefix 이후)이 Phase 5 read-mostly allowlist에 있어야 통과: 파일시스템 read(`cat`/`head`/`tail`/`wc`/`ls`/`pwd`/`file`/`stat`/`realpath`/`readlink`/`dirname`/`basename`), 검색/필터(`grep`/`sort`/`uniq`/`diff`/`cut`/`paste`/`column`/`tr`/`find`), JSON/YAML read(`jq`/`yq` `-i` 제외), shell builtins(`echo`/`printf`/`date`/`env`/`true`/`false`/`test`/`which`/`type`/`command`/`xxd`/checksums), `git` read-only subcommand(`status`/`diff`/`log`/`show`/`blame`/`grep`/`rev-parse`/`rev-list`/`merge-base`/`symbolic-ref`/`ls-files`/`ls-tree`/`branch`/`tag`/`config`/`describe`/`cat-file`/`fsck`/`shortlog`/`reflog`/`name-rev`/`for-each-ref`/`count-objects`/`verify-pack`/`check-ignore`/`check-attr`/`var`/`help`/`version`), 인터프리터(`bash`/`sh`/`python`/`perl`/`ruby`/`node`/`awk`/`sed`/`php`/`osascript`/`tsx`/`deno`/`bun`) + script canonical check, 파일시스템 ops(`mv`/`cp`/`mkdir`/`rm`/`rmdir`/`chmod`/`chown`/`truncate`/`touch`/`ln`/`install`) + target-in-`$WORK_DIR` 검증. 알 수 없는 command는 즉시 block. 추가 제약: 파괴적 변형(`/bin/rm`, `\rm`, `command/exec/builtin rm`) 정규화; `git` global flags(`-C <path>`, `--git-dir [=]<path>`, `--work-tree [=]<path>`, `-c <k=v>`, `-p`/`--no-pager`/`--bare`/...) fixed-point iteration으로 제거; `git` mutating 서브커맨드(위 목록) 정규화 후 block; `find -delete/-exec/-ok/...` block; `jq/sed/perl/ruby -i` in-place flag block; 인터프리터 `-c/-e` flag block; compound 연산자(`;`, `&&`, `||`, `|`, `&`) reject; helper 경로 shell metacharacter(`$`, `` ` ``, `(`, `)`, `<`, `>`, newline, CR) reject. `mv`/`cp`는 SRC와 DEST 양쪽 검증. **인터프리터 + script 호출**은 script canonical `realpath`가 `${PROJECT_ROOT}/skills/deep-integrate/<helper>.sh` 또는 `${HOME}/.claude/plugins/cache/claude-deep-suite/deep-work/*/skills/deep-integrate/<helper>.sh`와 정확히 일치할 때만 허용. 읽기 도구(`Read`, `Glob`, `Grep`, `Agent`, `AskUserQuestion`, `Skill`)는 통과.
-- `/deep-integrate` tool allowlist 축소: `Skill, Read, Bash, Glob, Grep, Agent, AskUserQuestion` (`Write, Edit` 제거).
+- **Phase 5 "Integrate"** — Test 이후의 skippable phase로, deep-suite 플러그인 아티팩트를 읽어 AI가 interactive loop(최대 5 라운드)에서 top-3 다음 단계를 추천.
+- 수동 재진입용 `/deep-integrate` 커맨드; `/deep-finish`로 바로 가는 `--skip-integrate` 플래그.
+- 헬퍼 스크립트, JSON 스키마, fixture를 갖춘 `skills/deep-integrate/`.
+- `phase5_work_dir_snapshot` state 필드 — Phase 5 진입 시 기록되는 불변 경계로, 런타임에서 `work_dir`을 변조해도 write 경계를 넓힐 수 없음.
+- `phase5-finalize.sh`(Phase 5 중 state를 쓰는 유일한 인가 경로)와 `phase5-record-error.sh`(`terminated_by: "error"` 기록); Stop hook이 `terminated_by: "interrupted"` 기록.
 
-### 업그레이드 안내
-- v6.2.x에서 Phase 5 진입한 세션은 `phase5_work_dir_snapshot`이 없을 수 있다. phase-guard는 backward-compat으로 `work_dir` fallback을 사용하지만, 이 경로는 state-tampering 공격에 더 노출된다. v6.3.0 신규 Phase 5 진입은 snapshot을 자동 기록한다.
-- `phase5-finalize.sh`는 state file basename이 `deep-work.<sid>.md` 패턴이고 `.claude/` 디렉토리에 있는지 검증한다. 기존에 redirect로 state를 수정하던 로직은 이 helper 호출로 전환해야 한다.
-- **의존성**: `phase5-record-error.sh`, `gather-signals.sh`, Stop-hook `terminated_by` marker는 `jq`가 `PATH`에 있어야 한다 (없으면 helper가 명시적 에러로 종료). `phase5-finalize.sh`는 `awk`만 사용하여 `jq` 의존성 없음.
+### Changed
 
-### 알려진 제약
-- **인터프리터 커버리지**: `Rscript`/`julia`/`lua`/`groovy`/`tclsh`는 allowlist 미포함. 실제 Phase 5 workflow에 이들이 필요하면 명시적으로 추가해야 한다. v6.3.1에서 검토.
-- **`awk -f script.awk`**: `-f` 플래그 형태는 interpreter-with-script canonical check에서 커버되지 않는다(`-e/-c`는 `-c/-e` 규칙으로 차단). Phase 5 Bash allowlist가 알 수 없는 형태를 거부하고 legitimate workflow에서 `awk -f`를 쓰지 않아 실무 위험은 낮음.
-- **레거시 세션 업그레이드**: v6.2.x에서 `phase5_work_dir_snapshot` 없이 Phase 5 진입한 세션은 mutable `work_dir` fallback. v6.3.0에서 재진입 시 snapshot이 자동 기록됨.
-- **`phase5-record-error.sh` / `phase5-finalize.sh` 단위 테스트**: 현재 `phase5-guard.test.js`에서 간접 커버. 전용 단위 테스트 파일은 v6.3.1 예정.
-- **Allowlist 명령 악용**: read-mostly allowlist의 명령은 표준 read-only form에서 허용되며 niche invocation은 이론적으로 악용 가능(예: `find`의 mutating flag 차단됨; `jq -i` 차단; `mv`/`cp`/`mkdir`은 target 검증; 나머지는 safe 가정). `curl`은 allowlist 미포함; 네트워크 접근 helper의 data-exfil 방어 같은 per-command invocation audit은 v6.4.0에서 검토.
-- **Non-Bash 도구(`Agent`/`Skill`)**: Phase 5 guard를 통과. `Agent`로 dispatch된 subagent는 자체 tool set을 가지며 Phase 5 enforcement는 호출 세션의 Bash/Write/Edit에만 적용. v6.3.0에서는 out-of-scope trust boundary로 취급.
+- Orchestrator가 Test와 `/deep-finish` 사이에 Phase 5를 dispatch; 에러 시 `--skip-integrate` 전달.
+- 새 Phase 5 guard 모드: write는 snapshot `$WORK_DIR` 아래로 제한, state 변조는 `phase5-finalize.sh`로 제한, Bash는 allowlist-only(default-deny) — read-mostly 명령과 `$WORK_DIR` 범위 파일 작업만 허용하고 destructive/in-place/compound 형태는 차단.
+- `/deep-integrate` tool allowlist 축소(`Write`, `Edit` 제거).
+
+### Upgrade notes
+
+- snapshot 없이 v6.2.x에서 Phase 5에 진입한 세션은 mutable `work_dir`로 fallback; Phase 5 재진입 시 snapshot 기록. Phase 5 헬퍼는 PATH에 `jq` 필요(`phase5-finalize.sh` 제외).
+
+### Known limitations
+
+- 일부 인터프리터(`Rscript`/`julia`/`lua`/...)와 `awk -f`는 Phase 5 allowlist에 없음; 네트워크 exfil 완화와 per-command invocation audit은 추후 추적. `Agent`/`Skill` tool은 Phase 5 guard를 pass-through.
 
 ## [6.2.4] — 2026-04-17
 
-내부 감사(`BUG_REVIEW_REPORT.md`)로 식별된 hook 레이어 버그 15건 + 문서 드리프트 7건을 수정하는 버그 픽스 릴리스. 실행 전 플랜 독립 리뷰에서 추가로 발견된 critical 5건도 함께 해결.
+내부 audit에서 식별된 hook-layer 버그와 문서 드리프트를 다루는 버그 수정 릴리스.
 
-### 수정됨
+### Fixed
 
-**Hooks — 호환성 및 파싱**
-- `file-tracker.sh`: BSD 전용 `sed -i ''` 구문을 Node.js 인라인 스크립트로 교체. 기존 코드는 Linux의 GNU sed에서 무음 실패하여 marker 파일 수정 후에도 `sensor_cache_valid`가 stale로 남았음. macOS에서도 insert-when-missing 경로가 두 번째 `---` 구분자를 잘못 처리했던 문제도 함께 해결.
-- `update-check.sh`: 플러그인 경로를 `process.argv[1]`로 전달 (기존에는 셸 문자열 보간). 경로에 apostrophe(`/Users/O'Brien/...`)가 포함되면 JS 구문 오류로 업데이트 확인이 조용히 스킵되던 문제 해결.
-- `phase-guard.sh` / `file-tracker.sh` / `phase-transition.sh`: `file_path` 추출을 regex에서 `extract_file_path_from_json` (JSON 파서) 기반으로 교체. escape된 따옴표를 포함한 경로(`a \"b\" c.txt`)가 잘려서 오인 block 및 receipt 손상이 발생하던 문제 해결.
-- `phase-transition.sh`: `SESSION_ID` 추출 시 가장 안쪽의 `deep-work.XXXX` 세그먼트를 취함. Fork worktree 경로(`.deep-work/sessions/deep-work.s-parent/sub/.claude/deep-work.s-child.md`)가 이제 `s-child`로 정확히 해결됨 (기존엔 다중 매치로 cache 파일 경로가 깨짐).
+- `file-tracker.sh`: BSD 전용 `sed -i ''`를 Node inline 스크립트로 교체(이전 코드는 Linux에서 silently 실패).
+- `update-check.sh`: 플러그인 경로를 `process.argv`로 전달하여 apostrophe가 포함된 설치 경로가 update check를 깨지 않음.
+- `phase-guard.sh` / `file-tracker.sh` / `phase-transition.sh`: JSON 파서 기반 `file_path` 추출(escaped quote 경로가 truncate되던 문제 해결).
+- `phase-transition.sh`: `SESSION_ID`용 innermost `deep-work.XXXX` 세그먼트 추출로 fork worktree 경로가 올바르게 해석.
+- Receipt 업데이트를 mkdir 기반 spinlock으로 감싸고 crash-safe pending-changes drain 적용; `sensor-trigger.js`와 `file-tracker.sh`가 state lock 공유.
+- `utils.sh write_registry`: lock 타임아웃 시 fail-closed(다른 프로세스 lock을 force-remove하지 않음) + 에러 로깅.
+- `phase-guard-core.js`: 내부 에러는 `exit(3)`(의도적 block과 구분); `phase-guard.sh`는 빈 `decision`에 fail-close.
+- `phase-guard.sh`: frontmatter에서 `slice_files` / `strict_scope` / `exempt_patterns`를 읽어 slice-scope를 실제로 강제; 모든 block-message heredoc이 interpolated 필드를 JSON-escape.
+- `phase-transition.sh` 캐시: `file-tracker.sh`가 phase 기반 early return 전에 stdin을 atomically 캐시하여 모든 phase 전환이 캐시를 refresh.
+- `notify.sh`: YAML-aware `notifications.enabled` 파서, `osascript`/PowerShell-toast escaping, `pipefail` 제거.
 
-**Hooks — race condition**
-- `file-tracker.sh` receipt 업데이트: read-modify-write를 mkdir 기반 spinlock(40회 × 50ms)으로 감쌈. 타임아웃 시 `<receipt>.pending-changes.jsonl`에 큐잉하고 다음 lock 보유자가 crash-safe 패턴(rename → `.draining.<pid>` → merge → canonical rename → `.draining` unlink)으로 드레인. 드레인 중 크래시가 나도 `.draining.*` 파일이 남아 다음 invocation에서 복구. 5+ 동시 PostToolUse 호출에서 `files_modified` 항목이 유실되거나, lock timeout 경로로 큐잉된 후 아무도 드레인하지 않아 조용히 사라지던 문제 해결.
-- `sensor-trigger.js` + `file-tracker.sh` state YAML 업데이트: 동일한 `<state>.lock`을 공유 — `file-tracker.sh`의 marker file `sensor_cache_valid` flip도 포함(초기 v6.2.4에서 누락됐다가 post-review에서 수정). 기존에는 `current_phase`/`active_slice`/`sensor_pending`/`sensor_cache_valid` 변경이 race로 하나가 씹힘.
-- `utils.sh` `write_registry`: lock 타임아웃 시 fail-closed (다른 프로세스의 lock 디렉터리 강제 제거 금지). 호출자(`register_session`, `update_last_activity`, `register_file_ownership`, `update_registry_phase`, `unregister_session`, `register_fork_session`)는 `_try_write_registry`를 통해 실패를 `.claude/deep-work-guard-errors.log`에 기록 (기존 조용히 swallow).
-- `session-end.sh` JSONL append: lock 타임아웃 시 `<jsonl>.pending-append.jsonl`에 큐잉. 다음 append는 receipt와 동일한 rename-first crash-safe 패턴 사용. 재시도 10→20회.
+### Changed
 
-**Hooks — 검증 강건화**
-- `phase-guard-core.js`: 내부 에러(잘못된 입력, 런타임 예외)를 `process.exit(3)`으로 구분, 가드 로그 참조 안내가 포함된 JSON block을 stdout에 출력. 의도적 block은 기존대로 exit 0 + `decision=block`. 기존에는 둘 다 exit 2여서 사용자 메시지에서 구분 불가.
-- `phase-guard.sh`: Node exit 3을 hook exit 2 + 디버그 메시지로 변환. stdout의 `decision`이 비어있으면 fail-closed + 별도 메시지 (기존엔 무음 allow).
-- `phase-guard.sh`: state frontmatter에서 `slice_files` / `strict_scope` / `exempt_patterns`를 읽어 (신규 `read_frontmatter_list` 헬퍼 사용) Node 입력에 전달. 기존엔 이 필드들이 한번도 전달되지 않아 `checkSliceScope`가 `undefined`를 받고 항상 `inScope=true`를 반환 → `deep-implement/SKILL.md`의 slice 범위 계약이 무음 미강제.
-- `phase-guard.sh` block 메시지: 4개 heredoc 모두 보간 필드(파일 경로, worktree 경로, phase 라벨, 다음 단계)를 JSON-escape. 따옴표/개행 포함 메시지가 기존엔 invalid JSON을 만들었음.
+- 문서: 7개 SKILL.md 전반의 깨진 참조 링크 21개 수정; 버전 라벨 refresh; CLAUDE.md 구조 목록 완성.
 
-**Hooks — phase-transition injector (C-1)**
-- `file-tracker.sh`가 stdin을 `$PROJECT_ROOT/.claude/.hook-tool-input.<ppid>`에 **phase early-return 이전에** 캐시, `.tmp.$$` + `mv`로 원자적 쓰기. `phase-transition.sh`는 `CLAUDE_TOOL_USE_INPUT` / `CLAUDE_TOOL_INPUT` 환경변수가 unset일 때 (Claude Code 프로덕션의 실제 동작) 이 캐시를 fallback으로 읽음. 초기 v6.2.4 수정 후에도 캐시가 `implement` phase 블록 내부에서만 기록되어 research→plan / plan→implement / test→idle 전환에서는 이전 implement payload가 재사용되거나 no-op. Post-review 수정으로 캐시 쓰기를 hook 최상단으로 이동.
-- `session-end.sh`가 자신의 `.hook-tool-input.$PPID` 및 60분 이상 된 `.hook-tool-input.*` 파일을 정리 — 캐시는 tool call 단위 임시 파일이며 세션 간 축적되면 안 됨.
+### Known limitations
 
-**알림**
-- `notify.sh`: YAML 인식 `notifications.enabled` 파서. 기존 `grep -q "^  enabled: false"`가 관련 없는 `team_mode:\n  enabled: false`를 false-positive로 매칭하여 전 채널 무음 차단.
-- `notify.sh`: `_osascript_escape` 헬퍼를 macOS `osascript` 호출에 적용. 메시지에 따옴표가 포함되면 무음 구문 오류로 알림이 미전달되던 문제 해결.
-- `notify.sh`: `_xml_escape` 헬퍼를 Windows PowerShell toast XML에 적용. `<`, `&`, `"` 문자가 XML을 깨트려 알림이 나타나지 않던 문제 해결.
-- `notify.sh`: `set -euo pipefail`에서 `pipefail` 제거. best-effort 스크립트에서 채널 미설정 시 grep 파이프라인이 비매칭으로 비정상 종료하는 문제 해결.
-
-**문서**
-- 7개 SKILL.md 파일의 `skills/shared/references/` → `../shared/references/` 링크 21건 일괄 수정 (`deep-work-workflow`, `deep-test`, `deep-implement`, `deep-plan`, `deep-research`, `deep-brainstorm`, `deep-work-orchestrator`).
-- `commands/*.md`의 `(v6.2.1)` 라벨 13건을 `(v6.2.4)`로 갱신.
-- `commands/deep-finish.md` 예시: `"deep_work_version": "5.3.0"` → `"6.2.4"` (두 minor 릴리스 동안 고정되어 있었음).
-- `hooks/hooks.json` description: `(v5.6.0 Session Fork)` → `(v6.2.4)`.
-- `skills/deep-work-orchestrator/SKILL.md`: phase 소유권 표의 Test 행 수정 — `/deep-finish` 이후 Test → idle 전환은 Orchestrator가 담당 (Phase Skill 아님).
-- `skills/deep-work-orchestrator/SKILL.md`: `deep-resume.md`가 이미 사용 중이었으나 문서화되지 않았던 `--resume-from=<phase>` 플래그 공식 문서화.
-- `CLAUDE.md`: 누락되었던 디렉터리·파일을 구조에 추가 (`sensors/`, `health/`, `templates/topologies/`, `assumptions.json`, `package.json`).
-
-### 내부
-
-- `hooks/scripts/utils.sh`에 공유 헬퍼 추가, 여러 훅에서 소비:
-  - `_acquire_lock` / `_release_lock`: mkdir 기반 spinlock, 타임아웃 fail-closed (`.claude/deep-work-guard-errors.log`에 기록).
-  - `extract_file_path_from_json`: JSON 파서 기반 file_path 추출. escape된 따옴표를 정확히 처리.
-  - `json_escape`: block 메시지 내 안전한 보간을 위한 JSON 문자열 이스케이프. 인자 필수 — stdin fallback 없음 (훅 hang 방지).
-  - `read_frontmatter_list`: frontmatter의 YAML 리스트 필드(`[a, b]` 또는 `- a` 블록)를 JSON 배열로 반환.
-- `hooks/scripts/utils.sh` `write_registry`: `_acquire_lock` 기반으로 리팩터링, fail-closed 동작으로 변경.
-- 테스트: 329개 (6.2.3의 294개에서), 91 suite. 순증 +35개 — 호환성(3), 입력 파싱 e2e(5), notify YAML/escape(4), receipt race(1, 80 병렬 쓰기 — canonical 완전성 + pending 사이드카 empty + `.draining.*` orphan 없음 검증), phase-guard 강건화(6), phase-transition cache(2), utils 헬퍼(19), post-review 강건화(7: cache-before-phase-check × 4 phase, marker-flip lock × 2, 원자적 캐시 쓰기 × 1).
-- 독립 3-way 리뷰 (Opus + Codex review + Codex adversarial)가 초기 v6.2.4 브랜치에서 critical 3건 + warning 3건을 식별; 모두 merge 전 해결. 리포트: `.deep-review/reports/2026-04-17-implementation-review.md`.
-
-### 알려진 제약
-
-- 크로스 플랫폼 CI matrix는 아직 구성되지 않음. 모든 새 수정은 `node --test` 기반 단위 테스트로 검증되었으나, Linux/Windows 커버리지는 새 portability 로직에 의존 (CI 강제 아님). 다음 릴리스에서 추가 예정.
+- 크로스 플랫폼 CI 매트릭스 미비; 새 portability 수정은 단위 테스트에 의존.
 
 ## [6.2.3] — 2026-04-16
 
-### 변경됨
-- **trigger-eval.json v6.2 업데이트**: 벤치마크 테스트셋을 31개에서 54개로 확장 (true 21 + false 33). v6.2 신규 기능 대응 true 10개 추가 (Session Fork, Mutation Test, Brainstorm, Team Mode, Assumption Engine, Worktree, 영어 쿼리, semantic-only 트리거, Debug). false 13개 추가 (동음이의어, 메타 쿼리, 영어 hard negative, standalone 커맨드). 기존 true 5개를 false로 재분류 (SOLID 리뷰, drift check, deep-status, quality gate 설정, 프리셋 설정) — standalone 커맨드는 full workflow 트리거가 아님.
+### Changed
+
+- `trigger-eval.json` 벤치마크 세트를 31 → 54 샘플로 확장·재조정; standalone 커맨드는 전체 워크플로우 세션을 트리거하지 않도록 재분류.
 
 ## [6.2.2] — 2026-04-16
 
-### 수정됨
-- **크로스 플랫폼 hooks 호환성**: `hooks.json`의 5개 hook command에서 POSIX inline env var assignment(`FOO=bar command`) 문법을 제거. Windows `cmd.exe`에서 이 문법을 파싱하지 못해 모든 hook이 실패하는 문제 해결. 스크립트가 Claude Code의 네이티브 env var(`CLAUDE_TOOL_USE_TOOL_NAME`, `CLAUDE_TOOL_USE_INPUT`)를 직접 읽되 기존 변수명도 fallback으로 유지.
+### Fixed
 
-### 변경됨
-- `hooks/scripts/phase-guard.sh`: `CLAUDE_TOOL_USE_TOOL_NAME` 읽기 + `CLAUDE_TOOL_NAME` fallback
-- `hooks/scripts/file-tracker.sh`: `CLAUDE_TOOL_USE_TOOL_NAME` 읽기 + `CLAUDE_TOOL_NAME` fallback
-- `hooks/scripts/phase-transition.sh`: `CLAUDE_TOOL_USE_INPUT` 읽기 + `CLAUDE_TOOL_INPUT` fallback
+- 5개 hook 커맨드 전부에서 POSIX inline 환경변수 할당 제거(Windows `cmd.exe`가 파싱 불가); 스크립트가 Claude Code의 native 환경변수를 backward-compatible fallback과 함께 직접 읽음.
 
 ## [6.2.1] — 2026-04-15
 
-### 변경됨
-- **커맨드 분류 정리**: `Deprecated in v5.2` 블록을 가진 11개 커맨드와 같은 표에 함께 분류되었던 2개(`deep-brainstorm`, `deep-phase-review`)를 5개 카테고리로 재분류 — Quality Gate(3), Internal(6), Escape hatch(1), Utility(2), Special utility(`/deep-phase-review` 이동).
-- **`/deep-finish` 표현**: "자동 호출이 주 경로이며, test 통과 후 수동 호출도 공식 경로"로 재서술 (deprecated 아님).
-- **Hook/skill 사용자 안내**가 `/deep-status` 플래그로 라우팅:
-  - `hooks/scripts/assumption-engine.js`: `/deep-assumptions` → `/deep-status --assumptions`
-  - `hooks/scripts/session-end.sh`: `/deep-report` → `/deep-status --report`
-  - `skills/deep-test/SKILL.md`: 동일 정렬
-- **Session Report 수동 경로 정책**: `/deep-report`와 `/deep-status --report` **둘 다** 공식 수동 경로로 유지. `skills/deep-work-workflow/SKILL.md` 제목·본문, `commands/deep-report.md` 본문, `commands/deep-resume.md` 본문 3위치 일관 표기.
-- **README**(en/ko): "Deprecated Commands (13)" 단일 표를 5개 카테고리 표로 분리; "What changed" bullets를 재분류 서술로 갱신(deprecated 아님); Worktree Isolation 섹션의 `/deep-cleanup`/`/deep-resume` 본문을 standalone utility로 재서술.
-- **`skills/deep-work-workflow/SKILL.md`** 분류 섹션을 6개 카테고리로 재작성.
+### Changed
 
-### 변경 없음
-- **삭제된 커맨드 없음.** `/deep-cleanup`과 `/deep-resume`은 각각 worktree 스캔/fork 정리, active 세션 선택/worktree 복원/phase dispatch의 유일한 경로로 계속 남습니다. 기능 이관은 follow-up으로 추적.
-- **functional 동작 변경 없음.** 기존 슬래시 커맨드는 모두 이전과 동일하게 동작; 라벨·문구·버전 번호만 변경.
-- 이전 섹션의 `v5.2` deprecated 기록은 역사로 보존.
+- 커맨드 분류 정리: 13개 커맨드를 Quality Gate / Internal / Escape hatch / Utility / Special utility로 재분류; `/deep-finish`를 "자동 호출 우선, 수동 일등급"으로 재구성.
+- Hook/skill 가이드가 `/deep-status` 플래그로 라우팅; README(en/ko)와 워크플로우 문서를 새 카테고리로 업데이트.
+
+### Notes
+
+- 삭제된 커맨드 없음, 기능 동작 변화 없음 — 라벨·문구·버전만 변경.
 
 ## [6.2.0] — 2026-04-14
 
-### 추가
-- **크로스 플러그인 컨텍스트**: Phase 1 Research에서 harnessability-report.json(deep-dashboard)과 evolve-insights.json(deep-evolve)을 참조하여 research context 강화.
+### Added
 
-## v6.1.0
+- Cross-Plugin Context: Phase 1 Research가 `harnessability-report.json`(deep-dashboard)과 `evolve-insights.json`(deep-evolve)을 참조.
 
-### 3-Layer Architecture + Computational Guard
-
-2026-04-12 세션의 Inferential Enforcement 실패 3건(worktree 격리 미적용, team 모드 미적용, codex 미실행)을 구조적으로 해결.
-
-#### 추가
-- **P0 Worktree Path Guard** — PreToolUse hook으로 worktree 외부 Write/Edit/Bash를 hard block. 메타 디렉토리(`.claude/`, `.deep-work/`)는 PROJECT_ROOT 기준으로 예외 처리. 모든 phase에서 session ID 없이도 작동.
-- **P1 Phase Transition Injector** — PostToolUse hook으로 `current_phase` 변경 시 worktree_path, team_mode, cross_model_enabled, tdd_mode를 LLM context에 자동 주입. Cache 파일로 전환 감지, `CLAUDE_TOOL_INPUT` 환경변수로 stdin 안전성 확보.
-- **6개 Phase Skill** — 각 phase별 독립 SKILL.md (brainstorm 120줄, research 183줄, plan 165줄, implement 187줄, test 147줄, orchestrator 230줄). 기존 command 대비 context 로드 45-81% 축소.
-- **Review + Approval Workflow** — Research/Plan 완료 후 6단계 프로토콜: 자동 리뷰 → main 에이전트 판단 → 사용자 승인 → 수정 → 최종 확인. Orchestrator가 current_phase 관리.
-- **`review-approval-workflow.md`** reference — Research/Plan 리뷰 게이트 공유 프로토콜 문서.
-
-#### 변경
-- **Command → Thin Wrapper** — 6개 core phase command를 `Skill()` 호출 1줄로 축소. 모든 wrapper의 `allowed-tools`에 `Skill` 포함.
-- **References 경로 통합** — `skills/deep-work-workflow/references/` → `skills/shared/references/` (14개 파일). 모든 command/skill 경로 업데이트.
-- **`deep-resume` 업데이트** — Research/Plan resume를 orchestrator 경유로 변경 (dead-end 방지). test_passed 시 `/deep-finish`로 라우팅.
-- **`deep-test` phase 전환** — 성공 시 `current_phase: idle` 미설정. Orchestrator/finish가 idle 전환 담당.
-- **Receipt 계약** — `status: "complete"` 필드를 implement receipt에 필수 명시 (deep-test gate 의존).
-- **Drift gate fallback** — `plan_approved_at` fallback 체인: timestamp → plan.md mtime → 24시간 커밋 window.
-- **`cross_model_enabled` 파싱** — nested YAML mapping 지원 (`grep -A3` fallback).
-- **`session-end.sh`** — 세션 종료 시 phase cache 정리 (stale P1 injection 방지).
-
-#### 아키텍처
-```
-Layer 1: Commands (thin wrappers) → Skill dispatch
-Layer 2: Skills (execution logic) → 100-230줄 SKILL.md + 공유 references
-Layer 3: Hooks (enforcement) → P0 hard block + P1 context injection
-```
-
-## v6.0.2
-
-### Phase Review Gate
-- **통합 리뷰 게이트** — 모든 Phase(0-3) 종료 시 셀프 리뷰 + 외부 리뷰 자동 실행. 사용자 확인 후 다음 단계로 전환.
-- **Phase별 Fallback 체인** — Phase 0-2(문서): Structural + Adversarial + Opus 서브에이전트. Phase 3(코드): deep-review → codex/gemini + Opus → 셀프 + Opus.
-- **사용자 확인 UX** — 요약 보기 + 3가지 선택지(자동 수정/현재 진행/상세 보기). 상세 보기에서 항목별 수정/스킵 선택.
-- **Degraded Mode** — 외부 리뷰어 실패 시 자동 fallback.
-- **`/deep-phase-review` 통합** — 수동 리뷰가 자동 게이트와 동일한 Fallback 체인 사용.
-
-### 작업 폴더 이름 변경
-- **세션 폴더 변경** — `deep-work/` → `.deep-work/` (숨김 디렉토리). `.claude/`, `.git/` 등 관례와 일치.
-- **자동 마이그레이션** — 기존 `deep-work/` 폴더는 다음 세션 시작 시 자동 마이그레이션. worktree 안전 체크 포함.
-- **메타데이터 갱신** — state 파일, JSONL 히스토리, fork 메타데이터 경로 일괄 업데이트.
-- **선택적 .gitignore** — 세션 폴더(`.deep-work/20*/`)와 히스토리만 제외, 설정 파일은 유지.
-
-## [6.0.1] - 2026-04-10
-
-### 추가 — Superpowers 강점 통합 (Slice Review, Red Flags, Escalation)
-
-- **Slice Review (Step C-2)**: 센서 파이프라인 이후 슬라이스별 2단계 독립 리뷰. Stage 1 (스펙 준수, required) + Stage 2 (코드 품질, advisory). Subagent 실패 시 graceful degradation.
-- **Red Flags 테이블**: implement (10항목) 및 test (6항목) 단계의 합리화 방지 테이블. Hook 기반 하드 게이트를 소프트 가이던스로 보완.
-- **Pre-flight Check (Step A-2)**: TDD 시작 전 전제조건 검증. `command -v`로 안전한 실행 가능성 확인. 2개 옵션: 계속 진행 (done_with_concerns) 또는 Plan 수정.
-- **Status Reporting**: 슬라이스별 `slice_confidence` (done/done_with_concerns) 및 `concerns` 배열. 리뷰/센서/pre-flight 이력 기반 자동 판정.
-- **Agent delegation prompt 확장**: 위임 에이전트용 규칙 7-10 (self-review, receipt 기록, pre-flight, confidence 판정).
-- **Phase 4 cross-slice + 보완 리뷰**: Section 4-2/4-3을 전체 제어 흐름으로 재작성. Phase 3 FAIL 슬라이스는 필수 보완 대상.
-- **Scope creep 감지**: `git diff --name-only`로 슬라이스 외 파일 변경 탐지.
-- **Per-slice working tree diff**: `git diff $git_before` (커밋이 아닌 working tree 비교).
-- **deep-finish.md concerns 요약**: 세션 리포트에 slice confidence 집계 및 concerns 목록 추가.
-
-### 변경
-
-- Phase 4 Spec Compliance (4-2) 및 Code Quality (4-3) 게이트가 per-slice 검증 대신 cross-slice 일관성 검증으로 전환 (per-slice은 Phase 3에서 수행).
-- Receipt의 `changes.git_diff`가 per-slice baseline (`git diff $git_before -- [files]`)으로 변경.
-- `AskUserQuestion`이 deep-implement.md의 `allowed-tools`에 추가.
-- 버전 참조 6.0.1로 통일 (CLAUDE.md, SKILL.md, package.json, plugin.json).
-
-## [6.0.0] - 2026-04-09
-
-### 추가
-- **Computational Sensor Pipeline (#2)** — 레지스트리 기반 센서 오케스트레이션, TDD 워크플로우 통합:
-  - `sensors/registry.json`: JS, TS, Python, C#, C++ 생태계 정의 (감지 규칙, lint/typecheck/mutation 명령, coverage 플래그)
-  - `sensors/detect.js`: 프로젝트 마커 파일(package.json, tsconfig.json, pyproject.toml 등)에서 자동 생태계 감지
-  - 8개 출력 파서: eslint, tsc, ruff, generic-line, generic-json, stryker, dotnet, clang-tidy
-  - TDD 상태 머신 확장: GREEN 이후 SENSOR_RUN → SENSOR_FIX → SENSOR_CLEAN 상태
-  - 자기 교정 루프: GREEN 후 센서 자동 실행, 센서별 최대 3회 수정
-  - `sensor-trigger.js`: Config/마커 파일 변경 시 생태계 전체 센서 재스캔 트리거
-  - `/deep-sensor-scan`: 독립 실행 computational sensor 스캔 커맨드
-  - 감지 결과 캐싱 (`.sensor-detection-cache.json`)
-  - Fail-closed 정책: non-zero exit + 0 진단 항목 = 명시적 실패
-- **Mutation Testing (#1)** — AI 생성 테스트 품질 검증:
-  - Stryker (JS/TS), stryker-net (C#), mutmut (Python) 통합 (registry.json 기반)
-  - `/deep-mutation-test`: git diff 기반 범위, 자동 테스트 재생성 루프 (최대 3회)
-  - Implement phase 복귀 패턴: Phase 4 mutation 실패 → Phase 3 TDD 루프로 테스트 보강
-  - Mutation Score Quality Gate (Advisory) + Session Quality Score 통합 (15% 가중치)
-  - `stryker-parser.js`: NoCoverage + 로깅 변이에 possibly_equivalent 태깅
-  - Receipt `mutation_testing` 필드: score, survived_details, auto_fix_rounds
-- **Health Engine (#3A)** — Phase 1 Research 자동 Health Check (4개 드리프트 센서 병렬 실행):
-  - `dead-export`: JS/TS 미사용 export 감지 (entry point/라이브러리/barrel 제외, health-ignore.json 지원)
-  - `stale-config`: tsconfig.json, package.json, .eslintrc 깨진 경로 참조 감지
-  - `dependency-vuln`: `npm audit --json` 기반 high/critical 취약점 감지 (Required gate)
-  - `coverage-trend`: 이전 세션 baseline 대비 커버리지 퇴화 감지 (5%p 임계값)
-- **아키텍처 Fitness Function (#4)** — `.deep-review/fitness.json` 선언적 아키텍처 규칙:
-  - 4개 rule checker: `file-metric` (줄 수), `forbidden-pattern` (정규식), `structure` (colocated 테스트), `dependency` (순환 의존성, dep-cruiser)
-  - `fitness-validator.js`: JSON 스키마 검증 + 규칙 실행 엔진 (`required_missing` 상태)
-  - `fitness-generator.js`: Ecosystem-aware 자동 생성 (비 JS/TS에서 dependency 규칙 제외)
-  - dep-cruiser 미설치 시 설명 + 설치 제안
-- **Health Check 오케스트레이터** (`health-check.js`) — 병렬 드리프트 스캔 (Promise.allSettled) + 순차 fitness 검증 (센서별 타임아웃, 전체 180초)
-- **Baseline 관리** — `health-baseline.json` commit/branch 스코핑, 브랜치 전환/rebase(git merge-base --is-ancestor)/7일 만료 시 자동 무효화
-- **Phase 4 Quality Gates**:
-  - Fitness Delta Gate (Advisory) — 이번 구현에서 추가된 fitness 위반 감지
-  - Health Required Gate (Required) — Phase 1 required 실패 전파 + 유저 acknowledge 흐름
-  - Phase 4 Baseline 갱신 — 게이트 통과 후 health-baseline.json 자동 업데이트
-- **Receipt 스키마 확장** — `health_report` 필드 + `scan_commit` (deep-review stale 판정용)
-- **deep-review 연동** — fitness.json을 리뷰 에이전트 프롬프트에 주입 + receipt health_report scan_commit 기반 stale 체크
-- **Harness Templates (#5)**: 6개 내장 토폴로지(nextjs-app, react-spa, express-api, python-web, python-lib, generic)를 갖춘 토폴로지 감지 레이어. deep merge 및 custom/ override 지원 템플릿 로더. Phase 1/3에 토폴로지별 가이드 통합. Fitness generator에 template fitness_defaults 확장.
-- **Self-Correction Loop (#6)**: always-on 레이어(토폴로지 가이드)와 fitness 레이어(fitness.json 규칙)를 갖춘 review-check 센서. 센서별 독립 3회 교정 제한. 설정 비활성화 지원. Receipt 스키마 확장.
-
-### 변경
-- 세션 품질 점수 5가지 가중치 (테스트 통과율 25%, 재작업 사이클 20%, Plan Fidelity 25%, 센서 클린율 15%, Mutation Score 15%). Health Check은 점수에서 제외.
-- `sensors/registry.json` — javascript/typescript에 `audit` 필드 추가
-
-## [5.8.1] - 2026-04-08
-
-### 변경
-- **Breaking**: `/deep-review` → `/deep-phase-review`로 리네이밍. deep-review 플러그인(deep-suite)과의 이름 충돌 해소. Phase 문서 리뷰는 `/deep-phase-review`, 코드 diff 리뷰는 deep-review 플러그인 사용.
-- `deep-plan.md`, `deep-resume.md`, `README.md`, `README.ko.md` 참조 업데이트
-- deep-review 플러그인 연동(Sprint Contract, 슬라이스 리뷰, 전체 리뷰)은 변경 없음
-
-## [5.8.0] - 2026-04-08
-
-### 추가
-- **Completeness Policy** (Section 3.3-1) — plan.md의 명시적 금지 패턴 정의 (TBD, TODO, 모호한 지시, 컨텍스트 없는 교차 참조). Claude 자체 재검토 + structural review `code_completeness` 차원으로 강제.
-- **Code sketch 크기별 완성도** — S: 주석 의사코드, M: 실제 함수 시그니처 + 타입 정의, L: 경계면 완전 코드 (인터페이스, API, 테스트). 기존 "의사코드 또는 실제 코드"를 비례 기준으로 대체.
-- **Slice 필드: `expected_output`, `steps`** — `expected_output`: verification_cmd 성공 시 예상 출력. `steps`: M/L slice 내 실행 가이드 (3-12개 번호 액션). 하위 호환성을 위해 모두 optional.
-- **`failing_test` 크기별 상세도** — S: 파일+설명, M: 함수 시그니처+핵심 assertion, L: 경계면 테스트 완전 본문.
-- **"Boundary: Files NOT to Modify"** 섹션 — plan 템플릿에 추가, 구현 중 scope creep 방지.
-- **Research 추적성 태그** — `[RF-NNN]` (Key Findings), `[RA-NNN]` (인터페이스/시그니처). plan Architecture Decision에서 구체적 연구 근거 참조 가능.
-- **Research 태그 Lifecycle 규칙** — 단조 증가 번호, incremental 보존, plan 참조 태그 삭제 경고.
-- **Research `Testing Patterns` 섹션** — 기존 테스트 프레임워크, assertion 스타일, 파일 명명 규칙 문서화.
-- **Brainstorm 맥락 적응형 질문** — Core 2개 + 맥락별 1-3개 (기능/리팩토링/버그/성능/통합) + 마무리 경계 질문.
-- **Brainstorm `Scope Assessment`** — 분해 점검 + 빠른 코드베이스 확인 후 접근법 비교.
-- **Brainstorm `Boundaries` 섹션** — 변경하지 않는 부분 명시, plan Boundary 섹션으로 전달.
-- **Review gate 차원: `code_completeness`, `buildability`** — 4곳 동기화 (structural 테이블, 하드코딩, cross-model Plan Rubric, JSON 스키마).
-- **Review gate 하위 호환성 fallback** — `expected_output`/`steps` 없는 기존 plan은 차원별 완화 기준으로 평가.
-
-### 변경
-- `deep-implement.md` slice 파서가 `expected_output`, `steps`, `contract`, `acceptance_threshold` 인식 (모두 optional).
-- Step B-1 (RED): `failing_test`에 테스트 코드가 있으면 직접 사용 (M/L).
-- Step B-2 (GREEN): `expected_output`이 있으면 verification_cmd 출력과 비교.
-- `deep-work.md` 인라인 plan: `failing_test` 표현 변경 + Completeness Policy 제외 주석.
-- `research-guide.md` quality criteria 4→8개 확장.
-- `plan-templates.md` API Endpoint 템플릿을 v5.8 exemplar로 업그레이드. 레거시 템플릿에 마이그레이션 가이드 추가.
-- `testability` 차원: `expected_output`은 권장, 필수 아님으로 명확화.
-
-## [5.7.0] - 2026-04-08
-
-### 추가
-- **W1: Sprint Contract 생성** — Phase 2 plan 승인 후, deep-review 플러그인이 설치되어 있으면 plan.md의 슬라이스에서 `.deep-review/contracts/SLICE-{NNN}.yaml` 자동 생성
-- **W2-a: 슬라이스 리뷰 제안** — Phase 3에서 슬라이스 GREEN 도달 시 `/deep-review --contract SLICE-{NNN}` 실행 제안
-- **W2-b: 전체 리뷰 제안** — Phase 4 진입 시 `/deep-review` 전체 리뷰 실행 제안
-- **K1: 위키 ingest 제안** — Phase 4 완료 후 `/wiki-ingest report.md` 실행 제안
-
-### 변경
-- Sprint Contract 생성 시점을 plan 작성 직후에서 **plan 승인 후**로 이동 (최종 plan과 contract 일치 보장)
-- 플러그인 감지를 cache + plugins 이중 경로로 통일 (설치 방식 무관)
-
-## [5.6.0] - 2026-04-07
-
-### 추가
-- **`/deep-fork` 커맨드**: deep-work 세션을 fork하여 다른 접근법을 탐색하면서 원래 세션을 보존
-  - Git 환경: worktree 기반 전체 복제, dirty 상태 검증 (`git stash --include-untracked`), session ID 기반 branch suffix (race condition 방지), worktree 컨텍스트 자동 전환 (`FORK_PROJECT_ROOT`)
-  - Non-git 환경: 산출물만 복제, plan phase 제한 (implement/test는 phase guard가 차단)
-  - 부모-자식 관계 추적: 상태 파일의 `fork_info`/`fork_children`
-  - `fork-snapshot.yaml`: fork 시점 상태 스냅샷 (비교 기준점)
-  - Stale 부모 검증 (git: commit 존재 확인, non-git: 작업 디렉토리 존재 확인)
-  - Fork 세대 제한: 최대 3세대, 초과 시 경고
-- **`/deep-status --tree`**: fork 관계 트리 시각화 (UTF-8 트리 문자)
-- **`/deep-status --compare` 자동 감지**: 인자 없이 호출 시 fork 관계 자동 감지 비교
-- **`/deep-status` fork 정보 표시**: 기본 출력에 `fork_info`/`fork_children` 표시
-- **`/deep-cleanup` fork 지원**: idle fork 세션 스캔, 부모+자식 전체 idle 시 일괄 정리 제안
-- **Phase guard**: artifacts-only fork 세션의 implement/test phase 차단
-- **Fork 유틸 함수**: `validate_fork_target`, `get_fork_generation`, `update_parent_fork_children`, `register_fork_session` (원자적 레지스트리 + 부모 업데이트)
-- **`session-end.sh`**: fork 세션 종료 시 부모의 `fork_children` 상태를 idle로 업데이트
-- **Fork 통합 테스트**: 원자적 등록, 다중 fork, phase-guard 통합, edge cases, git worktree fork 등 18개 테스트
-
-### 변경
-- `deep-work-sessions.json` 레지스트리: 세션별 `fork_parent`, `fork_generation` 필드 추가
-- 상태 파일 YAML frontmatter: `fork_info` (부모 관계), `fork_children` (자식 목록) 섹션 추가
-
-## [5.5.2] - 2026-04-06
-
-### 추가
-- **확장된 bash 파일 쓰기 감지**: 20+ 신규 FILE_WRITE_PATTERNS — perl in-place (`perl -pi -e`), 런타임 언어 쓰기 (node -e `fs.writeFileSync`, python -c `open().write()`, ruby -e `File.write`), awk in-place, swift, truncate, sponge, git 파괴 연산 (`reset --hard`, `clean -f`), curl/wget 출력, ln, tar/unzip/cpio 추출, rsync, 범용 `writeFile` 감지.
-- **확장된 safe command 패턴**: docker/kubectl 읽기 전용, cargo build/check/bench, go build/vet, deno test/check, bun run/x, python unittest, tsc --noEmit, stat/du/df/free/uname/hostname, diff/file, env/printenv, rmdir.
-- **확장된 테스트 파일 패턴**: Dart (`.test.dart`, `_test.dart`), Elixir (`_test.exs`), Lua (`.test.lua`), Vue (`.test.vue`), `fixtures/`, `__fixtures__/`, `__mocks__/`, `spec/` 디렉토리.
-- **확장된 TDD exempt 패턴**: `.toml`, `.ini`, `.cfg`, `.lock`, `.editorconfig`, `.svg`, `.png`, `.jpg`, `.gif`.
-- **TDD state 검증**: 알 수 없는 TDD 상태값을 processHook에서 차단하고 안내 메시지 제공.
-- **Backtick 및 subshell 처리**: `splitCommands`가 backtick 인용과 `$()` subshell 깊이를 추적하여 중첩 표현식 내부의 잘못된 분할 방지.
-- **Perl 타겟 파일 추출**: `extractBashTargetFile`이 `perl -pi -e` 명령에서 타겟 파일을 추출하여 정확한 TDD 적용.
-
-### 수정
-- **보안: file-write-first 감지 순서**: FILE_WRITE_PATTERNS를 SAFE_COMMAND_PATTERNS보다 먼저 검사하여, safe 패턴이 파일 쓰기를 은폐하는 것을 방지 (예: `node -e`의 `fs.writeFileSync` 우회 차단).
-- **file-tracker.sh Node.js 25 argv 호환성**: Node.js 25에서 `[eval]` 마커가 제거되어 receipt 생성이 무음 실패하던 문제 수정. `process.argv.filter(a => a !== '[eval]')`로 크로스 버전 호환.
-- **assumption-engine.js quality-timeline CLI**: 파싱된 `parsed` 객체 대신 raw `input` 문자열을 참조하던 버그 수정.
-- **assumption-engine.js evalSignal threshold 전달**: 시그널 평가자의 `threshold` 필드가 `fn()`에 올바르게 전달되도록 수정.
-- **assumption-engine.js readHistory dedup 순서**: `session_id` 중복 시 first→latest로 변경하여 finalized 레코드가 무시되는 문제 해결.
-- **assumption-engine.js 입력 가드**: `isSessionDuplicate`, `detectStaleness`, `detectNewModel`, `generateReport`에 `Array.isArray` 검사 추가.
-- **session-end.sh JSON 검증**: JSONL append 전 JSON 유효성 검증으로 malformed entry 방지.
-- **session-end.sh session ID fallback**: state file에 `started_at` 누락 시 `DEEP_WORK_SESSION_ID` 환경변수로 폴백.
-- **session-end.sh 에러 로깅**: 에러를 `/dev/null` 대신 `.claude/deep-work-guard-errors.log`에 기록.
-- **phase-guard.sh 에러 로깅**: Node.js 에러를 `.claude/deep-work-guard-errors.log`에 기록.
-- **utils.sh matchGlob trailing slash**: 정확한 경로 비교에서 trailing slash 정규화.
-- **utils.sh session pointer 안전성**: 세션 포인터 파일 쓰기 전 `mkdir -p` 추가.
-- **utils.sh session ID 생성**: `/dev/urandom` hex 생성에서 탭 문자 제거.
-
-### 변경
-- **Redirect 감지 범위 확대**: 일반 출력 리다이렉트 패턴을 `(?:^|\|)` 접두사에서 `(?:^|[|;]|\s)`로 변경하여 명령 중간 리다이렉트 감지 (예: `cat << EOF > file`).
-- **`node -e` safe 패턴 제거**: 이전에 safe로 처리되던 `node -e`를 다른 명령과 동일하게 file-write 패턴으로 평가.
-- **모델 이름 살균**: `validateModelName`이 비알파벳 문자 제거; `lookupModel`에 `toString().trim()` 추가.
-- **시그널 평가 threshold 설정 가능**: 평가자 정의의 `threshold` 필드로 설정 가능 (이전: 하드코딩된 기본 파라미터).
-- **광범위 리다이렉트 패턴**: 명령 중간 리다이렉트 (heredoc, 공백 후) 올바르게 감지.
-
-## [5.5.1] - 2026-04-03
-
-### 변경
-- **Plan 단계 team research 교차 검증**: `team_mode: team`일 때 plan 단계에서 부분 리서치 파일(`research-architecture.md`, `research-patterns.md`, `research-dependencies.md`)을 보조 참조로 로드. Claude 자체 재검토(Section 3.4.5)에서 합성 과정 누락 세부 사항을 교차 확인하여 plan 정확도 향상.
-- **TDD state 업데이트 필수화**: `deep-implement.md`의 B-1 (RED_VERIFIED), B-2 (GREEN) state file 업데이트를 필수로 표시하고 phase guard 차단 경고 추가.
-
-### 수정
-- **phase-guard.sh 입력 파싱 안정화**: JSON 입력 빌드를 `process.argv`에서 stdin pipe 방식으로 변경하여 대용량 tool input에서 `set -e` 실패 방지.
-
-## [5.5.0] - 2026-04-02
-
-### 추가
-- **Research Cross-Model Review**: codex/gemini adversarial review가 research 단계에도 적용 (기존: plan만 해당). Research 전용 rubric 사용 (completeness, accuracy, relevance, risk_identification, actionability).
-- **Plan Claude 자체 재검토**: plan 작성 직후 자동 품질 점검 — placeholder, 내부 일관성, research 정합성, scope creep, 누락된 rollback 커버리지 탐색. 명백한 결함은 structural review 전에 자동 수정.
-- **종합 판단 프로토콜**: 개별 conflict AskUserQuestion을 Claude 종합 판단 + 사용자 일괄 확인으로 대체. Research와 plan cross-model review 양쪽에 적용.
-- **Auto-fix 스냅샷 계약**: 매 auto-fix 반복 전 스냅샷 필수, score 하락 시 rollback. Research: `research.v{N}.md`, Plan: `plan.autofix-v{N}.md`.
-- **Degraded Mode**: cross-model 리뷰어 실패 시 `reviewer_status` 필드로 명시적 추적. Consensus/conflict 분류는 2개 이상 성공한 리뷰어 필요; 단독 결과는 "단독 이슈"로만 분류.
-- **State 스키마 마이그레이션 (v5.5)**: 신규 필드 `review_results.{phase}.judgments`, `judgments_timestamp`, `reviewer_status`. 기존 state file 자동 초기화. Resume 시 문서 수정 시각 vs judgments_timestamp 비교 검증.
-
-### 변경
-- **Structural Review 기준 강화**: auto-fix 트리거를 score < 5에서 score < 7로 상향 (research, plan 양쪽). Research max iterations 3으로 증가.
-- **Research 사용자 피드백 게이트**: 종합 판단 단계(Step 4.7)에 통합. Step 5와 auto-flow Step 9-3의 중복 AskUserQuestion 제거.
-- **deep-review.md**: 개별 conflict UX 대신 종합 판단 프로토콜 사용으로 업데이트.
-- **deep-resume.md**: `review_state: in_progress`로 resume 시 judgments_timestamp 검증 기반 새 리뷰 흐름으로 라우팅.
-
-## [5.3.0] - 2026-03-31
-
-### 추가
-- **Document Intelligence**: research.md/plan.md 피드백 적용 시 자동 중복 제거 및 정리. 3단계 프로토콜: Apply → Deduplicate → Prune. Refinement log 추적.
-- **Session Relevance Detection**: 피드백 적용 전 범위 확인 — 현재 세션 범위 밖 요청 감지 시 새 세션 분리 또는 백로그(`deep-work/backlog.md`) 저장 제안.
-- **Plan Fidelity Score**: 구현 vs 플랜 충실도를 0-100 점수로 산출. drift-check 및 deep-test 인라인 검증에 통합.
-- **Session Quality Score**: 세션 완료 시 자동 품질 점수(0-100) 산출. Core 지표: Test Pass Rate(35%), Rework Cycles(30%), Plan Fidelity(35%). 진단 지표(Code Efficiency, Phase Balance)는 참고용으로만 표시.
-- **Assumption Snapshot**: 세션 시작 시 각 assumption의 enforcement level 기록. 정확한 active/inactive cohort 분석 가능.
-- **Assumption Engine 품질 연동**: 품질 점수를 assumption 평가에 반영. Cohort 분석(cohort당 최소 3세션 게이트). `/deep-status --assumptions`에서 Quality Impact 표시.
-- **Cross-Session Quality Trend**: 세션 간 품질 점수 추이를 ASCII 차트로 시각화. `/deep-status --history`에서 확인.
-- **Quality Badge**: README용 shields.io 뱃지 생성. `/deep-status --badge`에서 사용. 뱃지: 품질 점수, 세션 수, 플랜 충실도.
-- **Authoritative JSONL write**: `deep-finish`가 `harness-sessions.jsonl`에 atomic upsert(lock 패턴)로 확정 기록. `session-end.sh`는 provisional 레코드만 기록.
-
-### 수정
-- **JSONL 경로**: `session-end.sh`가 per-session 폴더 대신 공유 `deep-work/harness-history/`에 기록하도록 수정. trend/assumption 커맨드에서 세션 데이터가 보이지 않던 버그 해결.
-
-### 변경
-- **README 개편**: 데모 GIF 삭제. 문제→해결 중심 서술 구조로 전환. 품질 측정 및 자기 진화 규칙 섹션 추가.
-- **exportBadge()**: 단일 뱃지 대신 `{ harness, quality, sessions, fidelity }` 객체 반환. 직접 소비자에 대한 breaking change — 테스트 업데이트 완료.
-- **hooks.json**: 설명을 "v5.3 Precision + Evidence Protocol"로 업데이트.
-
-## [5.2.0] - 2026-03-31
-
-### 추가
-- **Auto-flow 오케스트레이션**: `/deep-work`이 이제 모든 단계를 자동으로 연결 (brainstorm → research → plan → implement → test → finish). Plan 승인만이 유일한 필수 인터랙션
-- **통합 `/deep-status`**: `--receipts`, `--history`, `--report`, `--assumptions`, `--all` 플래그로 5개 개별 커맨드를 하나로 통합
-- **테스트 게이트 자동 실행**: Drift Check (필수), SOLID Review (권고), Insight Analysis가 Quality Gates 테이블 설정 없이 `/deep-test`에서 자동 실행
-
-### 변경
-- 13개 보조 커맨드에 deprecated 표시 추가 (여전히 동작, deprecation notice 추가)
-- `/deep-work` Step 1: 세션 감지 시 이어서/새로/취소 선택지 제공 (기존: 덮어쓰기 경고만)
-- `/deep-test`: plan.md의 Quality Gates 테이블이 이제 선택적 오버라이드 (자동 감지가 기본)
-- `phase-guard-core.js`: TDD 차단 메시지에 auto-flow 대안 안내 추가
-- SKILL.md 461줄 → ~250줄로 축소 (버전별 히스토리 섹션 제거)
-- plugin.json 키워드 36개 → 12개로 축소
-
-### Deprecated
-- `/deep-brainstorm` — `/deep-work` 흐름에서 자동 실행
-- `/deep-review` — `/deep-plan`에서 자동 실행
-- `/deep-receipt` — `/deep-status --receipts` 사용
-- `/deep-slice` — `/deep-implement`에서 자동 관리
-- `/deep-insight` — `/deep-test`에서 자동 실행
-- `/deep-finish` — `/deep-work` 흐름 끝에서 자동 실행
-- `/deep-cleanup` — `/deep-work` init 시 자동 감지
-- `/deep-history` — `/deep-status --history` 사용
-- `/deep-assumptions` — `/deep-status --assumptions` 사용
-- `/deep-resume` — `/deep-work` init 시 자동 감지
-- `/deep-report` — `/deep-status --report` 사용
-- `/drift-check` — `/deep-test`에서 자동 실행
-- `/solid-review` — `/deep-test`에서 자동 실행
-
-## [5.1.2] - 2026-03-30
-
-### 추가
-- **Team 모드 자동 설정**: Team 모드 선택 시 환경변수가 미설정이면 수동 안내 대신 Claude Code가 자동으로 `~/.claude/settings.json` 설정을 제안
-- **Team 모드 런타임 검증**: 모든 단계(research, plan, implement)에서 `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` 환경변수를 재검증, 비활성화 시 자동 Solo fallback
-
-### 수정
-- **Team 모드 Solo fallback**: 설정 미완료 시 초기화 단계뿐 아니라 전 단계에서 안정적으로 Solo 모드로 전환
-
-## [5.1.1] - 2026-03-30
-
-### 수정
-- **CRITICAL: Phase guard fail-closed** — `phase-guard-core.js`의 catch 블록이 내부 오류 시 allow 대신 block을 반환하도록 변경, TDD/단계 강제 우회 방지
-- **CRITICAL: Receipt 원자적 쓰기** — Receipt JSON 업데이트가 temp 파일 + rename 패턴을 사용하여 동시 PostToolUse 훅의 데이터 손상 방지
-- **HIGH: 명령어 체인 우회** — `detectBashFileWrite`가 체인된 명령어(`&&`, `||`, `;`, `|`)를 분리하여 각 하위 명령어를 독립 검증; safe prefix가 file-write suffix를 가리지 않음
-- **HIGH: Bash TDD 대상 추출** — 새 `extractBashTargetFile()` 함수가 bash 명령어에서 실제 대상 파일을 추출하여 전체 명령어 문자열 대신 정확한 test/exempt 패턴 매칭
-- **HIGH: Skipped phases 정확한 매칭** — 서브스트링 매칭을 쉼표 구분 정확 매칭으로 교체하여 오탐 방지
-- **HIGH: Write/Edit file_path 미추출 시 차단** — 파일 경로를 추출할 수 없을 때 allow 대신 block으로 변경
-- **MEDIUM: JSONL 히스토리 잠금** — `session-end.sh`가 동시 JSONL append에 mkdir 기반 잠금 사용
-- **MEDIUM: 크로스 플랫폼 타임스탬프 파싱** — 기간 계산을 Node.js `Date.parse`로 교체 (macOS/GNU date 분기 제거)
-- **MEDIUM: 알림 JSON 이스케이프** — 웹훅 페이로드가 `JSON.stringify`로 줄바꿈/유니코드 정상 이스케이프
-- **MEDIUM: 경로 정규화** — `normalize_path`가 `..` 세그먼트를 `path.resolve`로 해결
-- **MEDIUM: YAML 필드 추출** — `read_frontmatter_field`가 regex 인젝션 대신 리터럴 prefix 매칭 사용
-- **MEDIUM: Receipt 초기 생성** — Heredoc을 `JSON.stringify`로 교체하여 slice ID 인젝션 방지
-
-### 변경
-- Assumption engine의 `SIGNAL_EVALUATORS`가 `{ scope, fn }` 형식 사용; session-scoped 신호는 세션당 1회, slice-scoped 신호는 any-true 집계
-- `TEST_FILE_PATTERNS`에 Rust, Java, C#, Kotlin, Swift 패턴 추가
-- phase-guard-core.js에 `splitCommands`, `extractBashTargetFile` 새 export 추가
-
-## [5.1.0] - 2026-03-30
-
-### 추가
-- **자동 루프 검증**: Plan 리뷰와 테스트 단계에서 실패 시 자동 수정 + 재검증 (최대 3회)
-- **계약 협상**: Slice에 테스트 가능한 `contract`와 `acceptance_threshold` 필드 추가
-- **Assumption Engine 자동 적용**: 세션 시작 시 Wilson Score 기반 규칙 자동 조정
-- **적응형 Evaluator 모델**: 모든 검증 subagent가 설정 가능한 모델 사용 (기본: sonnet), Assumption Engine으로 자동 조정
-- **Phase 스킵 유연화**: `--skip-to-implement` 플래그, 인라인 slice 생성
-- **양방향 조정**: Assumption Engine이 증거 기반으로 규칙 강화도 자동 수행
-
-### 변경
-- Structural review가 실패 시 자동으로 수정 루프 실행 (최대 3회)
-- 테스트 단계가 실패 slice만 대상으로 자동 implement 복귀
-- Assumption health 보고서에 현재 세션의 자동 조정 내역 표시
-- Slice 형식에 `contract`와 `acceptance_threshold` 필드 추가
-- 기본 evaluator 모델이 haiku에서 sonnet으로 변경
-
-### 수정
-- Assumption Engine 보고서의 "Auto-application is a Phase 2 feature" 문구 제거
-
-## [5.0.0] - 2026-03-30
-
-### 추가
-- **Self-Evolving Harness (Assumption Engine)**: 모든 enforcement 규칙이 이제 machine-readable evidence signal을 가진 falsifiable hypothesis. deep-work가 세션 데이터로 자체 가설을 검증.
-- **`assumptions.json`**: 5개 핵심 가설 레지스트리 (phase_guard, tdd, research, cross_model_review, receipt_collection). evidence signal, 조절 가능한 enforcement 레벨, 최소 세션 임계값 포함.
-- **`assumption-engine.js`**: Wilson Score confidence, 모델별 분할, staleness 감지, 새 모델 감지, per-slice signal 평가, 리포트 생성, ASCII 타임라인, shields.io 배지 내보내기. 42개 단위 테스트.
-- **`/deep-assumptions` 커맨드**: report (기본 + --verbose), history (ASCII 타임라인), export (--format=badge), --rebuild (receipts에서 JSONL 재생성).
-- **Receipt의 `harness_metadata`**: slice별 메타데이터 (model_id, assumption_overrides, rework_count, tests_passed_first_try 등). 하위 호환.
-- **세션 히스토리 JSONL**: Stop hook에서 `harness-sessions.jsonl` append. per-slice 데이터, 세션 중복 방지, 크로스 플랫폼 날짜 계산.
-- **세션 초기화 시 건강도 요약**: `/deep-work`에서 충분한 히스토리가 있으면 가설 건강도 표시. 새 모델 감지 시 cold start 경고.
-- **리포트의 Assumption Health**: `/deep-report`에 confidence 테이블과 세션별 harness metadata 집계 포함.
-
-## [4.2.1] - 2026-03-26
-
-### 추가
-- **TDD Override**: 구현 중 TDD가 production 파일 수정을 차단하면, Claude가 차단 이유를 설명하고 사용자에게 대화형으로 선택지를 제공 — 테스트 먼저 작성(권장), 또는 사유와 함께 이 slice의 TDD 건너뛰기(config 변경, 테스트 불가, 긴급 수정). Override는 slice 범위로 제한되며 slice 전환 시 자동 해제.
-- **차단 메시지에 탈출구 안내**: strict/coaching 모드의 TDD 차단 메시지에 `/deep-slice spike`, `/deep-slice reset` 대안을 표시하여 사용자가 우회 방법을 즉시 알 수 있도록 개선.
-- **`tdd_override` 상태 필드**: 어떤 slice에 TDD override가 활성화되어 있는지 추적. Hook이 이 필드를 읽어 fast-path 허용 결정.
-- **Receipt에 override 기록**: Override된 slice는 receipt JSON에 `tdd_override: true`와 `tdd_override_reason`으로 기록. Receipt 대시보드에서 `override` 상태를 `spike`와 구분하여 표시 (merge 가능 + 경고).
-- 9개 새 unit test 추가 (총 56개)
-
-### 변경
-- `phase-guard-core.js`: `checkTddEnforcement`에 `tddOverride` 파라미터 추가; `processHook`에서 `state.tdd_override` 전달
-- `phase-guard.sh`: state 파일에서 `tdd_override` 읽기; active slice와 일치하는 override에 대한 fast-path 추가; Node.js에 override 전달
-- `deep-implement.md`: "TDD Override" 섹션 추가 (AskUserQuestion 흐름, main 모델 라우팅만 적용)
-- `deep-receipt.md`: Override 아이콘, 카운트, JSON 스키마 업데이트
-- `deep-finish.md`: `tdd_compliance`에 `override` 카운트 포함
-- `deep-history.md`: `tdd_compliance` 및 TDD 준수율 표시에 `override` 포함
-
-## [4.2.0] - 2026-03-25
-
-### 추가
-- **구조적 리뷰(Structural Review)**: 모든 페이즈 문서(brainstorm, research, plan)가 Claude haiku 서브에이전트를 통해 페이즈별 차원으로 구조적 리뷰를 받음
-- **적대적 크로스 모델 리뷰(Adversarial Review)**: Plan 문서가 codex 및/또는 gemini-cli에 의해 독립적으로 리뷰됨 (아키텍처, 가정, 리스크 커버리지)
-- **갈등 해결 UX**: 모델 간 의견이 다를 때 갈등을 투명하게 표시하고 사용자가 해결 방식을 결정 (수용, 면책, 수동 편집)
-- **리뷰 게이트**: 구조적 리뷰 점수 <5 또는 비판적 합의 이슈가 있으면 자동 구현 전환 차단
-- **`/deep-review` 커맨드**: 구조적 또는 적대적 리뷰를 언제든 수동 트리거
-- **`--skip-review` 플래그**: spike/실험 세션에서 모든 리뷰 건너뛰기
-- **크로스 모델 도구 자동 감지**: 세션 초기화 시 codex/gemini-cli 자동 감지
-- **프로필 `cross_model_preference`**: 프리셋에 크로스 모델 선호 저장 (항상/안함/매번 확인)
-- **리뷰 상태 resume/status 통합**: `/deep-resume`이 리뷰 상태를 인식; `/deep-status`가 리뷰 결과 표시
-- **JSON 스키마 정규화**: 모든 리뷰 결과가 구조화된 JSON으로 저장 (`{phase}-review.json`)
-
-### 변경
-- `deep-brainstorm.md`: 기존 spec review를 review-gate 프로토콜 참조로 교체
-- `deep-research.md`: 리서치 완료 후 구조적 리뷰 추가
-- `deep-plan.md`: 승인 전 구조적 + 적대적 리뷰 추가
-- `phase-guard-core.js`: SAFE_COMMAND_PATTERNS에 codex/gemini/mktemp 추가
-- State 파일: `review_state`, `cross_model_tools`, `cross_model_enabled`, `review_results` 필드 추가
-- 프로필: 프리셋 스키마에 `cross_model_preference` 추가
-
-### 수정
-- `.gitignore`: `deep-work-workflow-workspace/` 추가하여 venv 추적 방지
-
-## [4.1.0] - 2026-03-25
+## [6.1.0]
 
 ### Added
-- **Worktree 격리**: 세션이 기본적으로 격리된 git worktree에서 실행됩니다. `/deep-work` 시 `.worktrees/dw/<slug>/`에 worktree를 생성하여 main 브랜치를 보호합니다. `--no-branch` 또는 프리셋의 `git_branch: false`로 비활성화 가능.
-- **슬라이스 복잡도 기반 모델 자동 선택**: 구현 단계에서 각 슬라이스의 크기(S/M/L/XL)에 따라 최적 모델(haiku/sonnet/opus)을 자동 선택합니다. `/deep-slice model SLICE-NNN <모델>`로 슬라이스별 override 가능. 프리셋에서 routing_table 커스터마이즈 가능.
-- **세션 완료 워크플로우** (`/deep-finish`): 세션 종료 시 4가지 옵션 제공 — 베이스 브랜치로 병합, PR 생성, 브랜치 유지, 삭제. `session-receipt.json`으로 전체 세션 요약 생성.
-- **CI/CD receipt 검증**: `validate-receipt.sh`로 receipt 체인 무결성 검증. `templates/deep-work-ci.yml`로 GitHub Actions 워크플로우 템플릿 제공. `/deep-receipt export --format=ci`로 CI 친화적 번들 내보내기.
-- **세션 이력 대시보드** (`/deep-history`): 과거 세션들의 모델 사용량, TDD 준수율, 완료율, 비용 추적 등 크로스 세션 트렌드 표시.
-- **Worktree 정리** (`/deep-cleanup`): 7일 이상 된 비활성 deep-work worktree를 스캔하고 일괄/개별 삭제 옵션 제공.
-- **Receipt 스키마 v1.0**: 새 필드 — `schema_version`, `model_used`, `model_auto_selected`, `worktree_branch`, `git_before`, `git_after`, `estimated_cost`. Session receipt은 파생 캐시이며 slice receipt이 정본.
-- **Receipt 마이그레이션 헬퍼** (`receipt-migration.js`): v4.1 이전 receipt을 스키마 v1.0으로 자동 변환. atomic write 및 손상 파일 백업 지원.
-- **Worktree 인식 세션 재개** (`/deep-resume`): 세션 재개 시 worktree 경로를 감지하고 작업 디렉토리 컨텍스트를 복원. 삭제된 worktree도 우아하게 처리.
-- **모델 비용 추적**: slice 및 session receipt에 `estimated_cost` 필드로 세션별 AI 모델 사용 비용 가시성 제공.
-- **Shell 유틸리티 추출** (`utils.sh`): 3개 hook 스크립트의 공통 함수를 단일 소스 파일로 추출하여 코드 중복 제거.
-- **모델 라우팅 테스트**: 라우팅 테이블 조회, 모델 이름 검증, 커스텀 테이블 override에 대한 11개 새 유닛 테스트 추가 (총 48개 테스트).
+
+- **P0 Worktree Path Guard** — 활성 worktree 외부의 Write/Edit/Bash를 hard-block하는 PreToolUse hook(meta 디렉토리 예외), 모든 phase에 적용.
+- **P1 Phase Transition Injector** — `current_phase` 변경 시 worktree/team/cross-model/tdd context를 주입하는 PostToolUse hook.
+- 6개 phase skill(phase별 독립 SKILL.md)로 context load 45-81% 감소.
+- Review + Approval workflow — Research/Plan용 6단계 프로토콜, orchestrator가 `current_phase` 소유.
 
 ### Changed
-- 기본 `model_routing.implement`가 `"sonnet"`에서 `"auto"` (크기 기반 라우팅)로 변경
-- 프리셋의 기본 `git_branch`가 `true`로 변경 (worktree 격리 기본 활성화)
-- `session-end.sh`가 worktree 브랜치 정보를 표시하고 `/deep-finish` 사용을 안내
-- `validate-receipt.sh`가 macOS Bash 3.2 호환을 위해 `set -eo pipefail` 사용
 
-## [4.0.1] - 2026-03-25
+- 핵심 phase 커맨드를 thin `Skill()` dispatch wrapper로 축소; 공유 참조를 `skills/shared/references/`로 이전.
+- `deep-resume`이 Research/Plan resume을 orchestrator로 라우팅; `deep-test`가 성공 시 idle을 설정하지 않음.
+- Implement receipt가 `status: "complete"`를 명시적으로 요구; drift gate에 `plan_approved_at` fallback chain.
+
+## [6.0.2]
 
 ### Added
-- **Git 기반 자동 업데이트 체크**: SessionStart 훅에서 GitHub 최신 버전 확인. 자동 업그레이드, 스누즈(24h→48h→1w), 비활성화 지원.
-- **Shell injection 방지**: phase-guard.sh, file-tracker.sh에서 `process.argv`로 안전한 값 전달.
+
+- Unified Phase Review Gate — 모든 phase(0-3)가 전환 전 self-review + external review를 실행(phase별 fallback chain + 사용자 확인); `/deep-phase-review`도 동일 chain 사용.
+
+### Changed
+
+- 세션 폴더를 `deep-work/` → `.deep-work/`(hidden)로 rename, 자동 마이그레이션 + worktree 안전 점검; 세션 폴더와 히스토리만 gitignore.
+
+## [6.0.1] — 2026-04-10
+
+### Added
+
+- Superpowers 통합: per-slice 2단계 리뷰(Spec Compliance required + Code Quality advisory), Red Flags 표, pre-flight check, receipt별 `slice_confidence`/`concerns`.
+- Phase 4 cross-slice + backfill 리뷰(Phase 3에서 FAIL한 slice는 필수 backfill 대상); 전체 변경 파일 기준 scope-creep 감지; per-slice working-tree diff.
+
+### Changed
+
+- Phase 4 Spec Compliance와 Code Quality 게이트가 cross-slice 일관성에 집중; receipt `git_diff`가 per-slice baseline 사용.
+
+## [6.0.0] — 2026-04-09
+
+### Added
+
+- **Computational Sensor Pipeline** — registry 기반 ecosystem 감지(JS/TS/Python/C#/C++), 8개 output 파서, GREEN 이후 SENSOR_RUN → SENSOR_FIX → SENSOR_CLEAN 상태 머신 확장, 3-round 자기 교정 루프, `/deep-sensor-scan`, fail-closed 정책.
+- **Mutation Testing** — Stryker / stryker-net / mutmut 통합, git-diff 범위와 테스트 재생성 루프를 갖춘 `/deep-mutation-test`, Mutation Score quality gate(세션 점수의 15%).
+- **Health Engine** — Phase 1 Health Check, 4개 병렬 드리프트 센서(dead-export, stale-config, dependency-vuln, coverage-trend).
+- **Architecture Fitness Functions** — `.deep-review/fitness.json`의 선언적 규칙(file-metric, forbidden-pattern, structure, dependency) + validator + ecosystem-aware generator.
+- Baseline 관리(`health-baseline.json`, commit/branch 스코핑 + 자동 무효화); Phase 4 Fitness Delta(Advisory)와 Health Required(Required) 게이트; deep-review가 소비하는 receipt `health_report` 필드.
+- **Harness Templates** — 6개 내장 토폴로지, deep-merge 로더 + `custom/` override; Phase 1/3 통합.
+- **Self-Correction Loop** — `review-check` 센서(always-on 토폴로지 레이어 + fitness 레이어), 센서별 3-round 제한.
+
+### Changed
+
+- Session Quality Score가 5개 가중치 사용(Test Pass 25%, Rework 20%, Plan Fidelity 25%, Sensor Clean 15%, Mutation 15%); Health Check는 점수에서 제외.
+
+## [5.8.1] — 2026-04-08
+
+### Changed
+
+- **Breaking**: deep-review 플러그인과의 이름 충돌 해결을 위해 `/deep-review` → `/deep-phase-review`; phase-문서 리뷰는 rename된 커맨드, 코드-diff 리뷰는 플러그인 사용.
+
+## [5.8.0] — 2026-04-08
+
+### Added
+
+- Completeness Policy — `plan.md`용 명시적 금지 패턴(TBD, TODO, 모호한 지시, 내용 없는 cross-reference).
+- Code-sketch 계층화(S 주석 의사코드 / M 시그니처 + 타입 / L 완전한 boundary 코드)와 `failing_test` 상세 계층.
+- Slice 필드 `expected_output`과 `steps`; "Boundary: Files NOT to Modify" 섹션; research traceability 태그(`[RF-NNN]`, `[RA-NNN]`)와 lifecycle rule; research Testing Patterns 섹션.
+- Brainstorm context-adaptive 질문, Scope Assessment, Boundaries 섹션; review-gate `code_completeness`와 `buildability` 차원 + legacy-plan 호환 fallback.
+
+### Changed
+
+- Slice 파서가 새(선택) 필드를 인식; RED는 `failing_test` 사용, GREEN은 `expected_output` 비교; planning/research 가이드 업그레이드.
+
+## [5.7.0] — 2026-04-08
+
+### Added
+
+- Plan 승인 후 Sprint Contract 생성(deep-review 설치 시) — `plan.md` slice에서 `.deep-review/contracts/`로.
+- GREEN 시 per-slice 리뷰 제안(`/deep-review --contract SLICE-NNN`), Phase 4 시 전체 리뷰 제안, Phase 4 이후 wiki-ingest 제안.
+
+### Changed
+
+- Contract 생성을 plan 승인 후로 이동하여 contract가 최종 plan과 일치; 플러그인 감지를 설치 방식 무관하게 통일.
+
+## [5.6.0] — 2026-04-07
+
+### Added
+
+- `/deep-fork` — 다른 접근법 탐색을 위한 세션 fork(git worktree 전체 복제, 또는 non-git에서는 artifacts-only이며 implement/test 차단), parent-child 추적, fork-snapshot baseline, stale-parent 검증, 3-generation 제한.
+- `/deep-status --tree`와 `--compare` fork 자동 감지; 기본 status의 fork 정보; `/deep-cleanup` fork 지원; `utils.sh`의 fork 유틸리티 함수.
+
+### Changed
+
+- 세션 registry와 state frontmatter에 fork-relationship 필드 추가.
+
+## [5.5.2] — 2026-04-06
+
+### Added
+
+- 확장된 bash 파일 쓰기 감지(20+ 패턴: perl in-place, `node -e`/`python -c`/`ruby -e` 쓰기, awk, 파괴적 git ops, curl/wget 출력, 아카이브 추출, rsync)와 확장된 safe-command·test-file·TDD-exempt 패턴.
+- TDD state 검증과 backtick/subshell-aware 명령 분할.
 
 ### Fixed
-- macOS 호환성: `timeout` 명령 제거 (macOS 미지원)
-- 버전 일관성: CLAUDE.md, TODOS.md에 올바른 v4.0 버전 반영
 
-## [4.0.0] - 2026-03-25
+- **보안**: 파일 쓰기 패턴을 safe-command 패턴보다 먼저 검사(safe 접두사가 더 이상 파일 쓰기를 가리지 않음, 예: `fs.writeFileSync`가 있는 `node -e`).
+- `file-tracker.sh` Node 25 `process.argv` 호환성; `assumption-engine.js` 다수 수정(quality-timeline CLI, threshold 전달, dedup keep-latest, array 입력 가드); `session-end.sh` JSON 검증, session-id fallback, 에러 로깅.
+
+### Changed
+
+- Redirect 감지를 mid-command redirect까지 확장; `node -e`를 safe 패턴에서 제거; model-name sanitization과 configurable signal threshold.
+
+## [5.5.1] — 2026-04-03
+
+### Changed
+
+- Team 모드에서 plan phase가 부분 research 파일을 보조 참조로 로드하고 plan 결정을 교차 확인.
+- B-1 (RED_VERIFIED)과 B-2 (GREEN) state 업데이트를 phase-guard 차단 경고와 함께 필수로 표시.
+
+### Fixed
+
+- `phase-guard.sh`가 `process.argv` 대신 stdin 파이프로 JSON 입력을 읽어 대용량 입력에서 `set -e` 실패 방지.
+
+## [5.5.0] — 2026-04-02
+
+### Added
+
+- Research Cross-Model Review(codex/gemini)와 전용 research rubric; plan용 Claude self-review; per-conflict 프롬프트를 대체하는 Consolidated Judgment 프로토콜.
+- score-regression rollback을 갖춘 auto-fix snapshot 계약; 실패한 reviewer를 추적하는 degraded mode(`reviewer_status`); resume 검증을 갖춘 v5.5 state-schema 마이그레이션.
+
+### Changed
+
+- Structural-review auto-fix 트리거를 score < 7로 상향(research는 최대 3회); research user-feedback 게이트를 consolidated judgment에 통합.
+
+## [5.3.0] — 2026-03-31
+
+### Added
+
+- Document Intelligence — 피드백 적용 시 `research.md`/`plan.md`를 deduplicate·prune하고 refinement log 기록.
+- 세션 관련성 감지(out-of-scope 요청에 새 세션 또는 backlog 제안); Plan Fidelity Score(0-100); Session Quality Score(0-100); assumption snapshot과 quality 통합; cross-session 품질 트렌드; shields.io 품질 뱃지.
+- `deep-finish`의 authoritative JSONL write(atomic upsert); `session-end.sh`는 provisional 레코드만 기록.
+
+### Fixed
+
+- `session-end.sh`가 공유 `harness-history/`에 기록하여 세션 데이터가 trend/assumption 커맨드에 보임.
+
+### Changed
+
+- README를 problem-solution 내러티브로 재구성(데모 GIF 제거); `exportBadge()`가 구조화된 객체 반환(직접 consumer에 breaking).
+
+## [5.2.0] — 2026-03-31
+
+### Added
+
+- Auto-flow 오케스트레이션 — `/deep-work`가 모든 phase를 자동 체인; plan 승인이 유일한 필수 인터랙션.
+- `--receipts` / `--history` / `--report` / `--assumptions` / `--all`을 갖춘 통합 `/deep-status`; `/deep-test`에서 Drift Check(required), SOLID Review(advisory), Insight Analysis 자동 실행.
+
+### Changed
+
+- 13개 보조 커맨드를 deprecated로 표시(여전히 동작); `/deep-work` Step 1이 resume/new/cancel 제공; plan.md Quality Gates 표가 선택적 override로 변경.
+
+### Deprecated
+
+- `/deep-brainstorm`, `/deep-review`, `/deep-receipt`, `/deep-slice`, `/deep-insight`, `/deep-finish`, `/deep-cleanup`, `/deep-history`, `/deep-assumptions`, `/deep-resume`, `/deep-report`, `/drift-check`, `/solid-review`(기능이 auto-flow 또는 `/deep-status`로 통합).
+
+## [5.1.2] — 2026-03-30
+
+### Added
+
+- Team-mode 자동 설정(`~/.claude/settings.json` 구성 제안)과 런타임 검증, 모든 phase에서 자동 Solo fallback.
+
+### Fixed
+
+- 적절한 설정 없이 Team 모드 선택 시 모든 phase에서 안정적으로 Solo로 fallback.
+
+## [5.1.1] — 2026-03-30
+
+### Fixed
+
+- **Critical**: 내부 에러 시 phase-guard fail-closed(강제 우회 없음); receipt JSON 업데이트가 temp-file + rename 사용(동시 hook으로 인한 손상 없음).
+- 커맨드 체인 우회 차단(`&&`/`||`/`;`/`|` 하위 명령 독립 검사); bash TDD target 추출; comma-delimited 정확 매칭 skipped-phase; Write/Edit가 `file_path` 누락 시 fail-closed.
+- JSONL 히스토리 locking, 크로스 플랫폼 timestamp 파싱, notification JSON escaping, path 정규화, literal YAML 필드 추출, `JSON.stringify` 기반 receipt 초기 생성.
+
+### Changed
+
+- Signal evaluator가 `{ scope, fn }` 형식 사용; `TEST_FILE_PATTERNS` 확장(Rust, Java, C#, Kotlin, Swift).
+
+## [5.1.0] — 2026-03-30
+
+### Added
+
+- Auto-Loop Evaluation(plan-review와 test-phase 자동 재시도 + 에스컬레이션); Contract Negotiation(`contract` / `acceptance_threshold` slice 필드); Wilson Score 기반 Assumption Engine 자동 적용; 적응형 평가자 모델; `--skip-to-implement`.
+
+### Changed
+
+- Structural review가 에스컬레이션 전 최대 3회 auto-loop; 기본 평가자 모델 haiku → sonnet; slice 형식에 contract 필드 추가.
+
+## [5.0.0] — 2026-03-30
+
+### Added
+
+- **Self-Evolving Harness (Assumption Engine)** — 모든 강제 규칙이 machine-readable evidence signal을 갖춘 반증 가능 가설.
+- `assumptions.json`(5개 핵심 가설)과 `assumption-engine.js`(Wilson Score 신뢰도, staleness/new-model 감지, 리포트 + ASCII 타임라인 + 뱃지 export).
+- `/deep-assumptions` 커맨드; receipt의 per-slice `harness_metadata`; 세션 종료 시 append되는 `harness-sessions.jsonl`; 세션 init과 `/deep-report`의 assumption-health 요약.
+
+## [4.2.1] — 2026-03-26
+
+### Added
+
+- TDD Override — TDD가 production 편집을 차단하면 Claude가 테스트 먼저 작성 또는 이 slice에 TDD 건너뛰기를 사유와 함께 제안(slice-scoped, 전환 시 auto-clear); block 메시지의 escape-hatch 가이드; `tdd_override` state 필드와 receipt 필드.
+
+### Changed
+
+- `phase-guard-core.js` / `phase-guard.sh`가 `tdd_override` 반영; `deep-implement`에 TDD Override flow; receipt/finish/history 표면에 override count 표시.
+
+## [4.2.0] — 2026-03-25
+
+### Added
+
+- 모든 phase 문서의 Structural Review(Claude haiku 서브에이전트); plan의 adversarial cross-model 리뷰(codex / gemini-cli)와 투명한 conflict-resolution UX; 낮은 점수에서 auto-implement 차단하는 Review Gate; `/deep-review`; `--skip-review`; cross-model tool 자동 감지; profile `cross_model_preference`; resume/status의 리뷰 상태; JSON 정규화된 리뷰 결과.
+
+### Changed
+
+- Brainstorm/research/plan에 리뷰 단계 추가; `phase-guard-core.js`가 codex/gemini/mktemp를 safe 패턴에 추가; state와 profile 스키마 확장.
+
+### Fixed
+
+- `.gitignore`가 워크플로우 workspace venv를 제외.
+
+## [4.1.0] — 2026-03-25
+
+### Added
+
+- 기본 worktree 격리(`.worktrees/dw/<slug>/`, `--no-branch`로 opt-out); slice 복잡도 기반 모델 auto-routing(S/M/L/XL) + per-slice override; 4가지 완료 옵션을 갖춘 `/deep-finish`; CI/CD receipt 검증(`validate-receipt.sh`, CI 템플릿, `--format=ci` export); `/deep-history`; `/deep-cleanup`.
+- Receipt 스키마 v1.0(slice receipt canonical, session receipt derived) + 마이그레이션 헬퍼; worktree-aware resume; 모델 비용 추적; 공유 `utils.sh`.
+
+### Changed
+
+- 기본 `model_routing.implement` → `"auto"`; 기본 `git_branch` → `true`; `validate-receipt.sh`가 Bash 3.2용 `set -eo pipefail` 사용.
+
+## [4.0.1] — 2026-03-25
+
+### Added
+
+- SessionStart의 Git 기반 auto-update check(자동 업데이트, escalating snooze, opt-out); `phase-guard.sh` / `file-tracker.sh`의 `process.argv`를 통한 shell-injection 방지.
+
+### Fixed
+
+- macOS 호환성(`timeout` 사용 제거); 문서의 버전 일관성.
+
+## [4.0.0] — 2026-03-25
 
 ### BREAKING — Evidence-Driven Development Protocol
 
-deep-work이 **evidence-driven development protocol**로 전환되었습니다. 모든 코드 변경에 증거가 수반됩니다: failing test output, passing test output, git diff, spec compliance check, code review — 모두 JSON receipt으로 수집됩니다.
+deep-work가 evidence-driven development 프로토콜로 전환: 모든 코드 변경이 증거(failing/passing 테스트 출력, git diff, spec check, code review)를 JSON receipt으로 수집.
 
 ### Added
-- **Phase 0: 브레인스톰** (`/deep-brainstorm`): "왜 만드는가"를 먼저 탐색 — 문제 정의, 접근법 비교, spec-reviewer 검증. `--skip-brainstorm`으로 생략 가능.
-- **Slice 기반 실행**: Plan 태스크가 "slice"로 변환 — per-slice TDD 사이클, 파일 범위, 검증 커맨드, 스펙 체크리스트 포함.
-- **TDD 강제**: Hook 기반 상태 머신 (PENDING→RED→RED_VERIFIED→GREEN_ELIGIBLE→GREEN→REFACTOR). failing test 없이 production 코드 수정 차단. 모드: `strict`, `relaxed`, `coaching`, `spike`.
-- **Receipt 시스템**: slice별 JSON 증거 수집 (`receipts/SLICE-NNN.json`) — test output, git diff, lint, spec checklist, code review.
-- **Bash 도구 감시**: PreToolUse 훅이 Bash 커맨드도 감시. `echo >`, `sed -i`, `cp`, `tee` 등 파일 쓰기 패턴 탐지/차단.
-- **체계적 디버깅** (`/deep-debug`): 4단계 root-cause 조사 (investigate→analyze→hypothesize→fix). 예기치 않은 테스트 실패 시 자동 진입. 3회 실패 후 에스컬레이션.
-- **Slice 관리** (`/deep-slice`): ASCII 진행 대시보드, 수동 활성화, spike 모드, slice 리셋.
-- **Receipt 관리** (`/deep-receipt`): 대시보드 뷰, per-slice 상세, JSON/Markdown export.
-- **2단계 코드 리뷰**: Spec Compliance Review (required) + Code Quality Review (advisory) — 서브에이전트 기반.
-- **Receipt Completeness Gate** (required): 모든 slice에 receipt 존재 확인.
-- **Verification Evidence Gate** (required): 실제 테스트 실행 증거 확인.
-- **TDD Coaching 모드**: TDD 초보자를 위한 교육적 메시지 (차단 대신 가이드).
-- **Spike Mode Guard**: spike 종료 시 자동 git stash + slice 리셋.
-- **29개 unit test**: phase-guard-core.js (TDD 상태 머신, Bash 탐지, slice scope, receipt 검증).
+
+- Phase 0 Brainstorm(`/deep-brainstorm`, `--skip-brainstorm`로 생략); slice 기반 실행; hook 강제 TDD 상태 머신(모드: strict/relaxed/coaching/spike); per-slice receipt.
+- Bash tool 모니터링(non-implement phase에서 파일 쓰기 shell 패턴 차단); 체계적 디버깅(`/deep-debug`); `/deep-slice`; `/deep-receipt`; 2단계 code review; Receipt Completeness와 Verification Evidence 게이트; spike-mode guard.
 
 ### Changed
-- Hook 아키텍처: bash+Node.js 하이브리드 — bash fast path (~50ms), Node.js subprocess (~200ms).
-- Plan 포맷: Task Checklist → Slice Checklist (per-slice 메타데이터).
-- `hooks.json`: PreToolUse/PostToolUse에 `Bash` 추가.
-- `phase-guard.sh`: bash+Node 하이브리드로 전면 재작성.
-- `file-tracker.sh`: receipt 수집 및 active slice 매핑 확장.
-- `deep-implement.md`: Slice 단위 TDD 실행으로 전면 재설계.
-- `deep-test.md`: 4개 신규 Quality Gate 추가.
-- `deep-plan.md`: Slice 포맷 도입.
-- `deep-work.md`: Phase 0 옵션, `--tdd=MODE`, `--skip-brainstorm`.
-- `package.json`: 4.0.0 → 4.0.1.
 
-## [3.3.3] - 2026-03-24
+- bash + Node 하이브리드 hook 아키텍처; plan 형식이 slice 체크리스트로; implement/test/plan 전면 재작성; PreToolUse/PostToolUse 매처에 `Bash` 추가.
+
+## [3.3.3] — 2026-03-24
 
 ### Added
-- **멀티 프리셋 Profile System**: 작업 스타일별 Named 프리셋 지원 (예: `dev`, `quick`, `review`).
-  - Profile v2 형식: 단일 YAML 파일에 `presets:` 키로 여러 프리셋 저장
-  - v1 → v2 자동 마이그레이션 (기존 단일 프로필 → `default` 프리셋으로 래핑)
-  - `/deep-work --setup`으로 프리셋 관리 UI (생성, 수정)
-  - `/deep-work --profile=X "작업"` 으로 프리셋 직접 지정 (인터랙티브 스킵)
-  - 프리셋 2개 이상 시 AskUserQuestion으로 선택
-  - 프리셋 1개인 경우 자동 적용
-- **트리거 평가 최적화**: trigger-eval.json 확장 및 SKILL.md description 정제.
-  - trigger-eval.json 20개 → 31개 (16 true + 15 false)
-  - v3.3.2 기능 커버리지 추가: profile, preset, resume, checkpoint 키워드
-  - 동음이의어 false positive 방지 (profile picture, resume template, deep copy 등)
-  - SKILL.md description 최적화: 범용 키워드 제거, preset/프리셋 추가
+
+- 멀티 프리셋 profile 시스템(Profile v2 + `presets:`, v1 → v2 자동 마이그레이션, `--profile=X`, `--setup` 관리 UI, 인터랙티브 선택); false-positive 가드를 갖춘 확장된 trigger-eval 세트.
 
 ### Changed
-- `deep-work.md` Step 1.5 전면 재작성: v2 프로필 버전 체크 (v1 자동 마이그레이션, v2 정상 진행, 그 외 거부), 프리셋 선택 로직, 필드→변수 매핑
-- `deep-work.md` Step 1.5a 플래그 테이블에 `--profile=X` 추가
-- `deep-work.md` Step 1.5b: `--setup` 시 프리셋 관리 UI 표시 (태스크 유무에 따라 분기)
-- `deep-work.md` Step 1.5d: 프리셋 관리 UI 신규 섹션 (편집, 생성)
-- `deep-work.md` Step 7: 상태 파일 템플릿에 `preset` 필드 추가
-- `deep-work.md` Step 7.5: 프로필 저장 형식 v1 (`defaults.*`) → v2 (`presets.default.*`)
-- `deep-work.md` Step 8: 확인 메시지에 프리셋 이름 표시 (🎯 프리셋: [name])
-- `deep-resume.md` Step 1: 상태 파일에서 `preset` 필드 추출
-- `deep-resume.md` Step 3: 재개 상태 표시에 프리셋 이름 포함
-- SKILL.md Profile System 섹션에 멀티 프리셋 문서 추가
-- SKILL.md v3.3.3 Features 섹션 추가
 
-## [3.3.2] - 2026-03-22
+- `/deep-work` profile 로드/저장과 resume을 v2 형식으로 업데이트.
+
+## [3.3.2] — 2026-03-22
 
 ### Added
-- **Profile System**: 질문 없는 세션 초기화를 위한 자동 프로필 저장/로드.
-  - 첫 `/deep-work` 실행 시 설정 답변을 `.claude/deep-work-profile.yaml`에 자동 저장
-  - 이후 실행 시 모든 설정 질문 스킵, 저장된 프로필 즉시 적용
-  - 단일 세션 오버라이드 플래그: `--team`, `--zero-base`, `--skip-research`, `--no-branch`
-  - 프로필 재설정: `/deep-work --setup`
-  - 마이그레이션용 프로필 버전 필드 (`version: 1`)
-- **Session Resume (`/deep-resume`)**: 중단된 세션 복구 및 전체 컨텍스트 복원.
-  - `.claude/deep-work.local.md`에서 활성 세션 자동 감지
-  - 산출물에서 AI 컨텍스트 복원: research.md (요약), plan.md (전문), test-results.md (실패 내역)
-  - Phase별 자동 재개: research → plan 리뷰 → implement 체크포인트 → test
-  - Implement 단계: 체크포인트 기반 재개 (모델 라우팅 재위임 우회)
-- **Checkpoint Verification**: Agent 위임 후 구현 무결성 검증.
-  - `git diff --name-only` 기반 1차 검증
-  - git 변경이 있으나 미표시된 태스크의 plan.md `[x]` 자동 보정
-  - `file-changes.log` 미존재 시 graceful fallback (Agent 위임 모드)
+
+- Profile 시스템 — 첫 실행이 설정 답변을 저장하고 이후 실행이 즉시 적용; override 플래그; `--setup`.
+- Artifact 기반 context 복원과 phase auto-continue를 갖춘 세션 resume(`/deep-resume`); `git diff --name-only` 기반 checkpoint 검증.
 
 ### Changed
-- `deep-work.md` Step 1.5 (프로필 로드/플래그 파싱), Step 7.5 (프로필 저장) 구조 추가
-- `deep-work.md` Step 2-1 (git 브랜치) 프로필 설정에 따라 자동 생성/스킵
-- `deep-implement.md` Section 0-pre Agent 프롬프트에 체크포인트 의무 명시
-- `deep-implement.md` Section 0-pre에 Agent 완료 후 체크포인트 검증 단계 추가
-- SKILL.md description에 resume/profile 트리거 키워드 추가
-- SKILL.md에 Profile System, Session Resume, v3.3.2 Features 섹션 추가
 
-## [3.3.0] - 2026-03-22
+- `/deep-work`를 profile 로드/저장 중심으로 재구성; implement에 checkpoint mandate와 post-agent 검증 추가.
+
+## [3.3.0] — 2026-03-22
 
 ### Added
-- **Insight 계층 Quality Gate**: 3계층 Quality Gate 시스템의 세 번째이자 마지막 계층. 워크플로우 차단 없이 코드 메트릭과 분석 정보를 제공.
-  - `/deep-insight` 커맨드 (standalone/workflow 이중 모드)
-  - 내장 분석: 파일 메트릭, 복잡도 지표, 의존성 그래프, 변경 요약
-  - plan.md Quality Gates 테이블에 커스텀 ℹ️ 게이트 정의 가능
-  - `insight-report.md` 산출물
-  - `/deep-test`에서 Required/Advisory 게이트 이후 자동 실행
-- **PostToolUse 파일 추적**: `file-tracker.sh` 훅이 Implement 단계에서 파일 수정을 자동으로 `$WORK_DIR/file-changes.log`에 타임스탬프와 함께 기록. `/deep-report`와 `/deep-insight`에서 활용.
-- **Stop 훅 — 세션 종료 핸들러**: `session-end.sh` 훅이 CLI 세션 종료 시 실행. Deep Work 세션이 활성 상태이면 알림 메시지 출력 및 설정된 채널로 알림 전송.
-- **insight-guide.md**: Insight 계층 레퍼런스 가이드 — 분석 해석 방법, 커스텀 게이트 정의, 제한 사항
+
+- Insight Tier Quality Gate(`/deep-insight`, 내장 분석, `insight-report.md`, 차단 없음); `file-changes.log`로의 PostToolUse 파일 추적; 세션 종료 리마인더용 Stop hook.
 
 ### Changed
-- `hooks.json`이 PreToolUse 전용에서 PreToolUse + PostToolUse + Stop 3개 이벤트로 확장
-- `/deep-test` Section 2-1에서 ✅(required), ⚠️(advisory)와 함께 ℹ️(insight) 마커 파싱 추가
-- `/deep-test` Section 4에 "4-2. Built-in Insight Analysis" 단계 추가 (Required/Advisory 게이트 이후 실행)
-- `quality-gates.md` 출력에 "Insight Gates" 섹션 및 판정의 insight 카운트 추가
-- `/deep-report`가 `insight-report.md`와 `file-changes.log`를 읽어 리포트 보강
-- `/deep-status` 산출물 목록에 `insight-report.md`, `file-changes.log` 추가
-- `/deep-implement`에 PostToolUse 파일 추적 안내 노트 추가
-- SKILL.md Phase Enforcement 섹션에 3개 훅 유형 전체 문서화
-- SKILL.md description에 insight/metrics/tracking 트리거 키워드 추가
 
-## [3.2.2] - 2026-03-21
+- `hooks.json`을 PreToolUse + PostToolUse + Stop으로 확장; `/deep-test`가 ℹ️ insight 마커를 파싱하고 내장 Insight 단계 추가; 리포트와 status가 새 아티팩트를 읽음.
+
+## [3.2.2] — 2026-03-21
 
 ### Added
-- **다국어 지원 (i18n)**: 9개 커맨드 파일 모두 사용자의 메시지 또는 Claude Code `language` 설정에서 언어를 감지하여 해당 언어로 모든 사용자 대면 메시지를 출력. 한국어 템플릿을 참조 포맷으로 유지하며 Claude가 사용자 언어에 맞게 자연스럽게 번역. 영어, 일본어, 중국어 등 모든 언어 사용자 지원.
-- SKILL.md에 Internationalization 섹션 추가.
 
-## [3.2.1] - 2026-03-21
+- 다국어 지원 — 모든 커맨드 파일이 사용자 언어를 감지하여 메시지를 출력(한국어 템플릿이 참조), 영어/일본어/중국어/기타 사용자가 수정 없이 사용 가능.
+
+## [3.2.1] — 2026-03-21
 
 ### Fixed
-- **SKILL.md description 축소**: ~1,500자 → ~450자 (권장치의 3배 초과 해소). 하위 기능 트리거 키워드 제거하여 매칭 정확도 향상 및 매 대화마다 소모되는 프롬프트 예산 절감.
-- **SKILL.md changelog 중복 제거**: 본문과 중복되던 v3.1.0/v3.2.0 Features 섹션(~400단어) 삭제. 비표준 `compatibility` frontmatter 필드를 본문 Compatibility 섹션으로 이동.
-- **deep-research.md 섹션 번호 정리**: 0, 0-1, 0-2 → 1-1, 1-2, 1-3으로 논리적 실행 순서에 맞게 변경.
-- **deep-test.md allowed-tools 수정**: Phase Guard가 코드 수정을 차단하는 Test phase에서 `Edit` 도구 제거.
-- **커맨드 description 언어 통일**: `drift-check.md`, `solid-review.md`의 description을 한국어에서 영문으로 변경 (나머지 7개 커맨드와 일치).
-- **notify.sh JSON 안전성**: JSON 보간 전 `MESSAGE` 변수의 쌍따옴표/백슬래시 이스케이프 추가하여 잘못된 페이로드 방지.
-- **Phase Guard 경로 참조**: SKILL.md에 `hooks/scripts/phase-guard.sh` 명시적 경로 추가.
 
-### Added
-- `.gitignore` 파일 추가 (`.npmignore` 패턴 반영). 상태 파일 및 세션 아티팩트의 실수 커밋 방지.
-
-## [3.2.0] - 2026-03-18
-
-### Added
-- **3계층 Quality Gate 시스템**: Quality Gate를 3계층으로 분리 — Required (차단), Advisory (경고), Insight (정보, v3.3 예정).
-- **Plan Alignment / Drift Detection**: `/drift-check` 커맨드 및 `/deep-test` 내장 Required 게이트. plan.md 항목과 실제 git diff를 자동 비교하여 미구현 항목, 범위 초과, 설계 이탈을 감지. `drift-report.md` 산출물.
-- **SOLID Design Review**: `/solid-review` 커맨드 및 Advisory Quality Gate. 5가지 SOLID 원칙(SRP, OCP, LSP, ISP, DIP) 기준 코드 설계 품질 리뷰. 파일별 스코어카드, 종합 판정, Top 5 리팩토링 제안. `solid-review.md` 산출물.
-- **solid-guide.md**: 프레임워크 무관 SOLID 리뷰 체크리스트 (심각도 기준 + KISS 균형)
-- **solid-prompt-guide.md**: AI 도구에 SOLID 준수 코드를 요청하고 AI 출력물을 검증하는 가이드
-
-### Changed
-- `/deep-test`에서 plan.md 존재 시 다른 Quality Gate 이전에 Plan Alignment 검사를 자동 실행 (설정 불필요)
-- SKILL.md 구조 개선: Plan Alignment, SOLID Review, Session Report를 "Quality Gates & Utilities" 섹션으로 분리 (기존 "The Four Phases" 하위에서 이동)
-- SKILL.md description 최적화: ~40개 세부 트리거 키워드를 ~10개 대표 키워드로 통합 (신호 대 잡음비 개선)
-- SKILL.md에 v3.2.0 Features 섹션 추가 (영어 일관성 유지)
-- State 스키마에 `plan_approved_at` 필드 추가 (선택적, Drift Detection 비교 기준)
-
-## [3.1.0] - 2026-03-17
-
-### Breaking Changes
-- **저장소 구조 개편**: 루트 플러그인에서 `plugins/deep-work/` 서브디렉토리 패턴으로 전환. 기존 사용자는 재설치 필요.
-
-### Added
-- **모델 라우팅 (F1)**: Phase별 최적 모델 배정 (Research=sonnet, Plan=main, Implement=sonnet, Test=haiku). Agent 위임 패턴으로 토큰 30~40% 절감.
-- **멀티채널 알림 (F2)**: Phase 완료 시 OS 네이티브 + Slack/Discord/Telegram/커스텀 Webhook 알림. Fire-and-forget 패턴.
-- **증분 리서치 (F3)**: `/deep-research --incremental` — git diff 기반 변경 영역만 재분석. 시간 60~80% 절감.
-- **Quality Gate 시스템 (F4)**: plan.md에 Quality Gates 정의 → required/advisory 게이트 실행. `quality-gates.md` 산출물.
-- **Plan Diff 시각화 (F5)**: Plan 재작성 시 구조적 변경 사항 자동 시각화. `plan-diff.md` 산출물.
-- **model-routing-guide.md**: 모델 라우팅 설정 가이드
-- **notification-guide.md**: 알림 채널 설정 가이드
-
-### Changed
-- `/deep-work` 초기화에 모델 라우팅/알림 설정 옵션 추가
-- `/deep-status`에 모델 라우팅, 알림, Quality Gate 상태 표시
-- `/deep-report`에 Quality Gate 결과, Plan Diff 요약 섹션 추가
-- State 스키마에 `model_routing`, `notifications`, `last_research_commit`, `quality_gates_passed` 필드 추가
-- marketplace.json source 경로 `"./"` → `"./plugins/deep-work"` 변경
-
-## [3.0.0] - 2026-03-13
+- SKILL.md description 축소(~1,500 → ~450자)와 changelog bloat 제거; `deep-research.md` 단계 재번호; `deep-test.md`가 allowed-tools에서 `Edit` 제거; 커맨드 description 언어 표준화; `notify.sh` 메시지 escaping; SKILL.md의 명시적 phase-guard 경로.
 
 ### Added
 
-#### Phase 4: Test (`/deep-test`)
-- **P-1**: 새로운 Test phase 추가 (`implement → test → idle`)
-- 프로젝트 설정 파일에서 테스트/린트/타입체크 명령어 자동 감지 (package.json, pyproject.toml, Makefile, Cargo.toml, go.mod)
-- 테스트 실패 시 implement 단계로 자동 복귀, 수정 후 재테스트 루프 (최대 3회)
-- `test-results.md`에 시도별 검증 결과 누적 기록
-- Test phase에서 코드 수정 차단 (Phase Guard)
+- state 파일과 세션 아티팩트의 우발적 커밋을 방지하기 위해 `.npmignore`를 미러링한 `.gitignore`.
 
-#### 제로베이스 모드
-- **P-3**: 새 프로젝트를 처음부터 설계하는 Zero-Base 모드 추가
-- 기술 스택 선정, 코딩 컨벤션, 데이터 모델, API 설계, 스캐폴딩, 의존성 평가 6개 영역 Research
-- Plan에서 "Files to Create" + "Project Structure" + "Setup Instructions" 제공
-- `references/zero-base-guide.md` 신규 가이드 추가
+## [3.2.0] — 2026-03-18
 
-#### 대화형 Plan 리뷰
-- **A-7**: 채팅으로 피드백하면 plan.md 자동 수정 (파일 직접 편집 불필요)
-- 수정 내용 하이라이트 표시 후 재리뷰 대기
+### Added
 
-#### Plan 기능 강화
-- **A-6**: Plan 재작성 시 이전 버전을 `plan.v{N}.md`로 백업, Change Log 섹션 추가
-- **A-11**: 작업 유형별 Plan 템플릿 6종 (API 엔드포인트, UI 컴포넌트, DB 마이그레이션, 리팩토링, 버그 수정, Full Stack 기능)
-- **P-2**: Plan 승인 시 Team↔Solo 모드 전환 자동 제안 (태스크 수, 파일 수 기반)
-
-#### Research 기능 강화
-- **A-8**: 부분 리서치 재실행 — `/deep-research --scope=api,data`로 특정 영역만 재분석
-- **A-9**: Research 캐싱 — 이전 세션의 research.md를 베이스라인으로 활용, git diff 기반 변경 영역만 재분석
-
-#### Git 통합
-- **A-10**: 세션 시작 시 `deep-work/[slug]` 브랜치 생성 제안
-- 세션 완료(테스트 통과) 시 커밋 메시지 자동 생성 및 커밋 제안
-
-#### Phase 스킵
-- **A-1**: 세션 초기화 시 Research를 건너뛰고 Plan부터 시작 가능
-- 익숙한 코드베이스에서 불필요한 Research 생략
-
-#### Implement 체크포인트
-- **A-4**: 구현 중 중단 후 재실행 시 완료된 태스크 자동 스킵, 미완료 태스크부터 재개
-
-#### 시간 추적
-- **A-12**: 모든 Phase의 시작/완료 타임스탬프 기록
-- 세션 리포트에 Phase별 소요 시간 테이블 추가
-
-#### Team 모드 진행 알림
-- **A-13**: Team 모드에서 에이전트 태스크 완료 시 `[2/3] pattern-analyst 완료 ✅` 형식 진행 알림
-
-#### 세션 비교
-- **A-14**: `/deep-status --compare`로 두 세션의 접근법, 수정 파일, 검증 결과 비교
-
-#### 신규 파일
-- `commands/deep-test.md` — Test Phase 커맨드
-- `references/testing-guide.md` — Test Phase 상세 가이드
-- `references/plan-templates.md` — Plan 템플릿 모음
-- `references/zero-base-guide.md` — 제로베이스 Research 가이드
-- `CHANGELOG.md` — 변경 이력 파일
+- 3계층 Quality Gate 시스템(Required / Advisory / Insight); Plan Alignment / Drift Detection(`/drift-check` + 내장 게이트, `drift-report.md`); SOLID Design Review(`/solid-review` + advisory 게이트, `solid-review.md`); SOLID 리뷰 가이드.
 
 ### Changed
 
-#### 출력 형식 개선
-- **P-5**: research.md에 Executive Summary, Key Findings, Risk & Blockers를 최상단에 배치 (피라미드 원칙)
-- **P-5**: plan.md에 Plan Summary (접근법, 변경 범위, 리스크, 핵심 결정)를 최상단에 배치
+- `/deep-test`가 다른 게이트 전에 Plan Alignment를 자동 실행; SKILL.md 재구성; state 스키마에 `plan_approved_at` 추가.
 
-#### Phase Guard 메시지 개선
-- **A-2**: 차단 메시지에 Phase별 "다음 단계" 구체적 안내 추가
-- Research: "→ /deep-plan 또는 /deep-research 실행"
-- Plan: "→ 계획 승인 또는 /deep-plan 재실행"
-- Test: "→ 테스트 통과/실패 시 자동 처리, test-results.md 참조"
+## [3.1.0] — 2026-03-17
 
-#### Phase 흐름 변경
-- `research → plan → implement → idle` → `research → plan → implement → test ⟲ → idle`
-- Implement 완료 후 idle 대신 test phase로 자동 전환
-- Test 실패 시 implement로 복귀하는 재시도 루프
+### Breaking
 
-#### 상태 파일 스키마 확장
-- 신규 필드: `project_type`, `git_branch`, `test_retry_count`, `max_test_retries`, `test_passed`
-- 신규 타임스탬프: `research_started_at/completed_at`, `plan_started_at/completed_at`, `implement_started_at/completed_at`, `test_started_at/completed_at`
-
-#### 버전 통일
-- **A-3**: `plugin.json`과 `package.json`의 버전을 3.0.0으로 통일
-
-#### SKILL.md 업데이트
-- 4-phase 워크플로우 반영
-- 제로베이스 모드 트리거 키워드 추가 ("새 프로젝트 시작", "제로베이스", "zero-base", "from scratch")
-- 신규 기능 설명 추가 (Research 캐싱, 부분 재실행, Plan 템플릿, 대화형 리뷰 등)
-
-#### Reference 가이드 업데이트
-- `research-guide.md` — Executive Summary/Key Findings 출력 형식 추가, 제로베이스 가이드 링크
-- `planning-guide.md` — Plan Summary 출력 형식 추가, 템플릿 가이드 링크
-- `implementation-guide.md` — 완료 후 Test phase 전환으로 Completion Protocol 변경
-
-## [2.0.0] - 2026-03-07
+- 저장소 구조를 `plugins/deep-work/` 서브디렉토리로 마이그레이션 — 기존 사용자는 재설치 필요.
 
 ### Added
-- 작업별 폴더 히스토리 (`deep-work/YYYYMMDD-HHMMSS-slug/`)
-- 승인 시 자동 구현 시작
-- 세션 리포트 자동 생성 (`report.md`)
-- `/deep-report` 커맨드 (리포트 조회/재생성)
-- `/deep-status` 커맨드 (상태, 진행률, 세션 히스토리)
-- Solo/Team 모드 선택
-- Team 모드: 3명 병렬 Research, 파일 소유권 기반 병렬 Implement, 크로스 리뷰
+
+- Model Routing(phase별 모델 배정, 30-40% 토큰 절감); 멀티 채널 알림; 증분 research(`--incremental`, 60-80% 시간 절감); Quality Gate 시스템; Plan Diff 시각화; routing/notification 가이드.
 
 ### Changed
-- 상태 파일에 `work_dir`, `team_mode`, `started_at` 필드 추가
-- Phase Guard가 `deep-work/` 디렉토리 내 문서 수정은 허용
 
-## [1.1.0] - 2026-03-01
+- `/deep-work` init, `/deep-status`, `/deep-report`가 새 옵션 표면화; state 스키마와 marketplace source 경로 업데이트.
+
+## [3.0.0] — 2026-03-13
 
 ### Added
-- Phase Guard (PreToolUse hook) — Research/Plan 단계에서 코드 파일 수정 차단
-- 상태 파일 기반 phase 관리
+
+- 자동 감지 테스트/lint/type-check 명령과 fix-and-retest 루프(최대 3회 재시도), `test-results.md`, Test-phase 편집 차단을 갖춘 Phase 4 Test(`/deep-test`).
+- 새 프로젝트용 Zero-Base 모드; 인터랙티브 plan 리뷰(피드백이 `plan.md` 업데이트); plan 버전 백업과 6개 템플릿; 부분/캐시 research; git 브랜치 + commit 제안; implement checkpoint; phase별 시간 추적; team-mode 진행; `/deep-status --compare`.
 
 ### Changed
-- 기존 단순 프롬프트 기반에서 hook 기반 강제 분리로 전환
 
-## [1.0.0] - 2026-02-15
+- Phase 흐름이 `research → plan → implement → test ⟲ → idle`로; Executive Summary / Plan Summary를 먼저 배치(피라미드 원칙); phase-guard block 메시지에 next-step 가이드; state 스키마와 SKILL.md 확장.
+
+## [2.0.0] — 2026-03-07
 
 ### Added
-- 초기 버전
-- 3단계 워크플로우: Research → Plan → Implement
-- `/deep-work`, `/deep-research`, `/deep-plan`, `/deep-implement` 커맨드
-- `research.md`, `plan.md` 산출물 생성
-- 반복적 Plan 리뷰 지원
+
+- Per-task 폴더 히스토리(`deep-work/YYYYMMDD-HHMMSS-slug/`); plan 승인 시 implementation 자동 시작; 자동 생성 세션 리포트; `/deep-report`; `/deep-status`; 3-agent 병렬 research와 cross-review를 갖춘 Solo/Team 모드.
+
+### Changed
+
+- State 파일에 `work_dir` / `team_mode` / `started_at` 추가; Phase Guard가 `deep-work/` 내 문서 편집 허용.
+
+## [1.1.0] — 2026-03-01
+
+### Added
+
+- Research/Plan 중 코드 파일 편집을 차단하는 Phase Guard(PreToolUse hook); state 파일 기반 phase 관리.
+
+### Changed
+
+- 프롬프트 기반 접근에서 hook 기반 강제로 마이그레이션.
+
+## [1.0.0] — 2026-02-15
+
+### Added
+
+- 최초 릴리스: 3단계 워크플로우(Research → Plan → Implement); `/deep-work`, `/deep-research`, `/deep-plan`, `/deep-implement`; `research.md` / `plan.md` 아티팩트; 반복적 plan 리뷰.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,1148 +13,631 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **`skills/deep-research/SKILL.md` — Deep-Memory Brief Context subsection** (Cross-Plugin Context block, alongside Harnessability + Evolve Insights). When `.deep-memory/latest-brief.md` exists in the project root, the brief is quoted **verbatim** under a new `## Cross-project Memory` heading in `research.md` (heading hierarchy shifted by +2 to preserve deep-memory's render). When absent, the research artifact stays deep-memory-agnostic — a runtime-only suggestion is emitted but **nothing is written to `research.md`** (privacy invariant). `/deep-memory-brief` is **never auto-invoked**; recall stays user-driven. Provenance tokens (`mem-<ULID>`, Crockford-base32 uppercase, I/L/O/U excluded) extracted into the new `cross_project_memory.cited_memory_ids[]` state field.
-- **`skills/deep-integrate/SKILL.md` — `/deep-memory-harvest` recommendation** in the Phase 5 LLM prompt rule (§3-2) and the deterministic B-fallback list (§3-4). Gated on `deep-memory ∈ plugins.installed`, `session.changes.files_changed > 0`, and `loop.already_executed` not containing `deep-memory`. Installation suggestion path mirrors existing sibling-plugin convention.
-- **`skills/deep-integrate/detect-plugins.sh`** — `deep-memory` added to the `TARGETS` enumeration so the Phase 5 harvest gate's `plugins.installed`/`plugins.missing` signal correctly reports its presence. Regression test in `detect-plugins.test.js` asserts present→installed[] / absent→missing[].
-- **`docs/deep-memory-integration-handoff.md`** — spec-of-record for this PR (force-added under `docs/`, which is normally gitignored). Covers all 6 consumer items from deep-memory spec §14.2 — five landed, item 5 (`/deep-memory feedback`) deferred to Phase 4+ joint PR with the `cited_memory_ids[]` field forward-compatible.
-- **`tests/deep-memory-integration.test.js`** — 12 fixture-based contract tests pinning every documented invariant: spec doc structure, SKILL section wording, state-field schema, harvest gate language, ULID provenance regex (including character-class + length + Crockford-uppercase isolation), absent-brief privacy boundary, stale-warning wording, heading-shift +2 rule, 0-byte brief, non-empty no-ULID brief, and a defensive `assert.doesNotMatch(/또는 부재 안내/)` guarding against pre-fix wording re-entering the SKILL silently.
+- Phase 1 Research recall: when `.deep-memory/latest-brief.md` exists, the brief is quoted verbatim under a new `## Cross-project Memory` heading in `research.md`; when absent, nothing is written (privacy invariant). `/deep-memory-brief` is never auto-invoked. Cited memory IDs (`mem-<ULID>`) are captured into the `cross_project_memory.cited_memory_ids[]` state field.
+- Phase 5 Integrate recommends `/deep-memory-harvest` when `deep-memory` is installed and the session changed files; `skills/deep-integrate/detect-plugins.sh` now enumerates deep-memory in `plugins.installed`/`plugins.missing`.
+- `docs/deep-memory-integration-handoff.md` records the deferred `/deep-memory feedback` hook for a future joint PR.
+- `tests/deep-memory-integration.test.js` pins the documented invariants (privacy boundary, ULID regex, heading-shift rule, edge cases).
 
 ### Changed
 
-- **Research artifact schema** — additive `cross_project_memory` block (`brief_path`, `brief_mtime`, `brief_stale`, `cited_memory_ids[]`) recorded in the research state frontmatter. All four fields default to `null` / `[]` when the brief is absent, preserving forward-compat for projects that never install deep-memory.
-- **`.gitignore`** — `.deep-memory/` ignored at the project root (deep-memory manages its own persistence under `~/.deep-memory/`; the per-project brief is regenerated on demand).
-- Version bumped 6.8.0 → 6.9.0 across package and plugin manifests for a minor release.
-
-### Verification
-
-- `npm test`: 850 / 850 pass (137 suites) — baseline 837 + 13 new (5 graceful/cited + 1 detect-plugins regression + 3 stale/heading/empty + 1 R1-Y1 length-isolated + 1 R1-Y2 contract + 1 R2-N1 negative + 1 R2-N2 non-empty).
-- 3-round `/deep-review-loop` to convergence: round 1 REQUEST_CHANGES (🔴 1 / 🟡 3 / ℹ️ 2) → round 2 CONCERN (🟡 1 / ℹ️ 2) → round 3 APPROVE (natural convergence per §3.A.1). All 7 actionable findings ACCEPTED + fixed across 6 Respond commits; 1 info item deferred (R2-N3 — `.git` worktree-as-file wording, defensible as-is).
-- Reports retained under `.deep-review/reports/` and `.deep-review/responses/` (gitignored; author-local).
+- Research artifact schema gains an additive `cross_project_memory` block, defaulting to null/empty when no brief is present (forward-compatible).
 
 ## [6.8.0] — 2026-05-19 (Plan-quality contract enforcement + CI hardening + receipt-tracker robustness)
 
-### Added
-
-- **`tests/plan-quality-contract.test.js`** — pins the executable `deep-plan` slice contract, rejects legacy `Task N:` rows in planning/implementation references, and (new 4th block) pins `skills/shared/references/review-gate.md` to the v6.7 mandatory slice contract so the review gate cannot silently drift away from the test.
-- **`tests/ci-workflow-contract.test.js`** — pins the GitHub Actions advisory `shellcheck` step shape (name, `continue-on-error: true`, target, severity, ordering after `npm test`, missing-binary graceful skip).
-- **`hooks/scripts/file-tracker-lock-timeout.test.js`** — end-to-end regression test for the receipt-tracker stale-lock recovery contract: Phase 1 (lock held) asserts canonical receipt + pending sidecar state; Phase 2 (lock released, second invocation) asserts the drained file and the new file both land in canonical `changes.files_modified`.
-
 ### Changed
 
-- **Plan slice format (v6.7 executable steps)** — `steps` are now required for S/M/L slices (`S: 2-4`, `M: 3-7`, `L: 5-12`), and every code-changing step must include exact file paths plus code sketch or function signature detail.
-- **Planning references and templates** — `planning-guide.md`, `implementation-guide.md`, `plan-templates.md`, `plan-template-existing.md`, and `plan-template-zerobase.md` now use `SLICE-NNN` slice checklists with `depends_on`, `code_sketch`, `failing_test`, `verification_cmd`, and `expected_output`.
-- **Completeness Policy** — expanded to reject vague `Write tests for the above`, missing `failing_test` red signal, and missing exact `expected_output` fragment.
-- **Contract validation scope** — updated from the stale M/L/XL wording to all S/M/L slices.
-- **Plan review-gate aligned with v6.7 mandatory slice contract** — `skills/shared/references/review-gate.md` no longer marks `expected_output` as "recommended" and no longer applies a v5.8 backward-compat fallback that absolved missing `steps`/`expected_output` from the `testability`/`buildability`/`code_completeness` rubric. The wording now requires all five mandatory slice fields (`failing_test`, `verification_cmd`, `expected_output`, `code_sketch`, `steps`) for every non-inline S/M/L slice, with narrow exceptions for inline plans and legacy/resume inputs.
-- **Advisory shellcheck CI step** — runs `shellcheck --severity=warning --external-sources` against `hooks/scripts/**/*.sh`, non-blocking (`continue-on-error: true`). No gate change.
-- **`npm test` discovery widened to 6 explicit subtree globs** — replace the explicit-6-file list with `node --test --test-concurrency=1 hooks/**/*.test.js tests/**/*.test.js skills/**/*.test.js sensors/**/*.test.js templates/**/*.test.js scripts/**/*.test.js`. Runs serially to keep timing-sensitive tests stable on slower CI runners. CI Node version bumped from 20 to 22 (LTS) to support the glob form (glob support in `--test` positional args landed in Node 21.0.0 and was never back-ported to 20.x). `health/**/*.test.js` is covered by a separate `npm run test:health` script that runs cleanly in isolation but exposes a pre-existing event-loop leak in `health/health-check.test.js:236` ("overall timeout enforcement") when interleaved with other suites on GitHub-hosted runners — that leak is tracked as a follow-up. Discovered tests remain POSIX-only (use `bash` directly + `/tmp` hardcodes), so this does not enable Windows execution; it only ensures the bulk of the suite runs in the ubuntu+macos CI matrix.
-- **Receipt-tracker lock-timeout hardening** — restore the unconditional pre-lock receipt init in `hooks/scripts/file-tracker.sh` with `O_CREAT | O_EXCL` (`fs.writeFileSync` `flag: 'wx'`) so concurrent writers race safely. Single-write slices retain a canonical `SLICE-NNN.json` even when the in-lock update path times out on a stale lock. Pending-changes sidecar drains on the next successful lock-acquire in `file-tracker.sh` (session-end does not currently sweep pending-changes — tracked as a future improvement).
-- Version bumped 6.7.1 → 6.8.0 across package and plugin manifests for a minor release.
-
-### Verification
-
-- `npm test`: 901 / 901 pass (150 suites). Three contract suites pin the new surfaces (`plan-quality-contract`, `ci-workflow-contract`, `file-tracker-lock-timeout`).
-- 3-way deep-review (Claude Opus + Codex review + Codex adversarial) ran three iterative rounds; the round-3 fix commit closed every round-2 finding and round 3 converged with APPROVE for the round-3 fix scope; the O1 alignment commit closed the one out-of-scope finding raised in round 3.
+- Every non-inline S/M/L slice must declare `failing_test`, `verification_cmd`, `expected_output`, `code_sketch`, and `steps`; the plan review gate is aligned with this contract (no more "recommended" hedge or backward-compat fallback for missing fields).
+- Planning references and templates switched to `SLICE-NNN` checklists with `depends_on`, `code_sketch`, `failing_test`, `verification_cmd`, and `expected_output`; `steps` are required (S: 2-4, M: 3-7, L: 5-12) with exact file paths.
+- Completeness Policy expanded to reject vague directives, missing red signals, and missing exact `expected_output` fragments.
+- A non-blocking `shellcheck` advisory step lints `hooks/scripts/**/*.sh`; CI Node bumped 20 → 22 (LTS) to support recursive `node --test` glob discovery.
+- Receipt-tracker hardening: pre-lock receipt init restored with `O_CREAT | O_EXCL` so single-write slices retain a canonical `SLICE-NNN.json` even when the in-lock update path times out; pending changes drain on the next lock acquire.
 
 ## [6.7.1] — 2026-05-18 (Codex-native plugin manifest and AGENTS guide)
 
 ### Added
 
-- **`.codex-plugin/plugin.json`** — Codex-native plugin manifest pointing at the same skill and hook surfaces as the Claude Code manifest while preserving the existing `claude-deep-*` repository identity.
-- **`AGENTS.md`** — Codex project guide covering runtime surfaces, verification commands, and the downstream suite marketplace update requirement.
-- **`skills/deep-work/SKILL.md`** — restored the primary `deep-work` skill entry alias so Claude, Codex, and other skill callers can invoke `$deep-work:deep-work "task"` instead of knowing the internal `deep-work-orchestrator` name. The alias forwards all arguments to `deep-work-orchestrator`.
-- **`tests/skill-entry-alias.test.js`** — pins the skill-only entrypoint contract: no `commands/deep-work.md` wrapper is required, and the `deep-work` skill delegates to `deep-work-orchestrator` with `$ARGUMENTS` preserved.
+- `.codex-plugin/plugin.json` — Codex-native manifest pointing at the same skill and hook surfaces as the Claude Code manifest.
+- `AGENTS.md` — Codex project guide covering runtime surfaces, verification, and the downstream suite marketplace update.
+- Restored the primary `deep-work` skill alias so callers can invoke `$deep-work:deep-work "task"` without knowing the internal orchestrator name.
 
 ### Changed
 
-- Version bumped 6.7.0 → 6.7.1 across package and plugin manifests for a patch release.
-- README documentation now calls out Codex compatibility alongside the existing Claude Code surface.
-- Codex plugin default prompt now uses `$deep-work:deep-work "build this feature"` as the first-run entrypoint.
-- Manifest/package descriptions now describe the entry alias as skill-native for Claude and Codex, not Codex-only.
+- Manifest/package descriptions describe the entry alias as skill-native for both Claude and Codex; README calls out Codex compatibility.
 
-### Verification
-
-- Repository validation was run before release; see the PR checklist for the exact command output.
-
-## [6.7.0] - 2026-05-18 (24 commands → user-invocable skills: cross-platform — suite-wide migration completion)
-
-### Changed — 24 command-equivalent surfaces promoted to `user-invocable: true` skills
-
-- **Category A (7)**: thin `Skill()` wrappers under `commands/` deleted; the matching skill bodies gain `user-invocable: true` in frontmatter (no body changes). Targets: `deep-brainstorm`, `deep-research`, `deep-plan`, `deep-implement`, `deep-test`, `deep-integrate`, `deep-work-orchestrator`. Skill invocation now flows directly to the skill bodies instead of through a wrapper command — orchestrator's 5-phase dispatch unchanged.
-- **Category B (17)**: new `skills/<verb>/SKILL.md` files created with `user-invocable: true` frontmatter + new `## Invocation` / `## Inputs (skill args)` / `## Prerequisites` head sections; bodies preserved byte-for-byte except internal cross-reference path retargeting. Old `commands/<verb>.md` files deleted. Targets: `deep-assumptions`, `deep-cleanup`, `deep-debug`, `deep-finish` (660 lines — single largest in the suite), `deep-fork`, `deep-history`, `deep-insight`, `deep-mutation-test`, `deep-phase-review`, `deep-receipt`, `deep-report`, `deep-resume`, `deep-sensor-scan`, `deep-slice`, `deep-status` (hub of receipt/history/report/assumptions sub-pages), `drift-check`, `solid-review`.
-- **`commands/` directory removed**. `package.json` `files` field updated to drop `commands/`.
-- **deep-status hub sub-page retargeting**: §6/§7/§8/§9 lines that previously read "Read the `/deep-X` command file and follow its logic inline" now read "Read `skills/deep-X/SKILL.md` and follow its logic inline" — preserving the inline-dispatch hub-spoke pattern. The 4 sub-skill files (`deep-receipt` / `deep-history` / `deep-report` / `deep-assumptions`) also have their `참조처:` lines retargeted to `skills/deep-status/SKILL.md` §X.
-- **CLAUDE.md:133** retargeted: `commands/deep-finish.md §7-Z` → `skills/deep-finish/SKILL.md §7-Z` (caller-naming for `wrap-receipt-envelope.js`).
-- **`hooks/scripts/wrap-receipt-envelope.js`** JSDoc updated: caller naming `deep-finish.md, agents/implement-slice-worker.md` → `skills/deep-finish/SKILL.md §7-Z, agents/implement-slice-worker.md`.
-- **`skills/deep-work-orchestrator/SKILL.md`** internal references retargeted: `Read \`/deep-finish\`` → `Read \`skills/deep-finish/SKILL.md\``; `\`deep-resume.md\`가 사용` → `\`skills/deep-resume/SKILL.md\`가 사용`. `Skill("deep-X", args=...)` dispatches (already in orchestrator) now resolve to skill bodies via `user-invocable: true` enrollment.
-
-### Rationale — cross-platform parity completes the suite-wide migration
-
-- Slash commands are Claude Code-exclusive; user-invocable skills work in **Codex / Copilot CLI / Gemini CLI / Agent SDK** via `Skill({ skill: "deep-work:<verb>", args: "..." })`.
-- This is the **4th and final installment** of the suite-wide command→skill migration: deep-docs v1.3.0 (pilot, 1 command) → deep-evolve v3.4.0 (2nd, 1 command + `$ARGUMENTS`) → deep-wiki v1.6.0 (3rd, 5 commands) → **deep-work v6.7.0 (4th, 24 commands)**. All four installments share the same mechanical pattern (frontmatter `user-invocable: true`, `## Invocation` + `## Inputs (skill args)` + `## Prerequisites` head sections, body byte-preservation, cross-ref sed retargeting), proven across 3 prior PRs.
-- 24 atomic conversion (not partial) is required because `deep-status` is a hub that dispatches to 4 sub-skills via inline body Read; partial conversion would break the hub-spoke graph. Half of the 24 (Category A, 7) are 1-line frontmatter changes + wrapper deletion, so the real new-skill authoring volume is 17.
-
-### Migration — for callers
-
-- **Claude Code / cross-platform skill callers**: invoke via `Skill({ skill: "deep-work:<verb>", args: "..." })` or the host's equivalent skill invocation syntax. All 24 surfaces respond uniformly. Example: `Skill({ skill: "deep-work:deep-finish", args: "--skip-integrate --handoff-to=deep-wiki" })`.
-- **`$ARGUMENTS` preservation**: bodies that branch on `$ARGUMENTS` (notably `deep-finish` flags, `deep-fork` session-id + `--from-phase`, `deep-status` flag matrix, `deep-insight` / `drift-check` / `solid-review` target args, `deep-assumptions` subcommands) are preserved byte-for-byte — `args` field of `Skill()` is mapped to `$ARGUMENTS` identically to slash invocation.
-- **`phase-guard.sh` untouched** — already hardcodes `skills/deep-integrate/` for Phase 5 enforcement (since v6.5). Phase 5 dispatch unchanged.
-- **`BUG_REVIEW_REPORT.md` left as-is** — historical audit artifact pinned to v6.5.x line numbers; preserving historical accuracy.
-
-### Tests
-
-- All 177 existing `node:test` assertions continue to pass: `envelope-emit`, `envelope-chain`, `handoff-roundtrip`, `phase-guard-denylist`, `phase-guard-golden`. None of the 5 test files reference `commands/*` paths (verified pre-conversion), so no test updates were required.
-- `grep -rn 'commands/deep-\|commands/drift\|commands/solid'` across the entire plugin (excluding CHANGELOG / BUG_REVIEW_REPORT / docs/ / node_modules / .git) yields **0 hits** post-conversion.
-
-## [6.6.3] - 2026-05-12
-
-### Added — M5.5 #3 hook golden test + M5.5.X (§9) phase-guard hardening rollup
-
-- **`tests/phase-guard-golden.test.js`** — fixture-driven golden test (M5.5 #3). Loads `tests/fixtures/golden/<name>.input.json` + `<name>.expected.json` pairs and asserts exit code + decision + reason regex against `phase-guard.sh`. Initial corpus: 8 scenarios covering idle allow, implement slice scope (in/out), four non-implement denylist families (rm-rf, npm-publish, curl-pipe-shell, sql-destructive), and override pass-through. Driver fails loud on half-commits (missing `.input` or `.expected`).
-- **`hooks/scripts/test-helpers/run-phase-guard.js`** — shared `scrubHostEnv()` + `runPhaseGuard()` + `parseGuardOutput()` helpers (§9.2 W-R2.2). Consolidates the host-env scrub (`DEEP_WORK_SESSION_ID` / `DEEP_WORK_ROOT` / `CLAUDE_PROJECT_DIR`) that `tests/phase-guard-denylist.test.js` introduced inline, so sibling hook tests get host-env isolation without duplicating an incomplete deletion list per file.
-- **`tests/phase-guard-denylist.test.js` §9.3 additions** — 7 new assertions:
-  - Pre-flight assertion that `NON_IMPLEMENT_DANGEROUS` corpus covers every `family:` entry in `phase-guard-core.js` `DANGEROUS_NON_IMPLEMENT_PATTERNS`.
-  - Per-family override loop (5 families × research phase) — exercises every `CLAUDE_ALLOW_<FAMILY>=1` env var end-to-end so a typo in any override field gets caught at CI.
-  - Override fall-through composition test (`CLAUDE_ALLOW_RM_RF=1 + 'rm -rf foo && cp x.txt /etc/host.conf'`) — pins the contract that override env suppresses ONLY the denylist branch and falls through to the file-write gate.
+## [6.7.0] — 2026-05-18 (24 commands → user-invocable skills: cross-platform)
 
 ### Changed
 
-- **`hooks/scripts/phase-guard-core.js`** — §9.1 comment block extended at the non-implement branch entry to document (a) gate order, (b) load-bearing ordering rationale, (c) override-env semantics (suppresses denylist only, file-write still applies), (d) Phase 5 cross-coverage from `phase-guard.sh`.
-- **`hooks/scripts/phase-guard-core.js`** — §9.3 I-R3.1 `DANGEROUS_NON_IMPLEMENT_PATTERNS` docblock extended with intentional scope omissions (`DELETE FROM`, `DROP DATABASE`, alternate shell pipes, `yarn publish`, disk-level commands).
-- **`hooks/scripts/{phase-guard-hardening,phase5-guard,worktree-guard,multi-session,input-parsing-e2e}.test.js`** — §9.2 migration: replaced inline `{ ...process.env, ... }` spreads with `scrubHostEnv()` from the shared helper.
+- All 24 command-equivalent surfaces are now `user-invocable: true` skills under `skills/`; the `commands/` directory was removed and `package.json` `files` updated to drop it.
+- Skill invocation flows directly to skill bodies (`Skill({ skill: "deep-work:<verb>", args: "..." })`), working in Codex / Copilot CLI / Gemini CLI / Agent SDK as well as Claude Code; the orchestrator's 5-phase dispatch is unchanged.
+- `$ARGUMENTS`-branching bodies (`deep-finish` flags, `deep-fork`, `deep-status` flag matrix, etc.) are preserved byte-for-byte.
 
-### Notes
-
-- This PR is the M5.5 #3 (deep-work side) + M5.5.X (§9.1 + §9.2 + §9.3) rollup spec'd in `claude-deep-suite/docs/superpowers/plans/2026-05-12-m5.5-remaining-tests-handoff.md` §9 "Suggested rollup PR". M5.5 #3 for deep-evolve / deep-wiki and #5 for deep-review / deep-wiki / deep-evolve are tracked in separate PRs.
-- Test count: **162 → 177** (+15: 8 golden + 7 §9.3 = 15 new). npm test runtime ~29s on macOS bash 3.2.
-
-## [6.6.2] - 2026-05-12
-
-### Added — M5.5 #7 non-implement dangerous-command denylist (PR #28, 3 review rounds)
-
-- **`tests/phase-guard-denylist.test.js`** — 162-assertion phase-guard contract test covering Phase 5 read-mostly allowlist (7 spec families) + non-implement denylist (5 families × 4 phases + controls + regression guards).
-- **`hooks/scripts/phase-guard-core.js`** — `DANGEROUS_NON_IMPLEMENT_PATTERNS` (5 families: rm-rf, npm-publish, kubectl-destructive, sql-destructive, curl-pipe-shell) + `matchDangerousNonImplement()` + denylist gate at research/plan/test/brainstorm Bash entry. Each family has a `CLAUDE_ALLOW_<FAMILY>=1` env override.
-- **R3 regex fixes**: W-R3.1 (SQL TRUNCATE single-char bug) + W-R3.2 (kubectl `--all-namespaces` false-positive).
-
-## [6.6.1] - 2026-05-12
-
-### Added — M5.5 #4 cross-platform CI matrix (PR #27)
-
-- **`.github/workflows/tests.yml`** — `os: [ubuntu-latest, macos-latest]` × `node-version: '20'` matrix running `npm test` + 3 bash regression scripts.
-- **`hooks/scripts/test/test-v6.4.2-regression.sh` §2** — cross-platform `stat` fallback (`stat -c '%a' || stat -f '%A'`) caught by the new ubuntu leg on first run.
-
-## [6.6.0] - 2026-05-12
-
-### Added — M5.7.A plugin-side adoption of cross-plugin handoff + dashboard compaction telemetry
-
-- **`hooks/scripts/emit-handoff.js`** — CLI helper that wraps a handoff payload in the M3 envelope (`artifact_kind = "handoff"`, `schema.name = "handoff"`, `schema.version = "1.0"`) and writes it under `.deep-work/handoffs/` (or per-session). Flags: `--payload-file`, `--output`, `--source-session-receipt` (auto-chains `parent_run_id`), `--source-review-report`, `--parent-run-id`, `--session-id`. Payload required fields enforced before write: `schema_version`, `handoff_kind`, `from{producer,completed_at}`, `to{producer,intent}`, `summary`, `next_action_brief` — matches `claude-deep-suite/schemas/handoff.schema.json` + dashboard's `PAYLOAD_REQUIRED_FIELDS["deep-work/handoff"]`.
-- **`hooks/scripts/emit-compaction-state.js`** — CLI helper that wraps a compaction-state payload in the M3 envelope (`artifact_kind = "compaction-state"`, `schema.name = "compaction-state"`). Two input modes: build payload from CLI flags (`--trigger`, `--preserved`, `--discarded`, `--strategy`, `--pre-tokens`, `--post-tokens`) for hook-driven emit, OR `--payload-file` for skill-composed emit. Trigger enum validated against suite schema (`phase-transition`, `slice-green`, `loop-epoch-end`, `window-threshold`, `manual`, `session-stop`). Strategy enum validated. Powers dashboard metrics `suite.compaction.frequency` + `suite.compaction.preserved_artifact_ratio`.
-- **`commands/deep-finish.md` §7-Z-A** — new section after envelope wrap that emits a cross-plugin handoff when `--handoff-to=<plugin>` is supplied (or user opts-in interactively). Chains `parent_run_id` to the session-receipt envelope automatically. Writes to `.deep-work/handoffs/<UTC-ts>-<session_id>.json` matching dashboard's flat-dir `SOURCE_SPECS`.
-- **`hooks/scripts/session-end.sh`** Stop hook — best-effort `compaction-state.json` emit on session close (`trigger: session-stop`, `strategy: receipt-only` when session-receipt exists, otherwise preserves the state file). Wrapped in subshell + `|| true` to preserve the Stop hook's "must not block session close" contract.
-- **`hooks/scripts/phase-transition.sh`** PostToolUse hook — emits `compaction-state.json` on each Phase boundary (`trigger: phase-transition`, `strategy: key-artifacts-only`). Preserved set chosen per Phase: research→research.md, plan→research+plan, implement→plan, test→plan+receipts, idle→session-receipt.
-- **`tests/handoff-roundtrip.test.js`** — 16 assertions covering M5.5 #8 (deep-work half): payload-required-field contract identical to dashboard, CLI roundtrip producing envelopes that satisfy a mirrored `unwrapStrict`, cross-plugin chain (`parent_run_id === session-receipt.envelope.run_id`), trigger enum coverage (all 6 values), failure paths (missing required field → exit 1, unknown trigger → exit 1).
-
-### Changed
-
-- **`hooks/scripts/envelope.js`** — `ALLOWED_ARTIFACT_KINDS` extended from `{session-receipt, slice-receipt}` to include `handoff` and `compaction-state`. The set is consumed by both `wrapEnvelope` (output guard) and `unwrapEnvelope` (input guard); existing identity-triplet semantics preserved for session-receipt / slice-receipt callers.
-- **`scripts/validate-envelope-emit.js`** — `ALLOWED_KINDS` extended symmetrically so the CI validator accepts the two new envelope kinds. Payload `schema_version === "1.0"` enforcement carries through unchanged.
-
-### Notes
-
-- This release is **producer-only** for the new artifact kinds. deep-work does not consume `handoff.json` or `compaction-state.json` from other plugins; the dashboard does. Cross-plugin contract is enforced by `claude-deep-dashboard/lib/suite-collector.js unwrapStrict`.
-- See `claude-deep-suite/docs/superpowers/plans/2026-05-11-m5.7-plugin-adoption-handoff.md` §M5.7.A for the M5 acceptance criteria this milestone closes.
-
-## [6.5.0] - 2026-05-07
+## [6.6.3] — 2026-05-12
 
 ### Added
-- **M3 cross-plugin envelope adoption** for `session-receipt.json` and `receipts/SLICE-*.json` (claude-deep-suite Phase 2 priority #3; cf. `claude-deep-suite/docs/envelope-migration.md` §1). Both artifacts now ship as `{ schema_version: "1.0", envelope: { producer, producer_version, artifact_kind, run_id, generated_at, schema, git, provenance, [parent_run_id], [session_id] }, payload: { ... legacy receipt body ... } }`.
-- **`hooks/scripts/envelope.js`** — shared zero-dep envelope library: MSB-first ULID generator (Crockford Base32, 26-char), `detectGit()` head/branch/dirty trio with safe `0000000` fallback, `loadProducerVersion()` resolved relative to module path (handoff §4 literal-cwd-resolve), `wrapEnvelope()` builder, `unwrapEnvelope()` reader with full identity guards (producer / artifact_kind / schema.name) and corrupt-payload defense.
-- **`hooks/scripts/wrap-receipt-envelope.js`** — CLI helper invoked by markdown agent prompts (`agents/implement-slice-worker.md`, `commands/deep-finish.md`) to wrap a payload temp file. Supports `--source-evolve-insights`, `--source-harnessability`, `--source-artifacts-glob` for cross-plugin / intra-plugin chain extraction (writes `parent_run_id` from evolve-insights envelope and aggregates slice receipt + harnessability `run_id` into `provenance.source_artifacts[]`).
-- **`scripts/validate-envelope-emit.js`** — zero-dep self-test validator mirroring suite envelope schema. Enforces `additionalProperties: false` on root / envelope / git / schema / provenance / source_artifacts items, ULID Crockford alphabet (rejects I/L/O/U), SemVer 2.0.0 strict, RFC 3339, kebab-case, `schema.name === artifact_kind` identity, payload non-null/non-array object with `schema_version: "1.0"` preserved.
-- **`tests/envelope-emit.test.js`** + **`tests/envelope-chain.test.js`** + **fixtures (`sample-session-receipt.json`, `sample-slice-receipt.json`)** — 50+ assertions covering ULID/SemVer/RFC3339 patterns, identity guards, corrupt-payload defense, `parent_run_id` cross-plugin chain (session-receipt.envelope.parent_run_id === consumed evolve-insights.envelope.run_id), and intra-plugin chain (session-receipt's `provenance.source_artifacts[]` aggregates all SLICE-*.json `run_id`s).
+
+- `tests/phase-guard-golden.test.js` — fixture-driven golden test for `phase-guard.sh` (8 scenarios: idle allow, implement slice scope in/out, four non-implement denylist families, override pass-through).
+- Shared `scrubHostEnv()` / `runPhaseGuard()` / `parseGuardOutput()` test helpers; per-family `CLAUDE_ALLOW_<FAMILY>` override loop and override fall-through composition assertions.
 
 ### Changed
-- **`agents/implement-slice-worker.md`** — slice receipt emission protocol now writes the legacy body to `$WORK_DIR/receipts/.SLICE-NNN.payload.json` first, then invokes `node ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/wrap-receipt-envelope.js --artifact-kind slice-receipt ...` to produce the final envelope-wrapped `SLICE-NNN.json`. Payload `schema_version` must be the literal string `"1.0"`.
-- **`commands/deep-finish.md`** — Section 2 now writes the session-receipt body to `$WORK_DIR/.session-receipt.payload.json`. Sections 2-1 (quality fields) and 7 (outcome/outcome_ref) update the same temp file. New Section 7-Z performs the envelope wrap exactly once, after the outcome is decided, so `envelope.run_id` is generated only once per session. Cross-plugin chain is auto-detected from `.deep-evolve/<session>/evolve-insights.json` and `.deep-dashboard/harnessability-report.json`.
-- **`hooks/scripts/verify-delegated-receipt-runner.js`** — slice receipt loader invokes `unwrapEnvelope()` so verify-receipt-core sees the legacy body whether the file is envelope-wrapped or legacy. Identity-mismatched envelopes throw with a descriptive error.
-- **`hooks/scripts/validate-receipt.sh`** — `json_field` helper detects M3 envelope and reads from `.payload`, with full identity guard before unwrap. Falls through to top-level read for legacy receipts.
-- **`hooks/scripts/session-end.sh`** — slice receipt aggregation loop skips foreign envelopes (producer/artifact_kind/schema.name mismatch) before counting toward `slices_total`.
-- **`hooks/scripts/receipt-migration.js`** — envelope-wrapped receipts are recognized as already-migrated (no-op); the legacy v0 → v1.0 lift only applies to top-level legacy receipts.
-- **`skills/deep-integrate/gather-signals.sh`** — `read_json_safe` accepts optional `expected_producer` / `expected_artifact_kind` arguments and returns `.payload` for matching envelopes, `null` for foreign envelopes (defense-in-depth, handoff §4 round-4 lesson). Applied to deep-work session-receipt, deep-docs last-scan, deep-dashboard harnessability-report, deep-evolve evolve-insights, deep-wiki index. Forward-compat for deep-review/deep-evolve/deep-wiki Phase 2 priority #4–#6.
-- **`skills/deep-research/SKILL.md`** — Cross-Plugin Context section (Harnessability + Evolve Insights) documents envelope detection + identity guard procedure, with legacy fallback for forward-compat.
-- **`commands/deep-receipt.md`** / **`commands/deep-status.md`** / **`commands/deep-report.md`** — receipt read instructions document the envelope-aware unwrap rule (identity guard + payload extraction; legacy pass-through preserved).
 
-### Notes
-- Suite-side updates (claude-deep-suite `marketplace.json` SHA bump, `payload-registry/deep-work/{session,slice}-receipt/v1.0.schema.json` placeholder → authoritative shape, adoption ledger update) are out of scope for this PR per claude-deep-suite handoff §1: M3 Phase 2 plugin PRs touch the plugin repo only; suite-side updates are batched in Phase 3.
+- Extended `phase-guard-core.js` documentation on gate order, override-env semantics (suppresses denylist only, file-write still applies), and intentional scope omissions.
+
+## [6.6.2] — 2026-05-12
+
+### Added
+
+- Non-implement dangerous-command denylist in `phase-guard-core.js` covering 5 families (rm-rf, npm-publish, kubectl-destructive, sql-destructive, curl-pipe-shell), each with a `CLAUDE_ALLOW_<FAMILY>=1` override; gate applied at research/plan/test/brainstorm Bash entry.
+
+### Fixed
+
+- SQL `TRUNCATE` single-char match bug and kubectl `--all-namespaces` false-positive.
+
+## [6.6.1] — 2026-05-12
+
+### Added
+
+- Cross-platform CI matrix (`ubuntu-latest` + `macos-latest`) running `npm test` plus bash regression scripts.
+
+### Fixed
+
+- Cross-platform `stat` fallback (`stat -c '%a' || stat -f '%A'`) in a regression script.
+
+## [6.6.0] — 2026-05-12
+
+### Added
+
+- `hooks/scripts/emit-handoff.js` — wraps a handoff payload in the M3 envelope and writes it under `.deep-work/handoffs/`, auto-chaining `parent_run_id` to the session receipt.
+- `hooks/scripts/emit-compaction-state.js` — wraps a compaction-state payload in the M3 envelope (validated trigger/strategy enums); powers dashboard compaction metrics.
+- `deep-finish` emits a cross-plugin handoff when `--handoff-to=<plugin>` is supplied.
+- Stop hook and phase-transition hook emit best-effort `compaction-state.json` on session close and at each phase boundary.
+
+### Changed
+
+- `ALLOWED_ARTIFACT_KINDS` extended with `handoff` and `compaction-state` across the envelope library and CI validator.
+
+## [6.5.0] — 2026-05-07
+
+### Added
+
+- M3 cross-plugin envelope adoption: `session-receipt.json` and `receipts/SLICE-*.json` now ship as `{ schema_version, envelope, payload }`, with the session receipt's `parent_run_id` chaining to the consumed `evolve-insights.json` and `provenance.source_artifacts[]` aggregating slice run IDs.
+- `hooks/scripts/envelope.js` — zero-dep envelope library (ULID generator, git detection, `wrapEnvelope`/`unwrapEnvelope` with identity guards and corrupt-payload defense).
+- `hooks/scripts/wrap-receipt-envelope.js` — CLI helper for wrapping a payload, with cross-plugin/intra-plugin chain extraction flags.
+- `scripts/validate-envelope-emit.js` — zero-dep self-test validator mirroring the suite envelope schema.
+
+### Changed
+
+- Internal readers and cross-plugin consumers detect the envelope, enforce the identity guard, and unwrap to `.payload`; legacy non-envelope receipts pass through (forward-compatible).
 
 ## [6.4.2] — 2026-04-29
 
 ### Added
-- **Profile schema v3** — `interactive_each_session` array lets each user customize which items are asked every session. `defaults.*` separates values that are applied automatically.
-- **session-recommender sub-agent** — sonnet by default; receives task description + workspace meta + capability and returns fenced JSON recommendations. Allowlist `^(haiku|sonnet|opus)$`.
-- **`--no-ask` flag** — skips ask + recommender entirely (fastest path). `--profile=X --no-ask` is the v6.4.x "proceed as-is" equivalent.
-- **`--recommender=MODEL` / `--no-recommender` flags** — override the recommender model or skip the recommender step entirely.
-- **State file `recommendations` field** — optional; has no effect on phase-guard enforcement.
-- **State file permissions 600** — README guidance added for multi-user environments.
-- **`scripts/load-v3-profile.js`** — v3 schema profile loader (orchestrator §1-3-3).
-- **`scripts/parse-deep-work-flags.js`** — CLI flag parser with allowlists (PROFILE_NAME / RECOMMENDER / EXEC / TDD / RESUME_FROM).
-- **`scripts/detect-capability.js`** + **`scripts/format-ask-options.js`** — environment capability detection + AskUserQuestion option formatter.
-- **`scripts/migrate-profile-v2-to-v3.js`** — profile v2→v3 migration helper: atomic write + `flock` + idempotent + `.v2-backup` + rollback procedure.
-- **`scripts/recommender-input.js`** + **`scripts/recommender-parser.js`** — session-recommender input sanitization and output parser (5-key validation).
-- **`agents/session-recommender.md`** — session-init recommendation sub-agent (sonnet by default).
+
+- Profile schema v3 with `interactive_each_session` — per-user control of which items are asked each session, with `defaults.*` applied automatically.
+- `session-recommender` sub-agent (sonnet by default) infers ideal `team_mode` / `start_phase` / `tdd_mode` / `git` / `model_routing` from the task and workspace.
+- New flags: `--no-ask` (skip ask + recommender, fastest path), `--recommender=MODEL`, `--no-recommender`.
+- State-file permissions guidance (600) for multi-user environments.
 
 ### Changed
-- **`--profile=X` semantics preserved** — proceeds through the ask step as in v6.4.x (prevents silent regression). Users who relied on the fast path need to add `--no-ask`.
-- **Profile v2 → v3 auto-migration** — atomic write + `flock` + idempotent + `.v2-backup` backup + rollback procedure in README.
-- **Orchestrator §1-3 unified** — single confirm replaced by per-item ask N times + LLM recommendation. ask/recommender results are in-memory only; atomically serialized at §1-9 state-creation time.
-- **Assumption auto-adjust → recommender order** — auto-adjust result is reflected in recommender input `current_defaults`.
+
+- `--profile=X` now proceeds through the ask step (add `--no-ask` for the old fast path).
+- Profile v2 → v3 auto-migration: atomic write + flock + idempotent + `.v2-backup` + rollback.
 
 ### Fixed
-- **Shell injection in flag parser**: `parse-deep-work-flags` now accepts quoted single-string `$ARGUMENTS` — shell metacharacters are no longer evaluated before the allowlist check (orchestrator §1-3-1 invocation pattern).
-- **v6.4.1 `git_branch` profile compat**: `migrate-profile-v2-to-v3` translates `git_branch: <bool>` (v6.4.1 schema) to `defaults.git.use_branch` instead of rejecting it as an unsupported schema.
-- **Capability detection false negatives**: orchestrator §1-4-2 now uses `git rev-parse --is-inside-work-tree` + `git worktree list` instead of the `IS_GIT` env var — fixes false non-git detection in normal git repos.
-- **`--profile=X` not forwarded to loader**: `--profile=X` is now passed to `load-v3-profile.js` via `DEEP_WORK_INITIAL_PRESET` env (parity with migrate-profile call).
-- **Preset-level settings silently dropped**: `loadV3Profile` now returns `project_type`, `cross_model_preference`, and `auto_update` (previously these were dropped, silently losing zero-base / cross-model / auto-update settings).
+
+- Shell injection in the flag parser (quoted single-string `$ARGUMENTS` no longer evaluated before the allowlist check).
+- v6.4.1 `git_branch:` profiles are translated rather than rejected.
+- Capability detection false negatives in normal git repos (uses `git rev-parse`/`git worktree list`).
+- `--profile=X` now forwarded to the profile loader; preset-level settings (`project_type`, `cross_model_preference`, `auto_update`) no longer silently dropped.
 
 ### Removed
-- **Notification system removed entirely** — `hooks/scripts/notify.sh` (195 lines), `hooks/scripts/notify-parse.test.js` (125 lines), `skills/shared/references/notification-guide.md` (59 lines) deleted. Notify.sh guards cleaned from 5 phase skills + `multi-session.test.js`. **Note**: the `notification` variable in `assumption-engine.{js,test.js}` is an assumption auto-adjust result message (internal vocabulary) unrelated to external notifications — preserved.
 
-### Breaking Changes (patch bump, but explicit notice required)
+- Notification system removed entirely — `notify.sh`, its tests, and the notification guide deleted, and notify guards cleaned from the phase skills.
 
-- **Notification webhook users**: notify.sh + Slack/Discord/Telegram/webhook integrations are severed by this release. The patch bump was a user decision, but any active external webhook integration must be manually forked/backported before upgrading.
-- **Automated scripts using only `--profile=X`**: from v6.4.2, `--profile=X` proceeds through the ask step (to avoid silent regression). Add `--profile=X --no-ask` to preserve the old behavior.
-- **Profile schema v2 → v3 auto-migration**: no preserved data is lost, but `notifications.url` and similar fields are unrecoverable. `.v2-backup` is retained (rollback is possible).
+### Breaking
 
-### Migration
+- Slack/Discord/Telegram/webhook integrations are severed; active webhook users must fork v6.4.1 before upgrading.
+- Automated scripts relying on bare `--profile=X` must add `--no-ask` to preserve the old behavior.
+- Profile v2 → v3 auto-migration loses unrecoverable fields such as `notifications.url` (a `.v2-backup` is retained for rollback).
 
-- v6.4.x → v6.4.2: auto-migration runs on first call + one-time notice. External webhook integrations are severed by this release.
-- Rollback: `mv .claude/deep-work-profile.yaml.v2-backup .claude/deep-work-profile.yaml` (project-local).
-
-### Spec & Plan
-
-- Design: `docs/superpowers/specs/2026-04-29-deep-work-flexible-init-design.md`
-- Plan: `docs/superpowers/plans/2026-04-29-deep-work-flexible-init.md`
-
-## [6.4.1] - 2026-04-26
-
-### Changed
-- **Harness Engineering hardening**: SessionStart sensor detection now avoids slow `npx --no-install` probes and uses local `node_modules/.bin` plus fast PATH lookup so missing-tool environments complete well inside hook timeout.
-- **Phase 1 Health Engine wiring**: `deep-research` now documents the parent-owned topology, fitness proposal, health report, baseline, and unresolved required issue flow. `health-check` CLI auto-loads `.deep-review/fitness.json` by default and supports explicit `--fitness` / `--no-fitness`.
-- **Health report schema alignment**: `/deep-status` and `/deep-receipt` now read the actual producer paths under `health_report.drift.*` and `health_report.fitness.*`.
-
-### Fixed
-- **`multi-session.test.js:507` lint guard false-positive**. The exclusion regex only exempted `multi-session.test.js` itself, so legitimate test fixtures in `phase5-guard.test.js` (8 intentional `deep-work.local.md` references required to exercise the legacy-path code path) were flagged as "hardcoded legacy path in active code". Regex broadened from `multi-session\.test\.js` → `\.test\.js` so all test files are exempt — test files legitimately need these paths to verify legacy behavior. `node --test hooks/scripts/*.test.js` now reports 428/428 pass (previously 427/428 with this known failure documented in v6.3.1 Excluded notes).
-- **Receipt sensor validation compatibility**: Parent receipt verification now rejects empty/arbitrary sensor results, `fail`, `timeout`, and unsupported `not_applicable`, while still accepting documented metadata such as `sensor_results.ecosystem` and legacy delegated `skipped` statuses.
-- **Health Check CLI root parsing**: `--fitness <file>` and `--fitness=<file>` option values are no longer mistaken for the positional project root.
-
-## [6.4.0] - 2026-04-23
-
-### Changed — Breaking
-- **`model_routing.{research, implement, test}="main"` removed**. Existing state files are auto-migrated to `"sonnet"` on load. `model_routing.plan="main"` is preserved (Plan phase keeps conversational main-session execution).
-- **`team_mode` semantics unified** to concurrency only (solo=1, team=N). Main-session inline execution is now an explicit escape hatch, not a hidden default.
-
-### Added
-- 3 Claude Code subagents under `agents/`:
-  - `research-codebase-worker` — existing-codebase research (read-only tool allowlist)
-  - `research-zerobase-worker` — new-project research with web access (WebSearch/WebFetch/Context7 MCP)
-  - `implement-slice-worker` — TDD-enforced slice cluster implementation
-- `hooks/scripts/verify-delegated-receipt.sh` + `verify-receipt-core.js` — 8-item post-hoc receipt validation (scope, baseline chain, TDD hard-fail, recorded verification output advisory)
-- §5.6a Rollback Protocol: `git reset --hard <delegation_snapshot>` on verify-receipt failure
-- §5.5a inline escape hatches: auto-routing (spike, trivial inline plan) + `--exec=<inline|delegate>` CLI override + debug takeover via `active_cluster_takeover` state field
-- `scripts/validate-agents.sh` — static sanity check for agents/*.md
-
-### Fixed
-- Silent fallback from `team_mode=team` to solo when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` was missing (original bug)
-- Single `git_before` baseline reused across multi-slice receipts → per-slice `git_before_slice`/`git_after_slice` (F1)
-- Path-filtered diff hiding out-of-scope edits → unfiltered union-scope check (F2)
-- Zero-base subagent inheriting Write/Edit/Bash + web access → explicit read-only tool allowlist (F3 security)
-
-### Migration
-See `docs/migrations/v6.4.0.md`.
-
-## v6.3.1 — 2026-04-21
-
-### Fixed
-
-- **Phase skill body echo 버그** — `Skill("deep-*")` 호출 시 SKILL.md 본문의 markdown 템플릿이 사용자에게 노출된 뒤 phase 작업(예: brainstorm의 명확화 질문)이 수행되지 않고 대화가 종료되는 현상. 브레인스톰의 명확화 질문 누락 및 리서치/플랜의 분석 단계 누락을 모두 해결.
-- **Exit Gate pause/resume 회귀** (F1) — phase skill이 완료 시 current_phase를 다음 phase로 미리 전환하던 기존 동작이 Exit Gate "일시정지" 선택 시 `/deep-resume` 재개 경로에서 Exit Gate를 건너뛰고 다음 phase로 자동 진입하는 문제를 야기. current_phase 변경 주체를 Orchestrator로 일원화하여 해결.
-
-### Added
-
-- **4계층 echo 방어** (5개 phase skill 공통):
-  1. `> [!IMPORTANT]` admonition 블록 — skill body echo 금지 + Pre-checks 예외 허용
-  2. 템플릿 외부 분리 — `skills/shared/templates/{brainstorm,research}-template.md` + `plan-template-{existing,zerobase}.md` (2-mode 분기)
-  3. First Action 서브섹션 — phase 진입 시 즉시 수행할 가시 첫 동작 명시
-  4. Section 3 실행 순서 안전장치
-- **Phase Exit Gate × 5** — 각 phase 완료 시 AskUserQuestion으로 "진행 / 재실행 / 일시정지" 선택. "진행" 선택 시 즉시 다음 skill 호출.
-- **완료-Marker 감지 분기** — 모든 5개 phase skill Section 1에서 `*_completed_at` 필드 감지 시 Orchestrator로 제어 반환 (Exit Gate 재표시).
+## [6.4.1] — 2026-04-26
 
 ### Changed
 
-- **current_phase 변경 주체 일원화**: Brainstorm/Implement phase skill이 Section 3에서 직접 변경하던 동작 제거. 모든 phase의 current_phase 변경을 Orchestrator Exit Gate "진행" 분기로 이관.
-- Orchestrator §1-11 문구: "자동 흐름을 시작합니다..." → "각 phase 완료 시 진행 확인을 받으며 순차 실행합니다..."
-- `review-approval-workflow.md`: Exit Gate와의 관계 명시.
+- SessionStart sensor detection avoids slow `npx --no-install` probes, using local `node_modules/.bin` plus PATH lookup so missing-tool environments finish inside the hook timeout.
+- Phase 1 Health Engine wiring documented in `deep-research`; the `health-check` CLI auto-loads `.deep-review/fitness.json` with `--fitness` / `--no-fitness` overrides.
+- `/deep-status` and `/deep-receipt` read the actual producer paths under `health_report.drift.*` / `health_report.fitness.*`.
 
-### Excluded
+### Fixed
 
-- Phase 5 Integrate는 이미 interactive loop이므로 Exit Gate 적용 대상에서 제외.
-- Hook 스크립트 로직 변경 없음. `node --test hooks/scripts/*.test.js` 결과: 397/398 pass. 1 pre-existing failure (`multi-session.test.js:507` - phase5-guard.test.js fixture와의 lint 충돌)는 main 브랜치에도 존재하며 v6.3.1과 무관.
+- Lint guard false-positive on test fixtures (exemption broadened from one file to all `*.test.js`).
+- Parent receipt verification rejects empty/arbitrary sensor results, `fail`, `timeout`, and unsupported `not_applicable`, while still accepting documented metadata.
+- Health Check CLI no longer mistakes `--fitness <file>` for the positional project root.
 
-### Added (v6.3.1 NW5 integrity check + NO3 data preservation)
+## [6.4.0] — 2026-04-23
 
-- **Approval integrity hash** — Research/Plan approval 시점의 `sha256(research.md/plan.md)`를 `research_approved_hash` / `plan_approved_hash`로 state에 기록. `/deep-resume` Resume fast-path가 현재 파일 hash와 비교하여 out-of-band 편집(일시정지 중 외부 편집기 수정 등)을 자동 감지 — 불일치 시 **data preservation + in-place review** 경로 발동 (NO3): 편집된 문서를 `$WORK_DIR/{research,plan}.v{N}-edit.md`로 백업 + approval state invalidate + Skill 재호출 스킵하고 Review+Approval workflow 직접 진입. 편집 내용이 보존된 채 재검토되어 사용자 편집이 유실되지 않음. 필드 부재 시(pre-v6.3.1 세션 또는 재실행 후 재승인 전)는 Skill 재실행이 safer default.
-- **Backup filename collision 방지 (NP3)**: orchestrator가 생성하는 hash mismatch backup은 `-edit` 접미사를 사용하여 deep-plan/deep-research skill의 자체 backup(`v{N}.md`)과 파일명 충돌 방지.
+### Changed
 
-### Known Limitations (v6.3.2 예정)
+- **Breaking**: `model_routing.{research,implement,test}="main"` removed (auto-migrated to `"sonnet"` on load); `model_routing.plan="main"` preserved.
+- **Breaking**: `team_mode` semantics unified to concurrency only (solo=1, team=N); main-session inline execution is now an explicit escape hatch.
 
-- **Hash mismatch recovery의 plan-specific validation 부재**: NO3 data preservation 경로는 generic Review+Approval workflow를 실행하나, `deep-plan` 고유 validation(Completeness Policy, Contract Negotiation, Phase Review Gate)는 스킵됨. Out-of-band 편집이 `TBD` 같은 placeholder를 추가한 뒤 승인되는 경로는 현재 가드 불충분. Workaround: Exit Gate option 2 "재실행/수정"을 사용하면 skill 재실행으로 모든 validation 적용됨. v6.3.2에서 in-place review에도 phase-specific validation hook 추가 예정.
-- **Backup write-failure fail-safe 부재**: NO3 backup 복사 실패 시(권한/디스크 full 등) state 변경을 중단하는 가드 없음. 희귀 edge case이며 data는 여전히 원본 research.md/plan.md에 남아있음. v6.3.2에서 backup 실패 시 state 변경 중단 + 사용자 알림 가드 추가 예정.
+### Added
+
+- Three subagents under `agents/`: `research-codebase-worker` (read-only), `research-zerobase-worker` (read-only + web access), `implement-slice-worker` (TDD-enforced).
+- `verify-delegated-receipt.sh` + `verify-receipt-core.js` — 8-item post-hoc receipt validation.
+- Rollback protocol (`git reset --hard <snapshot>`) on verify-receipt failure; inline escape hatches (auto-routing, `--exec=<inline|delegate>`, debug takeover).
+- `scripts/validate-agents.sh` — static sanity check for `agents/*.md`.
+
+### Fixed
+
+- Silent fallback from `team_mode=team` to solo when the experimental-teams env var was missing.
+- Single `git_before` baseline reused across multi-slice receipts → per-slice baselines.
+- Path-filtered diff hiding out-of-scope edits → unfiltered union-scope check.
+- Zero-base subagent inheriting Write/Edit/Bash + web access → explicit read-only tool allowlist.
+
+## [6.3.1] — 2026-04-21
+
+### Fixed
+
+- Phase skill body echo bug — `Skill("deep-*")` no longer exposes the SKILL.md template and skips the phase work (brainstorm clarifying questions, research/plan analysis).
+- Exit Gate pause/resume regression — `current_phase` is now changed only by the orchestrator, so choosing "pause" re-presents the Exit Gate on `/deep-resume` instead of auto-entering the next phase.
+
+### Added
+
+- 4-layer echo defense across the 5 phase skills (admonition block, external templates, explicit First Action, execution-order safeguard).
+- Phase Exit Gate on each of the 5 phases (proceed / re-run / pause) via AskUserQuestion.
+- Completion-marker detection: phase skills return control to the orchestrator when a `*_completed_at` field is present.
+- Approval integrity hash (`research_approved_hash` / `plan_approved_hash`) so `/deep-resume` detects out-of-band edits and backs up the edited doc to `{research,plan}.v{N}-edit.md` before re-review.
+- Backup filename collision avoidance (`-edit` suffix vs. the skills' own `v{N}.md`).
+
+### Known limitations
+
+- Hash-mismatch recovery runs the generic review/approval flow without plan-specific validation (Completeness Policy, Contract Negotiation, Phase Review Gate); use Exit Gate "re-run" to apply full validation. Backup write-failure does not yet halt the state change.
 
 ## [6.3.0] — 2026-04-18
 
 ### Added
-- **Phase 5 "Integrate"** — new skippable phase after Test that reads deep-suite plugin artifacts (`deep-review`, `deep-docs`, `deep-wiki`, `deep-dashboard`, `deep-evolve`) and lets an AI recommend top-3 next steps which the user can choose to execute. Interactive loop (max 5 rounds) with recommendation + rationale + signals. Design spec: `docs/superpowers/specs/2026-04-18-phase5-integrate-design.md`.
-- `/deep-integrate` command for manual re-entry after skipping Phase 5.
-- `--skip-integrate` flag to skip Phase 5 and go directly to `/deep-finish`.
-- `skills/deep-integrate/` — new skill with helper scripts (`detect-plugins.sh`, `gather-signals.sh`, `phase5-finalize.sh`, `phase5-record-error.sh`), JSON schemas, and L6 snapshot fixtures.
-- `phase5_work_dir_snapshot` state field — immutable boundary snapshot recorded at Phase 5 entry, used by phase-guard as enforcement reference so that runtime tampering with `work_dir` cannot widen the write boundary.
-- `phase5-finalize.sh` helper — atomically records `phase5_completed_at` in the session state file. Validates the state file matches the current session and is the only sanctioned path for writing to state during Phase 5.
-- `phase5-record-error.sh` helper — used by `/deep-finish --skip-integrate` to record `terminated_by: "error"` in `integrate-loop.json` when Phase 5 failed. Belt-and-suspenders alongside the Stop-hook `terminated_by: "interrupted"` marker.
-- Stop-hook: record `terminated_by: "interrupted"` in `integrate-loop.json` on session interruption.
+
+- **Phase 5 "Integrate"** — a skippable phase after Test that reads deep-suite plugin artifacts and lets an AI recommend the top-3 next steps in an interactive loop (max 5 rounds).
+- `/deep-integrate` command for manual re-entry; `--skip-integrate` flag to go straight to `/deep-finish`.
+- `skills/deep-integrate/` with helper scripts, JSON schemas, and fixtures.
+- `phase5_work_dir_snapshot` state field — immutable boundary recorded at Phase 5 entry so runtime tampering with `work_dir` cannot widen the write boundary.
+- `phase5-finalize.sh` (only sanctioned path to write state during Phase 5) and `phase5-record-error.sh` (records `terminated_by: "error"`); Stop hook records `terminated_by: "interrupted"`.
 
 ### Changed
-- `deep-work-orchestrator` dispatches Phase 5 between Phase 4 (Test) and `/deep-finish`. On Phase 5 error, passes `--skip-integrate` to `/deep-finish` so state-machine can close.
-- `/deep-finish` hints `/deep-integrate` when no `integrate-loop.json` exists. `--skip-integrate` now bypasses the Phase 5-interrupted prompt and runs `phase5-record-error.sh` defensively.
-- **`phase-guard.sh` — new Phase 5 mode** (supersedes the prior "no changes required" plan in earlier drafts). When `current_phase=idle + phase5_entered_at + !phase5_completed_at` the guard enforces:
-  - `Write/Edit/MultiEdit/NotebookEdit`: target path must be under snapshot `$WORK_DIR`; state file direct modification is blocked — only `phase5-finalize.sh` may mutate it.
-  - `Bash`: **allowlist-only (default-deny)**. The first command token (after env-var prefixes) must be in the Phase 5 read-mostly allowlist: filesystem read (`cat`/`head`/`tail`/`wc`/`ls`/`pwd`/`file`/`stat`/`realpath`/`readlink`/`dirname`/`basename`), search/filter (`grep`/`sort`/`uniq`/`diff`/`cut`/`paste`/`column`/`tr`/`find`), JSON/YAML read (`jq`/`yq` without `-i`), shell builtins (`echo`/`printf`/`date`/`env`/`true`/`false`/`test`/`which`/`type`/`command`/`xxd`/checksums), `git` with read-only subcommand (`status`/`diff`/`log`/`show`/`blame`/`grep`/`rev-parse`/`rev-list`/`merge-base`/`symbolic-ref`/`ls-files`/`ls-tree`/`branch`/`tag`/`config`/`describe`/`cat-file`/`fsck`/`shortlog`/`reflog`/`name-rev`/`for-each-ref`/`count-objects`/`verify-pack`/`check-ignore`/`check-attr`/`var`/`help`/`version`), interpreters (`bash`/`sh`/`python`/`perl`/`ruby`/`node`/`awk`/`sed`/`php`/`osascript`/`tsx`/`deno`/`bun`) with canonical script path check, or filesystem ops (`mv`/`cp`/`mkdir`/`rm`/`rmdir`/`chmod`/`chown`/`truncate`/`touch`/`ln`/`install`) with target-in-`$WORK_DIR` verification. Unknown commands are rejected outright. Additional constraints: destructive variants (`/bin/rm`, `\rm`, `command/exec/builtin rm`) normalized; `git` global flags (`-C <path>`, `--git-dir [=]<path>`, `--work-tree [=]<path>`, `-c <k=v>`, `-p`/`--no-pager`/`--bare`/...) stripped via fixed-point iteration; `git` mutating subcommands (`add|commit|stash|checkout|merge|reset|rebase|cherry-pick|revert|apply|mv|rm|tag|push|fetch|pull|clean|am|format-patch|worktree|branch|submodule|notes|update-ref|write-tree|hash-object|bisect|replace|gc|prune|repack|reflog|remote|restore|switch|filter-branch|filter-repo`) blocked after normalization; `find -delete/-exec/-ok/...` blocked; `jq/sed/perl/ruby -i` in-place flags blocked; interpreter `-c/-e` flags blocked; compound operators (`;`, `&&`, `||`, `|`, `&`) rejected; shell metacharacters in helper paths (`$`, `` ` ``, `(`, `)`, `<`, `>`, newline, CR) rejected. `mv`/`cp` checks both SRC and DEST. **Interpreter + script invocations** (e.g. `python foo.py`, `sh foo.sh`) require the script path's canonical `realpath` to exactly match `${PROJECT_ROOT}/skills/deep-integrate/<helper>.sh` or `${HOME}/.claude/plugins/cache/claude-deep-suite/deep-work/*/skills/deep-integrate/<helper>.sh`; fake helpers under `$WORK_DIR` and other cached plugins are rejected. All other tools (`Read`, `Glob`, `Grep`, `Agent`, `AskUserQuestion`, `Skill`) pass through.
-- `/deep-integrate` tool allowlist narrowed to `Skill, Read, Bash, Glob, Grep, Agent, AskUserQuestion` (removed `Write, Edit`).
+
+- The orchestrator dispatches Phase 5 between Test and `/deep-finish`; on error it passes `--skip-integrate`.
+- New Phase 5 guard mode: writes must stay under the snapshot `$WORK_DIR`, state mutation is restricted to `phase5-finalize.sh`, and Bash is allowlist-only (default-deny) — read-mostly commands and `$WORK_DIR`-scoped filesystem ops only, with destructive/in-place/compound forms blocked.
+- `/deep-integrate` tool allowlist narrowed (removed `Write`, `Edit`).
 
 ### Upgrade notes
-- Sessions that entered Phase 5 under v6.2.x without `phase5_work_dir_snapshot` will fall back to reading `work_dir` from the state file. Phase-guard preserves backward compatibility via this fallback, but such sessions are more exposed to state-tampering attacks. Re-entering Phase 5 on v6.3.0 records the snapshot automatically.
-- `phase5-finalize.sh` rejects any state-file path whose basename does not match `deep-work.<sid>.md` in a `.claude/` directory. Callers that previously wrote to state via direct redirect must migrate to this helper.
-- **Dependencies**: `phase5-record-error.sh`, `gather-signals.sh`, and the Stop-hook `terminated_by` marker require `jq` on `PATH` (helpers exit with an explicit error when missing). `phase5-finalize.sh` uses only `awk` (no `jq` dependency).
+
+- Sessions that entered Phase 5 under v6.2.x without the snapshot fall back to mutable `work_dir`; re-entering Phase 5 records the snapshot. Phase 5 helpers require `jq` on PATH (except `phase5-finalize.sh`).
 
 ### Known limitations
-- **Interpreter coverage**: `Rscript`/`julia`/`lua`/`groovy`/`tclsh` are not yet in the interpreter allowlist — if these become part of a legitimate Phase 5 workflow they must be added explicitly. Track in v6.3.1.
-- **`awk -f script.awk`**: the `-f` flag form is not covered by the interpreter-with-script canonical check (only `awk -e/-c` is blocked via the `-c/-e` rule). Practical risk is low because the Phase 5 Bash allowlist rejects unknown forms and legitimate workflow does not use `awk -f`.
-- **Legacy session upgrade**: sessions that started Phase 5 under v6.2.x without the `phase5_work_dir_snapshot` field fall back to the mutable `work_dir`; re-entering Phase 5 in v6.3.0 populates the snapshot.
-- **`phase5-record-error.sh` / `phase5-finalize.sh` unit tests**: currently covered indirectly via `phase5-guard.test.js`. Dedicated unit test file planned for v6.3.1.
-- **Allowlist command abuse**: commands in the read-mostly allowlist are permitted in their standard read-only form but remain theoretically abusable in niche invocations (e.g. `find` minus mutating flags blocked; `jq` without `-i`; `mv`/`cp`/`mkdir` with target checks; other entries assumed safe). Deeper per-command invocation audit (esp. `curl` is not allowed; data-exfil mitigation on other networked helpers) tracked in v6.4.0.
-- **Non-Bash tools (`Agent`/`Skill`)**: pass through the Phase 5 guard. Subagents dispatched via `Agent` carry their own tool set; Phase 5 enforcement applies only to the invoking session's Bash/Write/Edit. Treated as out-of-scope trust boundary for v6.3.0.
+
+- Some interpreters (`Rscript`/`julia`/`lua`/...) and `awk -f` are not in the Phase 5 allowlist; networked exfil mitigation and per-command invocation audit are tracked for later. `Agent`/`Skill` tools pass through the Phase 5 guard.
 
 ## [6.2.4] — 2026-04-17
 
-Bug fix release addressing 15 hook-layer bugs + 7 documentation drift items identified by an internal audit (`BUG_REVIEW_REPORT.md`). Plan reviewed independently before execution; 5 additional critical issues found during review were also addressed.
+Bug-fix release addressing hook-layer bugs and documentation drift from an internal audit.
 
 ### Fixed
 
-**Hooks — portability & parsing**
-- `file-tracker.sh`: Replace BSD-only `sed -i ''` with a Node.js inline script. The previous code failed silently on Linux (`sed -i`'s GNU syntax differs), leaving `sensor_cache_valid` stale after marker-file changes. The insert-when-missing path also mis-handled the second `---` delimiter even on macOS — now fixed.
-- `update-check.sh`: Pass the plugin path via `process.argv[1]` instead of shell interpolation. An install path containing an apostrophe (e.g. `/Users/O'Brien/...`) caused a JS syntax error and silently skipped the update check.
-- `phase-guard.sh` / `file-tracker.sh` / `phase-transition.sh`: Replace regex-based `file_path` extraction with `extract_file_path_from_json` (JSON parser). Paths containing escaped quotes (`a \"b\" c.txt`) were truncated, causing spurious blocks and receipt corruption.
-- `phase-transition.sh`: Extract the innermost `deep-work.XXXX` segment for `SESSION_ID`. Fork worktree paths like `.deep-work/sessions/deep-work.s-parent/sub/.claude/deep-work.s-child.md` now resolve to `s-child` instead of a multi-line mess that broke the cache file path.
+- `file-tracker.sh`: replaced BSD-only `sed -i ''` with a Node inline script (previous code failed silently on Linux).
+- `update-check.sh`: pass the plugin path via `process.argv` so install paths containing an apostrophe no longer break the update check.
+- `phase-guard.sh` / `file-tracker.sh` / `phase-transition.sh`: JSON-parser-based `file_path` extraction (paths with escaped quotes were truncated).
+- `phase-transition.sh`: extract the innermost `deep-work.XXXX` segment for `SESSION_ID` so fork worktree paths resolve correctly.
+- Receipt updates wrapped in a mkdir-based spinlock with a crash-safe pending-changes drain; `sensor-trigger.js` and `file-tracker.sh` share the state lock.
+- `utils.sh write_registry`: fail-closed on lock timeout (no force-remove of another process's lock) with errors logged.
+- `phase-guard-core.js`: internal errors `exit(3)` (distinct from intentional blocks); `phase-guard.sh` fail-closes on empty `decision`.
+- `phase-guard.sh`: reads `slice_files` / `strict_scope` / `exempt_patterns` from frontmatter so slice-scope is actually enforced; all block-message heredocs JSON-escape interpolated fields.
+- `phase-transition.sh` cache: `file-tracker.sh` caches stdin before any phase-based early return and writes atomically, so all phase transitions refresh the cache.
+- `notify.sh`: YAML-aware `notifications.enabled` parser, `osascript`/PowerShell-toast escaping, and `pipefail` dropped.
 
-**Hooks — race conditions**
-- `file-tracker.sh` receipt updates: Wrap read-modify-write with a mkdir-based spinlock (40 retries × 50ms). On timeout, queue the pending entry to `<receipt>.pending-changes.jsonl`; the next lock holder drains it crash-safely (rename-to-`.draining.<pid>` → merge → canonical rename → unlink `.draining`). A crash anywhere mid-drain leaves recoverable state; the next invocation sweeps stray `.draining.*` files. Previously, 5+ concurrent PostToolUse invocations could drop `files_modified` entries, and the first-pass lock-timeout path could silently orphan queued entries if no later write drained them.
-- `sensor-trigger.js` + `file-tracker.sh` state YAML updates: Both now acquire the same `<state>.lock` before read-modify-write — including the marker-file `sensor_cache_valid` flip in `file-tracker.sh` (which initially missed the lock in v6.2.4 and was flagged by post-review). Previously, `current_phase` / `active_slice` / `sensor_pending` / `sensor_cache_valid` could race and lose one of the writes.
-- `utils.sh` `write_registry`: Fail-closed on lock timeout (no force-remove of another process's lock directory). The old force-remove behaviour silently corrupted the session registry under contention. Callers (`register_session`, `update_last_activity`, `register_file_ownership`, `update_registry_phase`, `unregister_session`, `register_fork_session`) now use `_try_write_registry` which logs failures to `.claude/deep-work-guard-errors.log` instead of silently swallowing them.
-- `session-end.sh` JSONL append: Lock timeout queues to `<jsonl>.pending-append.jsonl`. Drain on the next append uses the same rename-first crash-safe pattern as the receipt path. Retries bumped 10 → 20.
+### Changed
 
-**Hooks — validation hardening**
-- `phase-guard-core.js`: Internal errors (malformed input, runtime exceptions) now `process.exit(3)` with a JSON block message pointing at the guard error log. Intentional blocks continue to exit 0 with `decision=block`. Previously, both paths exited 2 — indistinguishable in user-facing output.
-- `phase-guard.sh`: Translate Node exit 3 to hook exit 2 with the debug-oriented block message. Empty `decision` on stdout now fail-closes with a distinct message instead of silently allowing.
-- `phase-guard.sh`: Read `slice_files` / `strict_scope` / `exempt_patterns` from state frontmatter (via the new `read_frontmatter_list` helper) and pass them into the Node input. Previously, these fields were never populated, so `checkSliceScope` received `undefined` and returned `inScope=true` unconditionally — the slice-scope contract in `deep-implement/SKILL.md` was silently unenforced.
-- `phase-guard.sh` block messages: All 4 heredocs now JSON-escape interpolated fields (file path, worktree path, phase label, next-step). Messages with literal quotes or newlines previously produced invalid JSON.
-
-**Hooks — phase-transition injector (C-1)**
-- `file-tracker.sh` caches stdin to `$PROJECT_ROOT/.claude/.hook-tool-input.<ppid>` **before** any phase-based early return, and writes atomically via `.tmp.$$` + `mv`. `phase-transition.sh` falls back to this cache when `CLAUDE_TOOL_USE_INPUT` / `CLAUDE_TOOL_INPUT` are unset — which is the actual Claude Code production behaviour (these env vars are not part of the hook protocol). Previously (even after the initial v6.2.4 fix), the cache was only written inside the `implement`-phase branch, so research→plan, plan→implement, and test→idle transitions never refreshed the cache; `phase-transition.sh` would fall back to a stale implement-phase payload or no-op. Post-review fix moves the cache write to the top of the hook.
-- `session-end.sh` now cleans up its own `.hook-tool-input.$PPID` and reaps `.hook-tool-input.*` files older than 60 minutes — the cache is transient per-tool-call and should not accumulate across sessions.
-
-**Notifications**
-- `notify.sh`: YAML-aware `notifications.enabled` parser. Previously, `grep -q "^  enabled: false"` false-positive-matched an unrelated `team_mode:\n  enabled: false`, silently suppressing all channels.
-- `notify.sh`: `_osascript_escape` helper applied to macOS `osascript` calls. A double-quote in the message (e.g. `phase "done"`) previously caused a silent syntax error.
-- `notify.sh`: `_xml_escape` helper applied to Windows PowerShell toast XML. `<`, `&`, `"` in the message would have broken the XML document and the notification would never appear.
-- `notify.sh`: Drop `pipefail` from `set -euo pipefail`. This is a best-effort script; many `grep` pipelines legitimately return non-zero when a channel isn't configured, and `pipefail` turned those no-ops into script aborts.
-
-**Documentation**
-- 21 broken `skills/shared/references/` → `../shared/references/` link fixes across 7 `SKILL.md` files (`deep-work-workflow`, `deep-test`, `deep-implement`, `deep-plan`, `deep-research`, `deep-brainstorm`, `deep-work-orchestrator`).
-- 13 `(v6.2.1)` labels in `commands/*.md` refreshed to `(v6.2.4)`.
-- `commands/deep-finish.md` example: `"deep_work_version": "5.3.0"` → `"6.2.4"` (was frozen across two minor releases).
-- `hooks/hooks.json` description: `(v5.6.0 Session Fork)` → `(v6.2.4)`.
-- `skills/deep-work-orchestrator/SKILL.md`: Corrected Test row in the phase ownership table — it is Orchestrator (not the Phase Skill) that transitions Test → idle after `/deep-finish`.
-- `skills/deep-work-orchestrator/SKILL.md`: Documented `--resume-from=<phase>` flag that `deep-resume.md` was already passing, but was undocumented in Orchestrator.
-- `CLAUDE.md`: Added previously-omitted directories and files to the structure listing (`sensors/`, `health/`, `templates/topologies/`, `assumptions.json`, `package.json`).
-
-### Internal
-
-- New `hooks/scripts/utils.sh` helpers consumed across the hook layer:
-  - `_acquire_lock` / `_release_lock`: mkdir-based advisory spinlock, fail-closed on timeout (logs to `.claude/deep-work-guard-errors.log`).
-  - `extract_file_path_from_json`: JSON-parser-based file_path extraction; handles escaped quotes correctly.
-  - `json_escape`: JSON-string escape for safe interpolation into block messages. Argument required — no stdin fallback (prevents hook hangs).
-  - `read_frontmatter_list`: reads YAML list fields (inline `[a, b]` or block `- a`) from frontmatter; emits JSON array.
-- `hooks/scripts/utils.sh` `write_registry`: refactored to use `_acquire_lock` with fail-closed behavior.
-- Test suite: 329 tests (from 294 in 6.2.3), across 91 suites. Net +35 tests covering: portability (3), input parsing e2e (5), notify YAML/escape (4), receipt race (1, 80 parallel writes — now validates canonical completeness + empty pending sidecar + no leftover `.draining.*` files), phase-guard hardening (6), phase-transition cache (2), utils helpers (19), post-review robustness (7: cache-before-phase-check × 4 phases, marker-flip lock behaviour × 2, atomic cache write × 1).
-- Independent review (3-way: Opus + Codex review + Codex adversarial) identified 3 critical + 3 warning issues on the initial v6.2.4 branch; all were addressed before merge. Report: `.deep-review/reports/2026-04-17-implementation-review.md`.
+- Documentation: 21 broken reference links fixed across 7 SKILL.md files; version labels refreshed; CLAUDE.md structure listing completed.
 
 ### Known limitations
 
-- Cross-platform CI matrix is not yet in place. All new fixes are unit-tested against Node `node --test`, but Linux/Windows coverage relies on the new portability logic rather than CI enforcement. Tracked for a future release.
+- Cross-platform CI matrix not yet in place; new portability fixes rely on unit tests.
 
 ## [6.2.3] — 2026-04-16
 
 ### Changed
-- **trigger-eval.json v6.2 update**: Benchmark test set expanded from 31 to 54 samples (true 21 + false 33). Added 10 true samples for v6.2 features (Session Fork, Mutation Test, Brainstorm, Team Mode, Assumption Engine, Worktree, English queries, semantic-only trigger, Debug). Added 13 false samples (homophone disambiguation, meta-queries, English hard negatives, standalone command invocations). Reclassified 5 existing true samples to false (SOLID review, drift check, deep-status, quality gate config, preset setup) — standalone commands should not trigger full workflow sessions.
+
+- `trigger-eval.json` benchmark set expanded 31 → 54 samples and rebalanced; standalone commands reclassified to not trigger full workflow sessions.
 
 ## [6.2.2] — 2026-04-16
 
 ### Fixed
-- **Cross-platform hooks compatibility**: Removed POSIX inline env var assignments (`FOO=bar command`) from all 5 hook commands in `hooks.json`. Windows `cmd.exe` cannot parse this syntax, causing all hooks to fail silently. Scripts now read Claude Code's native env vars (`CLAUDE_TOOL_USE_TOOL_NAME`, `CLAUDE_TOOL_USE_INPUT`) directly with backwards-compatible fallback.
 
-### Changed
-- `hooks/scripts/phase-guard.sh`: reads `CLAUDE_TOOL_USE_TOOL_NAME` with `CLAUDE_TOOL_NAME` fallback
-- `hooks/scripts/file-tracker.sh`: reads `CLAUDE_TOOL_USE_TOOL_NAME` with `CLAUDE_TOOL_NAME` fallback
-- `hooks/scripts/phase-transition.sh`: reads `CLAUDE_TOOL_USE_INPUT` with `CLAUDE_TOOL_INPUT` fallback
+- Removed POSIX inline env-var assignments from all 5 hook commands (Windows `cmd.exe` could not parse them); scripts now read Claude Code's native env vars directly with backward-compatible fallback.
 
 ## [6.2.1] — 2026-04-15
 
 ### Changed
-- **Command classification cleanup**: 11 commands previously labeled `Deprecated in v5.2` and 2 more (`deep-brainstorm`, `deep-phase-review`) in the same table are now reclassified into five accurate categories: Quality Gate (3), Internal (6), Escape hatch (1), Utility (2), and Special utility (`/deep-phase-review` moved out).
-- **`/deep-finish` framing**: now described as "auto-call is primary, manual invocation remains a first-class path after test pass" rather than deprecated.
-- **Hook/skill user-facing guidance** now routes to `/deep-status` flags:
-  - `hooks/scripts/assumption-engine.js`: `/deep-assumptions` → `/deep-status --assumptions`
-  - `hooks/scripts/session-end.sh`: `/deep-report` → `/deep-status --report`
-  - `skills/deep-test/SKILL.md`: same alignment
-- **Session Report manual policy**: both `/deep-report` and `/deep-status --report` remain supported manual entry points. Wording is unified across `skills/deep-work-workflow/SKILL.md` heading + body, `commands/deep-report.md` body, and `commands/deep-resume.md` body.
-- **README** (en/ko): "Deprecated Commands (13)" single table replaced by five category tables; "What changed" bullets updated to reflect reclassification (not deprecation); body references to `/deep-cleanup`/`/deep-resume` in the Worktree Isolation section reframed as standalone utilities.
-- **`skills/deep-work-workflow/SKILL.md`** classification section rewritten into 6 categories (Primary / Special / Quality Gate / Internal / Escape hatch / Utility).
 
-### Not changed
-- **No commands removed.** `/deep-cleanup` and `/deep-resume` continue to be the sole path for worktree scan/fork cleanup and for active-session selection/worktree restore/phase dispatch respectively. Their feature migration is tracked as a follow-up.
-- **No functional behavior changed.** Existing slash commands continue to work exactly as before; only labels, wordings, and version numbers changed.
-- Historical `v5.2` deprecated notes in earlier sections are preserved as-is.
+- Command classification cleanup: 13 commands reclassified into Quality Gate / Internal / Escape hatch / Utility / Special utility; `/deep-finish` reframed as "auto-call primary, manual first-class".
+- Hook/skill guidance routes to `/deep-status` flags; README (en/ko) and workflow docs updated to the new categories.
+
+### Notes
+
+- No commands removed and no functional behavior changed — only labels, wordings, and version numbers.
 
 ## [6.2.0] — 2026-04-14
 
 ### Added
-- **Cross-Plugin Context**: Phase 1 Research에서 harnessability-report.json(deep-dashboard)과 evolve-insights.json(deep-evolve)을 참조하여 research context 강화.
 
-## v6.1.0
+- Cross-Plugin Context: Phase 1 Research references `harnessability-report.json` (deep-dashboard) and `evolve-insights.json` (deep-evolve).
 
-### 3-Layer Architecture + Computational Guard
-
-Resolves inferential enforcement failures from 2026-04-12 session (worktree isolation bypass, team mode bypass, codex bypass).
-
-#### Added
-- **P0 Worktree Path Guard** — PreToolUse hook that hard-blocks Write/Edit/Bash outside the active worktree path. Meta directories (`.claude/`, `.deep-work/`) are exempt, anchored to PROJECT_ROOT to prevent external path bypass. Works across all phases, independent of session ID.
-- **P1 Phase Transition Injector** — PostToolUse hook that injects worktree_path, team_mode, cross_model_enabled, and tdd_mode into LLM context when `current_phase` changes. Uses cache file for transition detection, `CLAUDE_TOOL_INPUT` env var for stdin safety.
-- **6 Phase Skills** — Independent SKILL.md for each phase (brainstorm 120L, research 183L, plan 165L, implement 187L, test 147L, orchestrator 230L). Context load reduced 45-81% from original commands.
-- **Review + Approval Workflow** — 6-step protocol for Research and Plan: auto review → main agent judgment → user approval → modification → final confirmation. Orchestrator manages `current_phase` for these phases.
-- **`review-approval-workflow.md`** reference — Shared protocol document for Research/Plan review gates.
-
-#### Changed
-- **Command → Thin Wrapper** — 6 core phase commands reduced to single `Skill()` dispatch calls. `Skill` added to `allowed-tools` in all wrappers.
-- **References relocated** — `skills/deep-work-workflow/references/` → `skills/shared/references/` (14 files). All command/skill paths updated.
-- **`deep-resume` updated** — Research/Plan resume routed through orchestrator (prevents dead-end). Test-passed resume routes to `/deep-finish`.
-- **`deep-test` phase transition** — No longer sets `current_phase: idle` on success. Orchestrator/finish handles idle transition.
-- **Receipt contract** — `status: "complete"` field explicitly required in implement receipts (deep-test gate dependency).
-- **Drift gate fallback** — `plan_approved_at` fallback chain: timestamp → plan.md mtime → 24h commit window.
-- **`cross_model_enabled` parsing** — Nested YAML mapping support via `grep -A3` fallback in phase-transition.sh.
-- **`session-end.sh`** — Phase cache cleanup on session end (stale P1 injection prevention).
-
-#### Architecture
-```
-Layer 1: Commands (thin wrappers) → Skill dispatch
-Layer 2: Skills (execution logic) → 100-230 line SKILL.md + shared references
-Layer 3: Hooks (enforcement) → P0 hard block + P1 context injection
-```
-
-## v6.0.2
-
-### Phase Review Gate
-- **Unified Review Gate** — Every phase (0-3) now runs self-review + external review before transitioning. User confirms results before proceeding.
-- **Phase-specific Fallback Chain** — Phase 0-2 (documents): Structural + Adversarial + Opus subagent. Phase 3 (code): deep-review plugin → codex/gemini + Opus → self + Opus.
-- **User Confirmation UX** — Summary view with 3 options: auto-fix, proceed as-is, show details. Detail view allows per-issue fix/skip.
-- **Degraded Mode** — Graceful fallback when external reviewers fail.
-- **`/deep-phase-review` unified** — Manual review now uses the same Fallback chain as automatic gates.
-
-### Work Folder Rename
-- **Session folder renamed** — `deep-work/` → `.deep-work/` (hidden directory). Matches `.claude/`, `.git/` conventions.
-- **Auto-migration** — Existing `deep-work/` folders are automatically migrated on next session start. Worktree safety check included.
-- **Metadata update** — State files, JSONL history, and fork metadata paths are updated during migration.
-- **Selective .gitignore** — Only session folders (`.deep-work/20*/`) and history are excluded, not config files.
-
-## [6.0.1] - 2026-04-10
-
-### Added — Superpowers Integration (Slice Review, Red Flags, Escalation)
-
-- **Slice Review (Step C-2)**: Per-slice 2-stage independent review after sensor pipeline. Stage 1 (Spec Compliance, required) + Stage 2 (Code Quality, advisory). Subagent failure fallback with graceful degradation.
-- **Red Flags tables**: Rationalization prevention in implement (10 entries) and test (6 entries) phases. Complements hook-based hard gates with soft behavioral guidance.
-- **Pre-flight Check (Step A-2)**: Prerequisite verification before TDD cycle. Uses `command -v` for safe executability check. 2 options: continue (done_with_concerns) or plan revision.
-- **Status Reporting**: `slice_confidence` (done/done_with_concerns) and `concerns` array per slice receipt. Automatic judgment based on review/sensor/pre-flight history.
-- **Agent delegation prompt extended**: Rules 7-10 for self-review, receipt recording, pre-flight, and confidence judgment in delegated agents.
-- **Phase 4 cross-slice + backfill review**: Section 4-2/4-3 rewritten with full control flow (prompt, parser, judgment, storage, display). Slices with Phase 3 FAIL are mandatory backfill targets.
-- **Scope creep detection**: `git diff --name-only` against all changed files, not just slice files.
-- **Per-slice working tree diff**: `git diff $git_before` (not `..HEAD`) for accurate uncommitted change capture.
-- **deep-finish.md concerns summary**: Slice confidence tally and concerns list in session report.
-
-### Changed
-
-- Phase 4 Spec Compliance (4-2) and Code Quality (4-3) gates now focus on cross-slice consistency instead of per-slice validation (already done in Phase 3).
-- `changes.git_diff` in receipts now uses per-slice baseline (`git diff $git_before -- [files]`).
-- `AskUserQuestion` added to deep-implement.md `allowed-tools`.
-- Version references updated to 6.0.1 across CLAUDE.md, SKILL.md, package.json, plugin.json.
-
-## [6.0.0] - 2026-04-09
+## [6.1.0]
 
 ### Added
-- **Computational Sensor Pipeline (#2)** — Registry-driven sensor orchestration integrated into the TDD workflow:
-  - `sensors/registry.json`: Ecosystem definitions for JS, TS, Python, C#, C++ with detect rules, lint/typecheck/mutation commands, and coverage flags
-  - `sensors/detect.js`: Automatic ecosystem detection from project marker files (package.json, tsconfig.json, pyproject.toml, etc.)
-  - 8 output parsers: eslint, tsc, ruff, generic-line, generic-json, stryker, dotnet, clang-tidy
-  - TDD state machine extension: SENSOR_RUN → SENSOR_FIX → SENSOR_CLEAN states after GREEN
-  - Self-correction loop: automatic sensor execution after GREEN, up to 3 fix rounds per sensor
-  - `sensor-trigger.js`: Config/marker file changes trigger ecosystem-wide sensor re-scan
-  - `/deep-sensor-scan`: Standalone computational sensor scan command
-  - Detection result caching (`.sensor-detection-cache.json`)
-  - Fail-closed policy: non-zero exit + 0 diagnostics = explicit failure
-- **Mutation Testing (#1)** — AI-generated test quality verification:
-  - Stryker (JS/TS), stryker-net (C#), mutmut (Python) integration via registry.json
-  - `/deep-mutation-test`: git diff-based scope, automatic test regeneration loop (up to 3 rounds)
-  - Implement phase return pattern: Phase 4 mutation failure → Phase 3 TDD loop for test hardening
-  - Mutation Score Quality Gate (Advisory) + Session Quality Score integration (15% weight)
-  - `stryker-parser.js`: possibly_equivalent tagging for NoCoverage + logging mutations
-  - Receipt `mutation_testing` field: score, survived_details, auto_fix_rounds
-- **Health Engine (#3A)** — Automatic Health Check during Phase 1 Research with 4 drift sensors running in parallel:
-  - `dead-export`: Detects unused JS/TS exports via grep-based cross-referencing (entry point/library/barrel exclusion, health-ignore.json support)
-  - `stale-config`: Detects broken path references in tsconfig.json, package.json, .eslintrc
-  - `dependency-vuln`: Runs `npm audit --json` for known high/critical vulnerabilities (Required gate)
-  - `coverage-trend`: Compares current coverage against previous session baseline (5%p threshold)
-- **Architecture Fitness Functions (#4)** — Declarative architecture rules in `.deep-review/fitness.json`:
-  - 4 rule checkers: `file-metric` (line count), `forbidden-pattern` (regex), `structure` (colocated tests), `dependency` (circular deps via dep-cruiser)
-  - `fitness-validator.js`: JSON schema validation + rule execution engine with `required_missing` status
-  - `fitness-generator.js`: Ecosystem-aware auto-generation (dependency rules excluded for non-JS/TS projects)
-  - dep-cruiser install suggestion with explanation when dependency rules are present but tool is missing
-- **Health Check Orchestrator** (`health-check.js`) — Parallel drift scan (Promise.allSettled) + sequential fitness validation with per-sensor timeouts (180s total)
-- **Baseline Management** — `health-baseline.json` with commit/branch scoping, automatic invalidation on branch switch, rebase (git merge-base --is-ancestor), or 7-day expiry
-- **Phase 4 Quality Gates**:
-  - Fitness Delta Gate (Advisory) — Detects new fitness violations added during implementation
-  - Health Required Gate (Required) — Propagates Phase 1 required failures with user acknowledge flow
-  - Phase 4 Baseline Refresh — Updates health-baseline.json after gates pass
-- **Receipt Schema Extension** — `health_report` field with `scan_commit` for deep-review stale detection
-- **deep-review Integration** — fitness.json injected into review agent prompt + receipt health_report consumed with commit-based staleness check
-- **Harness Templates (#5)**: Topology detection layer with 6 built-in topologies (nextjs-app, react-spa, express-api, python-web, python-lib, generic). Template loader with deep merge and custom/ override support. Phase 1/3 integration with topology-specific guides. Fitness generator extended with template fitness_defaults.
-- **Self-Correction Loop (#6)**: review-check sensor with always-on layer (topology guides) and fitness layer (fitness.json rules). Per-sensor 3-round independent correction limit. Config disable support. Receipt schema extension.
+
+- **P0 Worktree Path Guard** — PreToolUse hook that hard-blocks Write/Edit/Bash outside the active worktree (meta directories exempt), across all phases.
+- **P1 Phase Transition Injector** — PostToolUse hook that injects worktree/team/cross-model/tdd context when `current_phase` changes.
+- 6 phase skills (independent SKILL.md per phase), reducing context load 45-81%.
+- Review + Approval workflow — 6-step protocol for Research and Plan, with the orchestrator owning `current_phase`.
 
 ### Changed
-- Session Quality Score now uses 5 weights (Test Pass Rate 25%, Rework Cycles 20%, Plan Fidelity 25%, Sensor Clean Rate 15%, Mutation Score 15%). Health Check is excluded from scoring.
-- `sensors/registry.json` — Added `audit` field to javascript/typescript ecosystems
 
-## [5.8.1] - 2026-04-08
+- Core phase commands reduced to thin `Skill()` dispatch wrappers; shared references relocated to `skills/shared/references/`.
+- `deep-resume` routes Research/Plan resume through the orchestrator; `deep-test` no longer sets idle on success.
+- Implement receipts explicitly require `status: "complete"`; drift gate gains a `plan_approved_at` fallback chain.
 
-### Changed
-- **Breaking**: `/deep-review` → `/deep-phase-review` renamed to resolve naming conflict with deep-review plugin (deep-suite). Phase document review is now `/deep-phase-review`; code diff review uses the deep-review plugin.
-- Updated references in `deep-plan.md`, `deep-resume.md`, `README.md`, `README.ko.md`
-- deep-review plugin integration (Sprint Contract, slice review, full review) unchanged
-
-## [5.8.0] - 2026-04-08
+## [6.0.2]
 
 ### Added
-- **Completeness Policy** (Section 3.3-1) — explicit banned patterns for plan.md (TBD, TODO, vague directives, cross-references without content). Enforced via Claude self-review + structural review `code_completeness` dimension.
-- **Code sketch tiering** — S: annotated pseudocode, M: actual function signatures + type definitions, L: complete boundary code (interfaces, APIs, tests). Replaces "pseudocode or actual code" with proportional standard.
-- **Slice fields: `expected_output`, `steps`** — `expected_output` defines what `verification_cmd` should print on success. `steps` provides execution guidance within M/L slices (3-12 numbered actions). Both optional for backward compatibility.
-- **`failing_test` detail tiers** — S: file + description, M: function signature + key assertion, L: complete test body for boundary tests.
-- **"Boundary: Files NOT to Modify"** section in plan templates — prevents scope creep during implementation.
-- **Research traceability tags** — `[RF-NNN]` for Key Findings, `[RA-NNN]` for interfaces/signatures. Tags enable plan Architecture Decision to reference specific research evidence.
-- **Research Tag Lifecycle Rules** — monotonic numbering, incremental preservation, deletion warnings for plan-referenced tags.
-- **Research `Testing Patterns` section** — documents existing test framework, assertion style, file naming for plan test specification.
-- **Brainstorm context-adaptive questions** — core 2 + context-adaptive 1-3 (by task type: feature/refactoring/bug/performance/integration) + closing boundary question.
-- **Brainstorm `Scope Assessment`** — decomposition check + quick codebase pulse before approach comparison.
-- **Brainstorm `Boundaries` section** — documents what explicitly stays unchanged, feeds into plan Boundary section.
-- **Review gate dimensions: `code_completeness`, `buildability`** — synchronized across 4 locations (structural table, hardcoded dimensions, cross-model Plan Rubric, JSON schema).
-- **Review gate backward compatibility fallback** — legacy plans without `expected_output`/`steps` evaluated with relaxed criteria per dimension.
+
+- Unified Phase Review Gate — every phase (0-3) runs self-review + external review before transitioning, with a phase-specific fallback chain and user confirmation; `/deep-phase-review` uses the same chain.
 
 ### Changed
-- `deep-implement.md` slice parser now recognizes `expected_output`, `steps`, `contract`, `acceptance_threshold` fields (all optional for backward compatibility).
-- Step B-1 (RED) uses test code from `failing_test` field when available (M/L slices).
-- Step B-2 (GREEN) compares `verification_cmd` output against `expected_output` when available.
-- `deep-work.md` inline plan template updated: `failing_test: [to be determined during implementation]` → `[구현 시 결정 — inline mode]` with Completeness Policy exemption comment.
-- `research-guide.md` quality criteria expanded from 4 to 8 items (RF/RA tags, code snippets per section, test patterns).
-- `plan-templates.md` API Endpoint template upgraded to v5.8 exemplar with full slice format. Legacy templates marked with migration guide.
-- `testability` dimension description clarified: `expected_output` is recommended, not required.
 
-## [5.7.0] - 2026-04-08
+- Session folder renamed `deep-work/` → `.deep-work/` (hidden) with auto-migration and worktree safety check; only session folders and history are gitignored.
+
+## [6.0.1] — 2026-04-10
 
 ### Added
-- **W1: Sprint Contract 생성** — Phase 2 plan 승인 후, deep-review 플러그인이 설치되어 있으면 plan.md의 슬라이스에서 `.deep-review/contracts/SLICE-{NNN}.yaml` 자동 생성
-- **W2-a: 슬라이스 리뷰 제안** — Phase 3에서 슬라이스 GREEN 도달 시 `/deep-review --contract SLICE-{NNN}` 실행 제안
-- **W2-b: 전체 리뷰 제안** — Phase 4 진입 시 `/deep-review` 전체 리뷰 실행 제안
-- **K1: 위키 ingest 제안** — Phase 4 완료 후 `/wiki-ingest report.md` 실행 제안
+
+- Superpowers integration: per-slice 2-stage review (Spec Compliance required + Code Quality advisory), Red Flags tables, pre-flight check, and `slice_confidence`/`concerns` per receipt.
+- Phase 4 cross-slice + backfill review (slices that FAILed in Phase 3 are mandatory backfill targets); scope-creep detection over all changed files; per-slice working-tree diff.
 
 ### Changed
-- Sprint Contract 생성 시점을 plan 작성 직후에서 **plan 승인 후**로 이동 (최종 plan과 contract 일치 보장)
-- 플러그인 감지를 cache + plugins 이중 경로로 통일 (설치 방식 무관)
 
-## [5.6.0] - 2026-04-07
+- Phase 4 Spec Compliance and Code Quality gates focus on cross-slice consistency; receipt `git_diff` uses the per-slice baseline.
+
+## [6.0.0] — 2026-04-09
 
 ### Added
-- **`/deep-fork` command**: Fork a deep-work session to explore different approaches while preserving the original session.
-  - Git environment: worktree-based full replication with dirty state validation (`git stash --include-untracked`), session-ID-based branch suffix (race-condition-free), automatic worktree context switch (`FORK_PROJECT_ROOT`).
-  - Non-git environment: artifacts-only replication with plan phase limit (implement/test blocked by phase guard).
-  - Parent-child relationship tracking via `fork_info` and `fork_children` in state files.
-  - `fork-snapshot.yaml` for comparison baseline at fork point.
-  - Stale parent validation (commit existence for git, work_dir existence for non-git).
-  - Fork generation limit: max 3 generations with warning.
-- **`/deep-status --tree`**: Visualize fork relationship tree with UTF-8 tree characters.
-- **`/deep-status --compare` auto-detection**: Auto-detect fork relationships when no session IDs given (parent↔child comparison).
-- **`/deep-status` fork info display**: Show `fork_info` and `fork_children` in default status output.
-- **`/deep-cleanup` fork support**: Scan for idle fork sessions, batch cleanup when parent + all children are idle.
-- **Phase guard**: Block implement/test phases for `artifacts-only` fork sessions with actionable error message.
-- **Fork utility functions** in `utils.sh`: `validate_fork_target`, `get_fork_generation`, `update_parent_fork_children`, `register_fork_session` (atomic registry + parent update).
-- **`session-end.sh`**: Update parent's `fork_children` status to idle when fork session ends.
-- **Fork integration tests**: 18 integration tests covering atomic registration, multi-fork, phase-guard integration, edge cases, and git worktree fork.
+
+- **Computational Sensor Pipeline** — registry-driven ecosystem detection (JS/TS/Python/C#/C++), 8 output parsers, a SENSOR_RUN → SENSOR_FIX → SENSOR_CLEAN state-machine extension after GREEN, a 3-round self-correction loop, `/deep-sensor-scan`, and a fail-closed policy.
+- **Mutation Testing** — Stryker / stryker-net / mutmut integration, `/deep-mutation-test` with git-diff scope and a test-regeneration loop, plus a Mutation Score quality gate (15% of the session score).
+- **Health Engine** — Phase 1 Health Check with 4 parallel drift sensors (dead-export, stale-config, dependency-vuln, coverage-trend).
+- **Architecture Fitness Functions** — declarative rules in `.deep-review/fitness.json` (file-metric, forbidden-pattern, structure, dependency) with a validator and ecosystem-aware generator.
+- Baseline management (`health-baseline.json`, commit/branch-scoped with auto-invalidation); Phase 4 Fitness Delta (Advisory) and Health Required (Required) gates; receipt `health_report` field consumed by deep-review.
+- **Harness Templates** — 6 built-in topologies with a deep-merge loader and `custom/` override; Phase 1/3 integration.
+- **Self-Correction Loop** — `review-check` sensor (always-on topology layer + fitness layer) with a per-sensor 3-round limit.
 
 ### Changed
-- `deep-work-sessions.json` registry: Added `fork_parent` and `fork_generation` fields per session entry.
-- State file YAML frontmatter: Added `fork_info` (parent relationship) and `fork_children` (child list) sections.
 
-## [5.5.2] - 2026-04-06
+- Session Quality Score uses 5 weights (Test Pass 25%, Rework 20%, Plan Fidelity 25%, Sensor Clean 15%, Mutation 15%); Health Check is excluded from scoring.
+
+## [5.8.1] — 2026-04-08
+
+### Changed
+
+- **Breaking**: `/deep-review` → `/deep-phase-review` to resolve the naming conflict with the deep-review plugin; phase-document review uses the renamed command, code-diff review uses the plugin.
+
+## [5.8.0] — 2026-04-08
 
 ### Added
-- **Extended bash file-write detection**: 20+ new FILE_WRITE_PATTERNS including perl in-place (`perl -pi -e`), runtime language writes (node -e `fs.writeFileSync`, python -c `open().write()`, ruby -e `File.write`), awk in-place, swift, truncate, sponge, destructive git operations (`reset --hard`, `clean -f`), curl/wget output, ln, tar/unzip/cpio extraction, rsync, and generic `writeFile` detection.
-- **Extended safe command patterns**: docker/kubectl read-only, cargo build/check/bench, go build/vet, deno test/check, bun run/x, python unittest, tsc --noEmit, stat/du/df/free/uname/hostname, diff/file, env/printenv, rmdir.
-- **Extended test file patterns**: Dart (`.test.dart`, `_test.dart`), Elixir (`_test.exs`), Lua (`.test.lua`), Vue (`.test.vue`), `fixtures/`, `__fixtures__/`, `__mocks__/`, `spec/` directories.
-- **Extended TDD exempt patterns**: `.toml`, `.ini`, `.cfg`, `.lock`, `.editorconfig`, `.svg`, `.png`, `.jpg`, `.gif`.
-- **TDD state validation**: Unknown TDD states are now blocked with actionable error message in processHook.
-- **Backtick and subshell handling**: `splitCommands` now correctly handles backtick quoting and `$()` subshell depth tracking, preventing false splits inside nested expressions.
-- **Perl target file extraction**: `extractBashTargetFile` now extracts target files from `perl -pi -e` commands for accurate TDD enforcement.
+
+- Completeness Policy — explicit banned patterns for `plan.md` (TBD, TODO, vague directives, content-free cross-references).
+- Code-sketch tiering (S annotated pseudocode / M signatures + types / L complete boundary code) and `failing_test` detail tiers.
+- Slice fields `expected_output` and `steps`; "Boundary: Files NOT to Modify" section; research traceability tags (`[RF-NNN]`, `[RA-NNN]`) with lifecycle rules; a research Testing Patterns section.
+- Brainstorm context-adaptive questions, Scope Assessment, and Boundaries sections; review-gate `code_completeness` and `buildability` dimensions with a legacy-plan compatibility fallback.
+
+### Changed
+
+- The slice parser recognizes the new (optional) fields; RED uses `failing_test`, GREEN compares against `expected_output`; planning/research guides upgraded.
+
+## [5.7.0] — 2026-04-08
+
+### Added
+
+- Sprint Contract generation after plan approval (when deep-review is installed) from `plan.md` slices into `.deep-review/contracts/`.
+- Per-slice review suggestion (`/deep-review --contract SLICE-NNN`) at GREEN, full-review suggestion at Phase 4, and wiki-ingest suggestion after Phase 4.
+
+### Changed
+
+- Contract generation moved to after plan approval so contracts match the final plan; plugin detection unified across install methods.
+
+## [5.6.0] — 2026-04-07
+
+### Added
+
+- `/deep-fork` — fork a session to explore a different approach (git worktree full replication or, in non-git, artifacts-only with implement/test blocked), with parent-child tracking, fork-snapshot baseline, stale-parent validation, and a 3-generation limit.
+- `/deep-status --tree` and `--compare` fork auto-detection; fork info in default status; `/deep-cleanup` fork support; fork utility functions in `utils.sh`.
+
+### Changed
+
+- Session registry and state frontmatter gain fork-relationship fields.
+
+## [5.5.2] — 2026-04-06
+
+### Added
+
+- Extended bash file-write detection (20+ patterns: perl in-place, `node -e`/`python -c`/`ruby -e` writes, awk, destructive git ops, curl/wget output, archive extraction, rsync) and extended safe-command, test-file, and TDD-exempt patterns.
+- TDD state validation and backtick/subshell-aware command splitting.
 
 ### Fixed
-- **Security: file-write-first detection order**: FILE_WRITE_PATTERNS are now checked before SAFE_COMMAND_PATTERNS, preventing safe patterns from masking file writes (e.g., `node -e` with `fs.writeFileSync` was previously bypassed).
-- **file-tracker.sh Node.js 25 argv compatibility**: Fixed `process.argv` indexing — Node.js 25 no longer includes `[eval]` marker, causing receipt creation to silently fail. Now uses `process.argv.filter(a => a !== '[eval]')` for cross-version compatibility.
-- **assumption-engine.js quality-timeline CLI**: Fixed reference to raw `input` string instead of parsed `parsed` object, causing the CLI action to always return empty results.
-- **assumption-engine.js evalSignal threshold passing**: Signal evaluator `threshold` field is now correctly passed to `fn()` instead of relying on hardcoded default parameters.
-- **assumption-engine.js readHistory dedup order**: Changed from keep-first to keep-latest when deduplicating by `session_id`, preventing finalized records from being ignored in favor of earlier active records.
-- **assumption-engine.js input guards**: Added `Array.isArray` checks in `isSessionDuplicate`, `detectStaleness`, `detectNewModel`, and `generateReport` to prevent crashes on non-array inputs.
-- **session-end.sh JSON validation**: Added JSON validation before JSONL append to prevent malformed entries from corrupting harness-sessions.jsonl.
-- **session-end.sh session ID fallback**: Falls back to `DEEP_WORK_SESSION_ID` env var when `started_at` field is missing from state file.
-- **session-end.sh error logging**: Errors now logged to `.claude/deep-work-guard-errors.log` instead of suppressed via `/dev/null`.
-- **phase-guard.sh error logging**: Node.js errors now appended to `.claude/deep-work-guard-errors.log` instead of discarded.
-- **utils.sh matchGlob trailing slash**: Normalized trailing slashes in exact path comparison.
-- **utils.sh session pointer safety**: Added `mkdir -p` before writing session pointer file.
-- **utils.sh session ID generation**: Fixed tab character stripping in hex generation from `/dev/urandom`.
+
+- **Security**: file-write patterns are now checked before safe-command patterns (safe prefixes no longer mask file writes, e.g. `node -e` with `fs.writeFileSync`).
+- `file-tracker.sh` Node 25 `process.argv` compatibility; several `assumption-engine.js` fixes (quality-timeline CLI, threshold passing, dedup keep-latest, array input guards); `session-end.sh` JSON validation, session-id fallback, and error logging.
 
 ### Changed
-- **Redirect detection broadened**: General output redirection pattern changed from `(?:^|\|)` prefix to `(?:^|[|;]|\s)` to catch mid-command redirects (e.g., `cat << EOF > file`).
-- **`node -e` removed from safe patterns**: Previously treated as safe, now evaluated against file-write patterns like any other command.
-- **Model name sanitization**: `validateModelName` now strips non-alphanumeric characters; `lookupModel` adds `toString().trim()` for robust size normalization.
-- **Signal evaluator thresholds**: Made configurable via `threshold` field on evaluator definitions (previously hardcoded as default parameters).
-- **Broader redirect pattern**: Mid-command redirects (heredoc, after whitespace) now correctly detected.
 
-## [5.5.1] - 2026-04-03
+- Redirect detection broadened to catch mid-command redirects; `node -e` removed from safe patterns; model-name sanitization and configurable signal thresholds.
+
+## [5.5.1] — 2026-04-03
 
 ### Changed
-- **Plan phase team research cross-verification**: When `team_mode: team`, the plan phase now loads partial research files (`research-architecture.md`, `research-patterns.md`, `research-dependencies.md`) as supplementary references. Claude self-review (Section 3.4.5) cross-checks plan decisions against these specialized analyses to catch details lost during synthesis.
-- **TDD state update enforcement**: B-1 (RED_VERIFIED) and B-2 (GREEN) state file updates in `deep-implement.md` are now marked as mandatory with explicit phase guard blocking warnings.
+
+- In team mode the plan phase loads partial research files as supplementary references and cross-checks plan decisions against them.
+- B-1 (RED_VERIFIED) and B-2 (GREEN) state updates marked mandatory with phase-guard blocking warnings.
 
 ### Fixed
-- **phase-guard.sh input parsing**: Switched JSON input building from `process.argv` to stdin pipe to avoid `set -e` failures on large tool inputs.
 
-## [5.5.0] - 2026-04-02
+- `phase-guard.sh` reads JSON input from a stdin pipe instead of `process.argv` to avoid `set -e` failures on large inputs.
+
+## [5.5.0] — 2026-04-02
 
 ### Added
-- **Research Cross-Model Review**: codex/gemini adversarial review now applies to research phase (previously plan-only). Uses dedicated research rubric (completeness, accuracy, relevance, risk_identification, actionability).
-- **Claude Self-Review for Plan**: Automatic quality check after plan creation — scans for placeholders, internal inconsistencies, research alignment, scope creep, and missing rollback coverage. Auto-fixes obvious defects before structural review.
-- **Consolidated Judgment Protocol**: Replaces per-conflict AskUserQuestion with Claude's synthesized judgment + user bulk confirmation. Applied to both research and plan cross-model reviews.
-- **Auto-fix Snapshot Contract**: Mandatory snapshots before each auto-fix iteration with score-regression rollback. Research: `research.v{N}.md`, Plan: `plan.autofix-v{N}.md`.
-- **Degraded Mode for Reviewers**: Failed cross-model reviewers are explicitly tracked (`reviewer_status` field). Consensus/conflict classification requires 2+ successful reviewers; single-reviewer results classified as standalone issues only.
-- **State Schema Migration (v5.5)**: New fields `review_results.{phase}.judgments`, `judgments_timestamp`, `reviewer_status`. Auto-initialization for old state files. Resume validation compares document mtime vs judgments_timestamp.
+
+- Research Cross-Model Review (codex/gemini) with a dedicated research rubric; Claude self-review for plans; a Consolidated Judgment protocol replacing per-conflict prompts.
+- Auto-fix snapshot contract with score-regression rollback; degraded mode tracking failed reviewers (`reviewer_status`); v5.5 state-schema migration with resume validation.
 
 ### Changed
-- **Structural Review threshold**: Auto-fix trigger raised from score < 5 to score < 7 for both research and plan phases. Max iterations increased to 3 for research.
-- **Research user feedback gate**: Integrated into consolidated judgment step (Step 4.7). Removed duplicate AskUserQuestion from Step 5 and auto-flow Step 9-3.
-- **deep-review.md**: Updated to use consolidated judgment protocol instead of per-conflict UX.
-- **deep-resume.md**: Resume with `review_state: in_progress` now routes to new review flow with judgments_timestamp validation.
 
-## [5.3.0] - 2026-03-31
+- Structural-review auto-fix trigger raised to score < 7 (max 3 iterations for research); the research user-feedback gate folded into consolidated judgment.
+
+## [5.3.0] — 2026-03-31
 
 ### Added
-- **Document Intelligence**: Automatic deduplication and pruning when feedback is applied to research.md/plan.md. 3-step protocol: Apply → Deduplicate → Prune with refinement log tracking.
-- **Session Relevance Detection**: Scope check before applying feedback — detects out-of-scope requests and offers to start a new session or save to backlog (`deep-work/backlog.md`).
-- **Plan Fidelity Score**: Numeric 0-100 score measuring implementation faithfulness to the approved plan. Integrated into drift-check and deep-test inline verification.
-- **Session Quality Score**: Automatic quality score (0-100) at session completion. Core metrics: Test Pass Rate (35%), Rework Cycles (30%), Plan Fidelity (35%). Diagnostic metrics (Code Efficiency, Phase Balance) shown for reference only.
-- **Assumption Snapshot**: Per-session capture of each assumption's enforcement level at session start. Enables accurate active/inactive cohort analysis.
-- **Assumption Engine Quality Integration**: Quality scores fed into assumption evaluation. Cohort analysis with 3-session minimum gate per cohort. Quality impact displayed in `/deep-status --assumptions`.
-- **Cross-Session Quality Trend**: ASCII chart showing quality score evolution over sessions. Available via `/deep-status --history`.
-- **Quality Badge**: shields.io badge generation for README display. Available via `/deep-status --badge`. Badges: quality score, session count, plan fidelity.
-- **Authoritative JSONL write**: `deep-finish` performs the authoritative write to `harness-sessions.jsonl` with atomic upsert (lock pattern). `session-end.sh` writes provisional records only.
+
+- Document Intelligence — deduplicate and prune `research.md`/`plan.md` when feedback is applied, with a refinement log.
+- Session relevance detection (offers a new session or backlog for out-of-scope requests); Plan Fidelity Score (0-100); Session Quality Score (0-100); assumption snapshots and quality integration; cross-session quality trend; shields.io quality badge.
+- Authoritative JSONL write at `deep-finish` (atomic upsert); `session-end.sh` writes provisional records only.
 
 ### Fixed
-- **JSONL path**: `session-end.sh` now writes to shared `deep-work/harness-history/` instead of per-session folder. Fixes bug where session data was invisible to trend/assumption commands.
+
+- `session-end.sh` writes to the shared `harness-history/` so session data is visible to trend/assumption commands.
 
 ### Changed
-- **README renewal**: Removed demo GIFs. Restructured to problem-solution narrative. Added Quality Measurement and Self-Evolving Rules sections.
-- **exportBadge()**: Returns `{ harness, quality, sessions, fidelity }` object instead of flat badge. Breaking change for direct consumers — tests updated.
-- **hooks.json**: Description updated to "v5.3 Precision + Evidence Protocol".
 
-## [5.2.0] - 2026-03-31
+- README restructured to a problem-solution narrative (demo GIFs removed); `exportBadge()` returns a structured object (breaking for direct consumers).
+
+## [5.2.0] — 2026-03-31
 
 ### Added
-- **Auto-flow orchestration**: `/deep-work` now automatically chains all phases (brainstorm → research → plan → implement → test → finish). Plan approval is the only required user interaction
-- **Unified `/deep-status`**: New flags `--receipts`, `--history`, `--report`, `--assumptions`, `--all` consolidate 5 separate commands into one
-- **Auto-run test gates**: Drift Check (required), SOLID Review (advisory), and Insight Analysis run automatically during `/deep-test` without Quality Gates table configuration
+
+- Auto-flow orchestration — `/deep-work` chains all phases automatically; plan approval is the only required interaction.
+- Unified `/deep-status` with `--receipts` / `--history` / `--report` / `--assumptions` / `--all`; auto-run Drift Check (required), SOLID Review (advisory), and Insight Analysis in `/deep-test`.
 
 ### Changed
-- 13 auxiliary commands marked as deprecated (still functional, deprecation notice added)
-- `/deep-work` Step 1: session detection now offers resume/new/cancel instead of overwrite warning
-- `/deep-test`: Quality Gates table in plan.md is now optional override (auto-detection is default)
-- `phase-guard-core.js`: TDD block messages now include auto-flow alternative note
-- SKILL.md trimmed from 461 to ~250 lines (version history sections removed)
-- plugin.json keywords reduced from 36 to 12
+
+- 13 auxiliary commands marked deprecated (still functional); `/deep-work` Step 1 offers resume/new/cancel; plan.md Quality Gates table becomes an optional override.
 
 ### Deprecated
-- `/deep-brainstorm` — auto-runs in `/deep-work` flow
-- `/deep-review` — auto-runs in `/deep-plan`
-- `/deep-receipt` — use `/deep-status --receipts`
-- `/deep-slice` — auto-managed in `/deep-implement`
-- `/deep-insight` — auto-runs in `/deep-test`
-- `/deep-finish` — auto-runs at end of `/deep-work` flow
-- `/deep-cleanup` — auto-detected in `/deep-work` init
-- `/deep-history` — use `/deep-status --history`
-- `/deep-assumptions` — use `/deep-status --assumptions`
-- `/deep-resume` — auto-detected in `/deep-work` init
-- `/deep-report` — use `/deep-status --report`
-- `/drift-check` — auto-runs in `/deep-test`
-- `/solid-review` — auto-runs in `/deep-test`
 
-## [5.1.2] - 2026-03-30
+- `/deep-brainstorm`, `/deep-review`, `/deep-receipt`, `/deep-slice`, `/deep-insight`, `/deep-finish`, `/deep-cleanup`, `/deep-history`, `/deep-assumptions`, `/deep-resume`, `/deep-report`, `/drift-check`, `/solid-review` (functionality folded into the auto-flow or `/deep-status`).
+
+## [5.1.2] — 2026-03-30
 
 ### Added
-- **Team mode auto-setup**: When user selects Team mode without the required environment variable, Claude Code now offers to automatically configure `~/.claude/settings.json` instead of only showing manual instructions
-- **Team mode runtime validation**: All phases (research, plan, implement) now re-check `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` before attempting team operations, with automatic Solo fallback if unavailable
+
+- Team-mode auto-setup (offers to configure `~/.claude/settings.json`) and runtime validation with automatic Solo fallback across all phases.
 
 ### Fixed
-- **Team mode Solo fallback**: Team mode selection without proper configuration now reliably falls back to Solo mode across all phases, not just at initialization
 
-## [5.1.1] - 2026-03-30
+- Team-mode selection without proper configuration now reliably falls back to Solo across all phases.
 
-### Fixed
-- **CRITICAL: Phase guard fail-closed** — `phase-guard-core.js` catch block now blocks (not allows) on internal errors, preventing TDD/phase enforcement bypass
-- **CRITICAL: Receipt atomic writes** — Receipt JSON updates use temp-file + rename pattern to prevent data corruption from concurrent PostToolUse hooks
-- **HIGH: Command chain bypass** — `detectBashFileWrite` now splits chained commands (`&&`, `||`, `;`, `|`) and checks each sub-command independently; safe prefix no longer shields file-write suffixes
-- **HIGH: Bash TDD target extraction** — New `extractBashTargetFile()` extracts actual destination file from bash commands instead of matching test/exempt patterns against the entire command string
-- **HIGH: Skipped phases exact matching** — Substring match replaced with comma-delimited exact match to prevent false positives
-- **HIGH: Write/Edit fail-closed on missing file_path** — File editing tools now block (not allow) when file path cannot be extracted from tool input
-- **MEDIUM: JSONL history locking** — `session-end.sh` uses mkdir-based locking for concurrent JSONL appends
-- **MEDIUM: Cross-platform timestamp parsing** — Duration calculation replaced with Node.js `Date.parse` (removes macOS/GNU date branching)
-- **MEDIUM: Notification JSON escaping** — Webhook payloads use `JSON.stringify` for proper newline/unicode escaping
-- **MEDIUM: Path normalization** — `normalize_path` resolves `..` segments via `path.resolve` when present
-- **MEDIUM: YAML field extraction** — `read_frontmatter_field` uses literal prefix matching instead of regex interpolation
-- **MEDIUM: Receipt initial creation** — Heredoc replaced with `JSON.stringify` to prevent slice ID injection
-
-### Changed
-- `SIGNAL_EVALUATORS` in assumption engine now use `{ scope, fn }` format; session-scoped signals evaluate once per session, slice-scoped signals aggregate via any-true
-- `TEST_FILE_PATTERNS` extended with Rust, Java, C#, Kotlin, Swift patterns
-- New exports: `splitCommands`, `extractBashTargetFile` in phase-guard-core.js
-
-## [5.1.0] - 2026-03-30
-
-### Added
-- **Auto-Loop Evaluation**: Plan review and test phase auto-retry with max retries and user escalation
-- **Contract Negotiation**: Testable `contract` and `acceptance_threshold` fields in slice definitions
-- **Assumption Engine Auto-Apply**: Automatic rule adjustment at session start based on Wilson Score evidence
-- **Adaptive Evaluator Model**: All evaluator subagents use configurable model (default: sonnet), auto-adjustable by Assumption Engine
-- **Phase Skip Flexibility**: `--skip-to-implement` flag for quick fixes, inline slice generation
-- **Bidirectional adjustment**: Assumption Engine can tighten rules back when evidence supports it
-
-### Changed
-- Structural review now auto-loops on failure (up to 3 attempts) before escalating
-- Test phase auto-returns to implement for targeted slice re-execution
-- Assumption health report shows active auto-adjustments
-- Slice format now includes `contract` and `acceptance_threshold` fields
-- Default evaluator model changed from haiku to sonnet
+## [5.1.1] — 2026-03-30
 
 ### Fixed
-- Assumption Engine report no longer says "Auto-application is a Phase 2 feature"
 
-## [5.0.0] - 2026-03-30
-
-### Added
-- **Self-Evolving Harness (Assumption Engine)**: Every enforcement rule is now a falsifiable hypothesis with machine-readable evidence signals. deep-work studies its own assumptions using session data.
-- **`assumptions.json`**: Registry of 5 core assumptions (phase_guard, tdd, research, cross_model_review, receipt_collection) with evidence signals, adjustable enforcement levels, and minimum session thresholds.
-- **`assumption-engine.js`**: Core analysis module with Wilson Score confidence, model-aware splitting, staleness detection, new model detection, per-slice signal evaluation, report generation, ASCII timeline, and shields.io badge export. 42 unit tests.
-- **`/deep-assumptions` command**: Report (default + --verbose), history (ASCII timeline), export (--format=badge), and --rebuild (regenerate JSONL from receipts).
-- **`harness_metadata` in receipts**: Per-slice metadata (model_id, assumption_overrides, rework_count, tests_passed_first_try, bugs_caught_in_red_phase, review_defects_found, research_references_used, cross_model_unique_findings). Backward-compatible.
-- **Session history JSONL**: `harness-sessions.jsonl` appended at session termination via Stop hook. Per-slice data, session dedupe, cross-platform date math. Disk error handling (stderr log, never blocks).
-- **Health summary on session init**: `/deep-work` shows assumption health if sufficient history exists. New model detection with cold start warning.
-- **Assumption Health in reports**: `/deep-report` includes assumption confidence table and per-session harness metadata aggregation.
-
-## [4.2.1] - 2026-03-26
-
-### Added
-- **TDD Override**: When TDD blocks a production file edit during implementation, Claude now detects the block, explains the reason to the user, and offers an interactive choice — write the test first (recommended), or skip TDD for this slice with a recorded reason (config change, untestable code, urgent fix). Override is slice-scoped and auto-clears on slice transition.
-- **Escape hatch guidance in block messages**: Both strict and coaching TDD block messages now show `/deep-slice spike` and `/deep-slice reset` as alternatives, so users know how to bypass TDD when needed.
-- **`tdd_override` state field**: New state file field tracks which slice has an active TDD override. Hook reads this field for fast-path allow decisions.
-- **Override in receipts**: Overridden slices are recorded with `tdd_override: true` and `tdd_override_reason` in receipt JSON. Receipt dashboard shows `override` status distinct from `spike` (merge-eligible with warning).
-- 9 new unit tests for TDD override (total: 56 tests)
+- **Critical**: phase-guard fail-closed on internal errors (no enforcement bypass); receipt JSON updates use temp-file + rename (no corruption from concurrent hooks).
+- Command-chain bypass closed (`&&`/`||`/`;`/`|` sub-commands checked independently); bash TDD target extraction; exact comma-delimited skipped-phase matching; Write/Edit fail-closed on missing `file_path`.
+- JSONL history locking, cross-platform timestamp parsing, notification JSON escaping, path normalization, literal YAML field extraction, and receipt initial creation via `JSON.stringify`.
 
 ### Changed
-- `phase-guard-core.js`: `checkTddEnforcement` accepts new `tddOverride` parameter; `processHook` passes `state.tdd_override`
-- `phase-guard.sh`: Reads `tdd_override` from state file; adds fast-path for override matching active slice; passes override to Node.js
-- `deep-implement.md`: New "TDD Override" section with AskUserQuestion flow (main model routing only)
-- `deep-receipt.md`: Override icon, count, and JSON schema updated
-- `deep-finish.md`: `tdd_compliance` includes `override` count
-- `deep-history.md`: `tdd_compliance` and TDD compliance display include `override`
 
-## [4.2.0] - 2026-03-25
+- Signal evaluators use a `{ scope, fn }` format; `TEST_FILE_PATTERNS` extended (Rust, Java, C#, Kotlin, Swift).
+
+## [5.1.0] — 2026-03-30
 
 ### Added
-- **Structural Review**: All phase documents (brainstorm, research, plan) now undergo structural review via Claude haiku subagent with phase-specific dimensions
-- **Adversarial Cross-Model Review**: Plan documents are independently reviewed by codex and/or gemini-cli for architecture, assumptions, and risk coverage
-- **Conflict Resolution UX**: When models disagree, conflicts are transparently shown to users who decide the resolution (accept, waiver, or manual edit)
-- **Review Gate**: Structural review score <5 or critical consensus issues block auto-implement transition
-- **`/deep-review` command**: Manually trigger structural or adversarial review at any time
-- **`--skip-review` flag**: Skip all reviews for spike/experimental sessions
-- **Cross-model tool auto-detection**: Automatically detects codex/gemini-cli at session init
-- **Profile `cross_model_preference`**: Save cross-model preference (always/never/ask) in presets
-- **Review state in resume/status**: `/deep-resume` recognizes review state; `/deep-status` displays review results
-- **JSON Schema normalization**: All review results stored as structured JSON (`{phase}-review.json`)
+
+- Auto-Loop Evaluation (plan-review and test-phase auto-retry with escalation); Contract Negotiation (`contract` / `acceptance_threshold` slice fields); Assumption Engine auto-apply via Wilson Score; adaptive evaluator model; `--skip-to-implement`.
 
 ### Changed
-- `deep-brainstorm.md`: Spec review replaced with review-gate protocol reference
-- `deep-research.md`: Added structural review after research completion
-- `deep-plan.md`: Added structural + adversarial review before approval
-- `phase-guard-core.js`: Added codex/gemini/mktemp to SAFE_COMMAND_PATTERNS
-- State file: Added `review_state`, `cross_model_tools`, `cross_model_enabled`, `review_results` fields
-- Profile: Added `cross_model_preference` to preset schema
+
+- Structural review auto-loops (up to 3) before escalating; default evaluator model changed haiku → sonnet; slice format gains contract fields.
+
+## [5.0.0] — 2026-03-30
+
+### Added
+
+- **Self-Evolving Harness (Assumption Engine)** — every enforcement rule is a falsifiable hypothesis with machine-readable evidence signals.
+- `assumptions.json` (5 core assumptions) and `assumption-engine.js` (Wilson Score confidence, staleness/new-model detection, report + ASCII timeline + badge export).
+- `/deep-assumptions` command; per-slice `harness_metadata` in receipts; `harness-sessions.jsonl` appended at session end; assumption-health summary at session init and in `/deep-report`.
+
+## [4.2.1] — 2026-03-26
+
+### Added
+
+- TDD Override — when TDD blocks a production edit, Claude offers to write the test first or skip TDD for this slice with a recorded reason (slice-scoped, auto-clears on transition); escape-hatch guidance in block messages; `tdd_override` state field and receipt fields.
+
+### Changed
+
+- `phase-guard-core.js` / `phase-guard.sh` honor `tdd_override`; `deep-implement` gains a TDD Override flow; receipt/finish/history surfaces show override counts.
+
+## [4.2.0] — 2026-03-25
+
+### Added
+
+- Structural Review of all phase documents (Claude haiku subagent); adversarial cross-model review of plans (codex / gemini-cli) with a transparent conflict-resolution UX; a Review Gate blocking auto-implement on low scores; `/deep-review`; `--skip-review`; cross-model tool auto-detection; profile `cross_model_preference`; review state in resume/status; JSON-normalized review results.
+
+### Changed
+
+- Brainstorm/research/plan gain review steps; `phase-guard-core.js` adds codex/gemini/mktemp to safe patterns; state and profile schemas extended.
 
 ### Fixed
-- `.gitignore`: Added `deep-work-workflow-workspace/` to prevent venv from being tracked
 
-## [4.1.0] - 2026-03-25
+- `.gitignore` excludes the workflow workspace venv.
+
+## [4.1.0] — 2026-03-25
 
 ### Added
-- **Worktree isolation**: Sessions now run in isolated git worktrees by default. `/deep-work` creates a worktree at `.worktrees/dw/<slug>/`, keeping main branch clean. Opt-out with `--no-branch` or `git_branch: false` in preset.
-- **Model auto-routing by slice complexity**: Implement phase automatically selects the optimal model (haiku/sonnet/opus) based on each slice's size (S/M/L/XL). Override per-slice with `/deep-slice model SLICE-NNN <model>`. Customizable routing table in presets.
-- **Session completion workflow** (`/deep-finish`): 4 explicit options at session end — merge to base branch, create PR, keep branch for later, or discard. Generates `session-receipt.json` with full session summary.
-- **CI/CD receipt validation**: `validate-receipt.sh` validates receipt chain integrity. `templates/deep-work-ci.yml` provides a GitHub Actions workflow template. `/deep-receipt export --format=ci` for CI-friendly bundle export.
-- **Session history dashboard** (`/deep-history`): Cross-session trends showing model usage, TDD compliance rates, completion rates, and cost tracking.
-- **Worktree cleanup** (`/deep-cleanup`): Scans for stale deep-work worktrees (7+ days, no active session) and offers batch or individual cleanup.
-- **Receipt schema v1.0**: New fields — `schema_version`, `model_used`, `model_auto_selected`, `worktree_branch`, `git_before`, `git_after`, `estimated_cost`. Session receipt is a derived cache; slice receipts are the canonical source of truth.
-- **Receipt migration helper** (`receipt-migration.js`): Auto-converts pre-v4.1 receipts to schema v1.0 with atomic writes and corrupted file backup.
-- **Worktree-aware resume** (`/deep-resume`): Detects worktree path on session resume and restores working directory context. Handles deleted worktrees gracefully.
-- **Model cost tracking**: `estimated_cost` field in slice and session receipts for per-session AI model spending visibility.
-- **Shell utilities extraction** (`utils.sh`): Shared functions (`find_project_root`, `normalize_path`, `read_frontmatter_field`, `init_deep_work_state`) extracted from 3 hook scripts into a single source file, eliminating code duplication.
-- **Model routing tests**: 11 new unit tests for routing table lookup, model name validation, and custom table overrides (total: 48 tests across 2 test files).
+
+- Worktree isolation by default (`.worktrees/dw/<slug>/`, opt-out via `--no-branch`); model auto-routing by slice complexity (S/M/L/XL) with per-slice override; `/deep-finish` with 4 completion options; CI/CD receipt validation (`validate-receipt.sh`, CI template, `--format=ci` export); `/deep-history`; `/deep-cleanup`.
+- Receipt schema v1.0 (slice receipts canonical, session receipt derived) with a migration helper; worktree-aware resume; model cost tracking; shared `utils.sh`.
 
 ### Changed
-- Default `model_routing.implement` changed from `"sonnet"` to `"auto"` (size-based routing)
-- Default `git_branch` in presets changed to `true` (worktree isolation enabled by default)
-- `session-end.sh` now shows worktree branch info and suggests `/deep-finish` for cleanup
-- `validate-receipt.sh` uses `set -eo pipefail` instead of `set -euo pipefail` for macOS Bash 3.2 compatibility
 
-## [4.0.1] - 2026-03-25
+- Default `model_routing.implement` → `"auto"`; default `git_branch` → `true`; `validate-receipt.sh` uses `set -eo pipefail` for Bash 3.2.
+
+## [4.0.1] — 2026-03-25
 
 ### Added
-- **Git-based auto-update check**: SessionStart hook checks GitHub for newer versions on every session start. Supports auto-update, snooze (escalating backoff: 24h→48h→1w), and opt-out. Modeled after gstack's update-check pattern.
-- **Shell injection prevention**: phase-guard.sh and file-tracker.sh now pass values via `process.argv` instead of string interpolation, preventing injection from file paths containing special characters.
+
+- Git-based auto-update check on SessionStart (auto-update, escalating snooze, opt-out); shell-injection prevention via `process.argv` in `phase-guard.sh` / `file-tracker.sh`.
 
 ### Fixed
-- macOS compatibility: removed `timeout` command usage (not available on macOS)
-- Version consistency: CLAUDE.md and TODOS.md now reflect correct v4.0 version
 
-## [4.0.0] - 2026-03-25
+- macOS compatibility (removed `timeout` usage); version consistency in docs.
+
+## [4.0.0] — 2026-03-25
 
 ### BREAKING — Evidence-Driven Development Protocol
 
-deep-work is now an **evidence-driven development protocol**. Every code change carries proof: failing test output, passing test output, git diff, spec compliance check, and code review — all collected as JSON receipts.
+deep-work becomes an evidence-driven development protocol: every code change carries proof (failing/passing test output, git diff, spec check, code review) collected as JSON receipts.
 
 ### Added
-- **Phase 0: Brainstorm** (`/deep-brainstorm`): Explore "why" before "how" — problem definition, approach comparison, spec-reviewer validation. Skip with `--skip-brainstorm`.
-- **Slice-based execution**: Plan tasks are now "slices" — self-contained units with TDD cycles, file scope, verification commands, and spec checklists.
-- **TDD enforcement**: Hook-enforced state machine (PENDING→RED→RED_VERIFIED→GREEN_ELIGIBLE→GREEN→REFACTOR). Production code edits blocked until failing test exists. Modes: `strict`, `relaxed`, `coaching`, `spike`.
-- **Receipt system**: JSON evidence per slice in `receipts/SLICE-NNN.json` — test output, git diff, lint results, spec checklist, code review.
-- **Bash tool monitoring**: PreToolUse hook now intercepts Bash commands, blocking file-writing patterns (`echo >`, `sed -i`, `cp`, `tee`) during non-implement phases. Closes the bypass gap where AI could use shell redirects instead of Write/Edit.
-- **Systematic debugging** (`/deep-debug`): 4-phase root-cause investigation (investigate→analyze→hypothesize→fix). Auto-triggers on unexpected test failures. Escalates after 3 failed hypotheses.
-- **Slice management** (`/deep-slice`): Dashboard with ASCII progress visualization, manual activation, spike mode entry, slice reset with git stash.
-- **Receipt management** (`/deep-receipt`): Dashboard view, per-slice detail, export as JSON (CI/CD) or markdown (PR descriptions).
-- **2-stage code review**: Spec Compliance Review (required gate) + Code Quality Review (advisory gate) via subagents in test phase.
-- **Receipt Completeness Gate**: Required gate — blocks test phase if any slice lacks a receipt.
-- **Verification Evidence Gate**: Required gate — ensures actual test execution output exists.
-- **TDD Coaching mode**: Guides beginners through TDD with educational messages instead of hard blocks.
-- **Spike Mode Guard**: Auto-stashes spike code and resets slice on mode exit.
-- **29 unit tests**: Node.js test suite for phase-guard-core.js (TDD state machine, Bash detection, slice scope, receipt validation).
+
+- Phase 0 Brainstorm (`/deep-brainstorm`, skip with `--skip-brainstorm`); slice-based execution; hook-enforced TDD state machine (modes: strict/relaxed/coaching/spike); per-slice receipts.
+- Bash tool monitoring (intercepts file-writing shell patterns in non-implement phases); systematic debugging (`/deep-debug`); `/deep-slice`; `/deep-receipt`; 2-stage code review; Receipt Completeness and Verification Evidence gates; spike-mode guard.
 
 ### Changed
-- Hook architecture: bash+Node.js hybrid — fast path in bash (~50ms), complex logic in Node.js subprocess (~200ms).
-- Plan format: Task Checklist → Slice Checklist with per-slice metadata.
-- `hooks.json`: Added `Bash` to PreToolUse and PostToolUse matchers.
-- `phase-guard.sh`: Full rewrite as bash+Node hybrid.
-- `file-tracker.sh`: Extended for receipt collection and active slice mapping.
-- `deep-implement.md`: Full rewrite — slice-unit TDD execution.
-- `deep-test.md`: 4 new quality gates (Receipt, Spec, Quality, Evidence).
-- `deep-plan.md`: Slice format with TDD fields.
-- `deep-work.md`: Phase 0 option, `--tdd=MODE` flag, `--skip-brainstorm` flag.
-- `package.json`: Version 4.0.0.
 
-## [3.3.3] - 2026-03-24
+- Hybrid bash + Node hook architecture; plan format becomes a slice checklist; full rewrites of implement/test/plan; `Bash` added to PreToolUse/PostToolUse matchers.
+
+## [3.3.3] — 2026-03-24
 
 ### Added
-- **Multi-Preset Profile System**: Named presets for different work styles (e.g., `dev`, `quick`, `review`).
-  - Profile v2 format with `presets:` key (single YAML file, multiple named presets)
-  - Auto-migration from v1 to v2 (existing single profile → `default` preset)
-  - `/deep-work --setup` now opens preset management UI (create, edit presets)
-  - `/deep-work --profile=X "task"` for direct preset selection (skip interactive)
-  - Interactive preset selection via AskUserQuestion when multiple presets exist
-  - Single preset auto-applied without prompting
-- **Trigger Evaluation Optimization**: Expanded trigger-eval.json and refined SKILL.md description.
-  - trigger-eval.json expanded from 20 to 31 queries (16 true + 15 false)
-  - Added coverage for v3.3.2 features: profile, preset, resume, checkpoint keywords
-  - Added false-positive guards for ambiguous terms (profile picture, resume template, deep copy, etc.)
-  - SKILL.md description optimized: removed generic keywords, added preset/프리셋
+
+- Multi-preset profile system (Profile v2 with `presets:`, v1 → v2 auto-migration, `--profile=X`, `--setup` management UI, interactive selection); expanded trigger-eval set with false-positive guards.
 
 ### Changed
-- `deep-work.md` Step 1.5 rewritten for v2 profile: version check (v1 auto-migrate, v2 proceed, other reject), preset selection logic, field-to-variable mapping
-- `deep-work.md` Step 1.5a flag table: added `--profile=X`
-- `deep-work.md` Step 1.5b: `--setup` now shows preset management UI (with or without task)
-- `deep-work.md` Step 1.5d: New preset management UI section (edit existing, create new)
-- `deep-work.md` Step 7: State file template includes `preset` field
-- `deep-work.md` Step 7.5: Profile save format changed from v1 (`defaults.*`) to v2 (`presets.default.*`)
-- `deep-work.md` Step 8: Confirmation message shows preset name (🎯 프리셋: [name])
-- `deep-resume.md` Step 1: Extracts `preset` field from state file
-- `deep-resume.md` Step 3: Resume status display shows preset name
-- SKILL.md Profile System section updated with multi-preset documentation
-- SKILL.md v3.3.3 Features section added
 
-## [3.3.2] - 2026-03-22
+- `/deep-work` profile load/save and resume updated for the v2 format.
+
+## [3.3.2] — 2026-03-22
 
 ### Added
-- **Profile System**: Automatic profile save/load for zero-question session initialization.
-  - First `/deep-work` run saves setup answers to `.claude/deep-work-profile.yaml`
-  - Subsequent runs skip all setup questions, apply saved profile instantly
-  - Override flags for single-session changes: `--team`, `--zero-base`, `--skip-research`, `--no-branch`
-  - Profile re-setup: `/deep-work --setup`
-  - Profile version field (`version: 1`) for future migration support
-- **Session Resume (`/deep-resume`)**: Resume interrupted sessions with full context restoration.
-  - Auto-detects active session from `.claude/deep-work.local.md`
-  - Restores AI context from artifacts: research.md (summary), plan.md (full), test-results.md (failures)
-  - Auto-continues from current phase: research → plan review → implement checkpoint → test
-  - Implement phase always uses checkpoint-based resume (bypasses model routing re-delegation for safety)
-- **Checkpoint Verification**: Post-agent implementation integrity check.
-  - Uses `git diff --name-only` as primary verification source
-  - Auto-corrects plan.md `[x]` markers when git changes exist but task was unmarked
-  - Falls back gracefully when `file-changes.log` is unavailable (agent delegation mode)
+
+- Profile system — first run saves setup answers, later runs apply them instantly; override flags; `--setup`.
+- Session resume (`/deep-resume`) with artifact-based context restoration and phase auto-continue; checkpoint verification via `git diff --name-only`.
 
 ### Changed
-- `deep-work.md` restructured with Step 1.5 (profile load/flag parse) and Step 7.5 (profile save)
-- `deep-work.md` Step 2-1 (git branch) now auto-creates/skips based on profile setting
-- `deep-implement.md` Section 0-pre agent prompt includes checkpoint mandate
-- `deep-implement.md` Section 0-pre adds post-agent checkpoint verification step
-- SKILL.md description extended with resume/profile trigger keywords
-- SKILL.md updated with Profile System, Session Resume, and v3.3.2 Features sections
 
-## [3.3.0] - 2026-03-22
+- `/deep-work` restructured around profile load/save; implement gains a checkpoint mandate and post-agent verification.
+
+## [3.3.0] — 2026-03-22
 
 ### Added
-- **Insight Tier Quality Gate**: Third and final tier of the 3-tier Quality Gate system. Provides informational code metrics and analysis without blocking workflow.
-  - `/deep-insight` command with standalone/workflow dual mode
-  - Built-in analyses: file metrics, complexity indicators, dependency graph, change summary
-  - Custom ℹ️ gates in plan.md Quality Gates table
-  - Produces `insight-report.md` artifact
-  - Automatically runs during `/deep-test` after Required and Advisory gates
-- **PostToolUse File Tracking**: `file-tracker.sh` hook automatically logs file modifications during Implement phase to `$WORK_DIR/file-changes.log` with timestamps. Used by `/deep-report` and `/deep-insight`.
-- **Stop Hook — Session End Handler**: `session-end.sh` hook fires on CLI session close. If a deep-work session is active, outputs a reminder message and sends notification via configured channels.
-- **insight-guide.md**: Reference guide for Insight tier — analysis interpretation, custom gate definition, limitations
+
+- Insight Tier Quality Gate (`/deep-insight`, built-in analyses, `insight-report.md`, never blocks); PostToolUse file tracking to `file-changes.log`; a Stop hook for session-end reminders.
 
 ### Changed
-- `hooks.json` expanded from PreToolUse-only to PreToolUse + PostToolUse + Stop events
-- `/deep-test` Section 2-1 now parses ℹ️ (insight) markers in Quality Gates table alongside ✅ (required) and ⚠️ (advisory)
-- `/deep-test` Section 4 adds new "4-2. Built-in Insight Analysis" step after Required/Advisory gates
-- `quality-gates.md` output format includes new "Insight Gates" section and insight count in verdict
-- `/deep-report` reads `insight-report.md` and `file-changes.log` for enriched reports
-- `/deep-status` artifact checklist includes `insight-report.md` and `file-changes.log`
-- `/deep-implement` notes PostToolUse file tracking in Solo Mode instructions
-- SKILL.md Phase Enforcement section updated to document all three hook types
-- SKILL.md description extended with insight/metrics/tracking trigger keywords
 
-## [3.2.2] - 2026-03-21
+- `hooks.json` expanded to PreToolUse + PostToolUse + Stop; `/deep-test` parses ℹ️ insight markers and adds a built-in Insight step; reports and status read the new artifacts.
+
+## [3.2.2] — 2026-03-21
 
 ### Added
-- **Internationalization (i18n)**: All 9 command files now detect the user's language from their messages or Claude Code's `language` setting, and output all user-facing messages in the detected language. Korean templates are preserved as the reference format; Claude translates naturally to the user's language while preserving emoji, formatting, and structure. This enables English, Japanese, Chinese, and any other language users to use the plugin without modification.
-- Internationalization section added to SKILL.md documentation.
 
-## [3.2.1] - 2026-03-21
+- Internationalization — all command files detect the user's language and output messages accordingly (Korean templates as the reference), enabling English/Japanese/Chinese/other users without modification.
+
+## [3.2.1] — 2026-03-21
 
 ### Fixed
-- **SKILL.md description trimmed**: Reduced from ~1,500 chars to ~450 chars (3x over budget). Removes sub-feature trigger phrases that diluted matching precision and wasted prompt budget on every conversation.
-- **SKILL.md changelog bloat removed**: Removed v3.1.0/v3.2.0 Features sections (~400 words) that duplicated content already covered in the body. Moved `compatibility` frontmatter (non-standard field) into body section.
-- **deep-research.md section numbering**: Renumbered steps 0, 0-1, 0-2 to 1-1, 1-2, 1-3 to match logical execution order.
-- **deep-test.md allowed-tools**: Removed `Edit` from allowed-tools — code modifications are blocked during Test phase by Phase Guard.
-- **Command description language consistency**: Standardized `drift-check.md` and `solid-review.md` descriptions to English (matching the other 7 commands).
-- **notify.sh JSON safety**: Added `MESSAGE` variable escaping (double quotes and backslashes) before JSON interpolation to prevent malformed payloads.
-- **Phase Guard path reference**: Added explicit `hooks/scripts/phase-guard.sh` path in SKILL.md for discoverability.
 
-### Added
-- `.gitignore` file mirroring `.npmignore` patterns to prevent accidental commits of state files and session artifacts.
-
-## [3.2.0] - 2026-03-18
-
-### Added
-- **3-Tier Quality Gate System**: Quality Gates now support three tiers — Required (blocking), Advisory (warning), and Insight (informational, planned for v3.3).
-- **Plan Alignment / Drift Detection**: `/drift-check` command and built-in Required gate in `/deep-test`. Automatically compares plan.md items against actual git diff to detect unimplemented items, out-of-scope changes, and design decision drift. Produces `drift-report.md`.
-- **SOLID Design Review**: `/solid-review` command and Advisory Quality Gate. Evaluates code against 5 SOLID principles (SRP, OCP, LSP, ISP, DIP) with per-file scorecards, overall verdict, and top-5 refactoring suggestions. Produces `solid-review.md`.
-- **solid-guide.md**: Framework-agnostic SOLID review checklist with severity levels and KISS balance criteria
-- **solid-prompt-guide.md**: Guide for requesting SOLID-compliant code from AI tools and verifying AI output
-
-### Changed
-- `/deep-test` now automatically runs Plan Alignment check before other Quality Gates when plan.md exists (no configuration needed)
-- SKILL.md restructured: moved Plan Alignment, SOLID Review, and Session Report under new "Quality Gates & Utilities" section (previously misplaced under "The Four Phases")
-- SKILL.md description optimized: consolidated ~40 granular trigger keywords into ~10 representative phrases for better signal-to-noise ratio
-- v3.2.0 Features section added to SKILL.md with English-consistent language
-- `plan_approved_at` field added to state schema (optional, used by Drift Detection baseline)
-
-## [3.1.0] - 2026-03-17
-
-### Breaking Changes
-- **Repository structure overhaul**: Migrated from root-level plugin to `plugins/deep-work/` subdirectory pattern. Existing users must reinstall.
-
-### Added
-- **Model Routing (F1)**: Optimal model assignment per phase (Research=sonnet, Plan=main, Implement=sonnet, Test=haiku). Agent delegation pattern reduces tokens by 30-40%.
-- **Multi-channel Notifications (F2)**: OS native + Slack/Discord/Telegram/custom Webhook notifications on phase completion. Fire-and-forget pattern.
-- **Incremental Research (F3)**: `/deep-research --incremental` — re-analyzes only changed areas based on git diff. Saves 60-80% of research time.
-- **Quality Gate System (F4)**: Define Quality Gates in plan.md, then execute required/advisory gates. Produces `quality-gates.md` artifact.
-- **Plan Diff Visualization (F5)**: Automatically visualizes structural changes when a plan is rewritten. Produces `plan-diff.md` artifact.
-- **model-routing-guide.md**: Model routing configuration guide
-- **notification-guide.md**: Notification channel setup guide
-
-### Changed
-- Added model routing/notification configuration options to `/deep-work` initialization
-- Added model routing, notification, and Quality Gate status display to `/deep-status`
-- Added Quality Gate results and Plan Diff summary sections to `/deep-report`
-- Added `model_routing`, `notifications`, `last_research_commit`, `quality_gates_passed` fields to state schema
-- Changed marketplace.json source path from `"./"` to `"./plugins/deep-work"`
-
-## [3.0.0] - 2026-03-13
+- SKILL.md description trimmed (~1,500 → ~450 chars) and changelog bloat removed; `deep-research.md` step renumbering; `deep-test.md` drops `Edit` from allowed-tools; command-description language standardized; `notify.sh` message escaping; explicit phase-guard path in SKILL.md.
 
 ### Added
 
-#### Phase 4: Test (`/deep-test`)
-- **P-1**: New Test phase added (`implement → test → idle`)
-- Auto-detects test/lint/type-check commands from project config files (package.json, pyproject.toml, Makefile, Cargo.toml, go.mod)
-- On test failure, automatically returns to implement phase; fix-and-retest loop (up to 3 retries)
-- Cumulative per-attempt verification results recorded in `test-results.md`
-- Code modifications blocked during Test phase (Phase Guard)
+- `.gitignore` mirroring `.npmignore` to prevent committing state files and session artifacts.
 
-#### Zero-Base Mode
-- **P-3**: Zero-Base mode for designing new projects from scratch
-- Research covers 6 areas: tech stack selection, coding conventions, data models, API design, scaffolding, dependency evaluation
-- Plan provides "Files to Create" + "Project Structure" + "Setup Instructions"
-- New `references/zero-base-guide.md` guide added
+## [3.2.0] — 2026-03-18
 
-#### Interactive Plan Review
-- **A-7**: Provide feedback via chat and plan.md is automatically updated (no need to edit the file directly)
-- Changes are highlighted, then awaits re-review
+### Added
 
-#### Plan Enhancements
-- **A-6**: Previous plan versions backed up as `plan.v{N}.md` on rewrite, with Change Log section added
-- **A-11**: 6 plan templates by task type (API endpoint, UI component, DB migration, refactoring, bug fix, Full Stack feature)
-- **P-2**: Automatic Team/Solo mode switch suggestion on plan approval (based on task count and file count)
-
-#### Research Enhancements
-- **A-8**: Partial research re-run — `/deep-research --scope=api,data` to re-analyze specific areas only
-- **A-9**: Research caching — uses previous session's research.md as baseline, re-analyzes only changed areas based on git diff
-
-#### Git Integration
-- **A-10**: Suggests creating a `deep-work/[slug]` branch at session start
-- Auto-generates commit message and suggests commit on session completion (tests passed)
-
-#### Phase Skip
-- **A-1**: Option to skip Research and start from Plan during session initialization
-- Eliminates unnecessary Research for familiar codebases
-
-#### Implement Checkpoints
-- **A-4**: On resume after interruption during implementation, automatically skips completed tasks and resumes from unfinished ones
-
-#### Time Tracking
-- **A-12**: Records start/completion timestamps for all phases
-- Adds per-phase elapsed time table to session report
-
-#### Team Mode Progress Notifications
-- **A-13**: In Team mode, progress notifications on agent task completion in the format `[2/3] pattern-analyst completed`
-
-#### Session Comparison
-- **A-14**: `/deep-status --compare` to compare approaches, modified files, and verification results between two sessions
-
-#### New Files
-- `commands/deep-test.md` — Test Phase command
-- `references/testing-guide.md` — Test Phase detailed guide
-- `references/plan-templates.md` — Plan template collection
-- `references/zero-base-guide.md` — Zero-Base Research guide
-- `CHANGELOG.md` — Changelog file
+- 3-Tier Quality Gate system (Required / Advisory / Insight); Plan Alignment / Drift Detection (`/drift-check` + built-in gate, `drift-report.md`); SOLID Design Review (`/solid-review` + advisory gate, `solid-review.md`); SOLID review guides.
 
 ### Changed
 
-#### Output Format Improvements
-- **P-5**: Placed Executive Summary, Key Findings, and Risk & Blockers at the top of research.md (pyramid principle)
-- **P-5**: Placed Plan Summary (approach, scope of changes, risks, key decisions) at the top of plan.md
+- `/deep-test` auto-runs Plan Alignment before other gates; SKILL.md restructured; `plan_approved_at` added to the state schema.
 
-#### Phase Guard Message Improvements
-- **A-2**: Added phase-specific "next step" guidance to block messages
-- Research: "→ Run /deep-plan or /deep-research"
-- Plan: "→ Approve the plan or re-run /deep-plan"
-- Test: "→ Handled automatically on test pass/fail, see test-results.md"
+## [3.1.0] — 2026-03-17
 
-#### Phase Flow Changes
-- `research → plan → implement → idle` → `research → plan → implement → test ⟲ → idle`
-- Auto-transitions to test phase after implement completion instead of idle
-- Retry loop returning to implement on test failure
+### Breaking
 
-#### State File Schema Extensions
-- New fields: `project_type`, `git_branch`, `test_retry_count`, `max_test_retries`, `test_passed`
-- New timestamps: `research_started_at/completed_at`, `plan_started_at/completed_at`, `implement_started_at/completed_at`, `test_started_at/completed_at`
-
-#### Version Unification
-- **A-3**: Unified `plugin.json` and `package.json` versions to 3.0.0
-
-#### SKILL.md Updates
-- Reflects 4-phase workflow
-- Added Zero-Base mode trigger keywords ("new project", "zero-base", "from scratch")
-- Added descriptions for new features (Research caching, partial re-run, Plan templates, interactive review, etc.)
-
-#### Reference Guide Updates
-- `research-guide.md` — Added Executive Summary/Key Findings output format, link to Zero-Base guide
-- `planning-guide.md` — Added Plan Summary output format, link to templates guide
-- `implementation-guide.md` — Updated Completion Protocol to transition to Test phase
-
-## [2.0.0] - 2026-03-07
+- Repository structure migrated to a `plugins/deep-work/` subdirectory — existing users must reinstall.
 
 ### Added
-- Per-task folder history (`deep-work/YYYYMMDD-HHMMSS-slug/`)
-- Auto-starts implementation on plan approval
-- Auto-generates session report (`report.md`)
-- `/deep-report` command (view/regenerate report)
-- `/deep-status` command (status, progress, session history)
-- Solo/Team mode selection
-- Team mode: 3-agent parallel Research, file-ownership-based parallel Implement, cross-review
+
+- Model Routing (per-phase model assignment, 30-40% token savings); multi-channel notifications; incremental research (`--incremental`, 60-80% time savings); Quality Gate system; Plan Diff visualization; routing/notification guides.
 
 ### Changed
-- Added `work_dir`, `team_mode`, `started_at` fields to state file
-- Phase Guard now allows document edits within `deep-work/` directory
 
-## [1.1.0] - 2026-03-01
+- `/deep-work` init, `/deep-status`, and `/deep-report` surface the new options; state schema and marketplace source path updated.
+
+## [3.0.0] — 2026-03-13
 
 ### Added
-- Phase Guard (PreToolUse hook) — Blocks code file modifications during Research/Plan phases
-- State-file-based phase management
+
+- Phase 4 Test (`/deep-test`) with auto-detected test/lint/type-check commands and a fix-and-retest loop (up to 3 retries), `test-results.md`, and Test-phase edit blocking.
+- Zero-Base mode for new projects; interactive plan review (feedback updates `plan.md`); plan version backups and 6 templates; partial/cached research; git branch + commit suggestions; implement checkpoints; per-phase time tracking; team-mode progress; `/deep-status --compare`.
 
 ### Changed
-- Migrated from simple prompt-based approach to hook-based enforcement
 
-## [1.0.0] - 2026-02-15
+- Phase flow becomes `research → plan → implement → test ⟲ → idle`; Executive Summary / Plan Summary placed first (pyramid principle); phase-guard block messages gain next-step guidance; state schema and SKILL.md extended.
+
+## [2.0.0] — 2026-03-07
 
 ### Added
-- Initial release
-- 3-phase workflow: Research → Plan → Implement
-- `/deep-work`, `/deep-research`, `/deep-plan`, `/deep-implement` commands
-- `research.md` and `plan.md` artifact generation
-- Iterative Plan review support
+
+- Per-task folder history (`deep-work/YYYYMMDD-HHMMSS-slug/`); auto-start implementation on plan approval; auto-generated session report; `/deep-report`; `/deep-status`; Solo/Team mode with 3-agent parallel research and cross-review.
+
+### Changed
+
+- State file gains `work_dir` / `team_mode` / `started_at`; Phase Guard allows document edits within `deep-work/`.
+
+## [1.1.0] — 2026-03-01
+
+### Added
+
+- Phase Guard (PreToolUse hook) blocking code-file edits during Research/Plan; state-file-based phase management.
+
+### Changed
+
+- Migrated from a prompt-based approach to hook-based enforcement.
+
+## [1.0.0] — 2026-02-15
+
+### Added
+
+- Initial release: 3-phase workflow (Research → Plan → Implement); `/deep-work`, `/deep-research`, `/deep-plan`, `/deep-implement`; `research.md` / `plan.md` artifacts; iterative plan review.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,8 @@ For detailed version history see [`CHANGELOG.md`](CHANGELOG.md) / [`CHANGELOG.ko
 
 To check the current version: `jq -r .version .claude-plugin/plugin.json`
 
+> 📄 **Docs maintenance**: this repo's documentation follows `docs/DOCS_RULE.md` (local maintainer guide — single-source-of-truth rules for README / CHANGELOG / this file).
+
 ---
 
 ## Project Overview

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,53 @@
+# Contributing to deep-work
+
+Thanks for your interest in improving **deep-work** — the Evidence-Driven
+Development Protocol plugin and core harness engine of the
+[claude-deep-suite](https://github.com/Sungmin-Cho/claude-deep-suite).
+
+## Getting started
+
+```bash
+git clone https://github.com/Sungmin-Cho/claude-deep-work.git
+cd claude-deep-work
+```
+
+Node 20+ is required. The plugin's runtime is zero-dependency (Node built-ins +
+bash hooks); there is no install step for development.
+
+## Tests
+
+```bash
+npm test          # runs the full suite (hooks + tests + skills + sensors + templates + scripts)
+npm run test:core # fast core subset (envelope, handoff, phase-guard, skill-entry, deep-memory)
+```
+
+`npm test` runs serially (`--test-concurrency=1`) to keep timing-sensitive hook
+tests stable. `health/**/*.test.js` runs cleanly in isolation via
+`npm run test:health` but has a known event-loop leak when interleaved with the
+full suite, so it is kept on a separate script.
+
+## Conventions
+
+- **Documentation** follows [`docs/DOCS_RULE.md`](docs/DOCS_RULE.md) (the local
+  maintainer rulebook). The README is evergreen; release notes live only in the
+  CHANGELOG.
+- **CHANGELOG** uses [Keep a Changelog](https://keepachangelog.com/) — add your
+  entry under `[Unreleased]` in both `CHANGELOG.md` and `CHANGELOG.ko.md`.
+- **Version triple-sync** — `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`,
+  and `package.json` versions must always match.
+- **Atomic commits** — one task per commit; never `git add -A`.
+
+## Pull requests
+
+1. Branch from `main`.
+2. Keep changes focused and make sure `npm test` is green.
+3. Update the CHANGELOG (`[Unreleased]`, both languages) when behavior changes.
+4. Explain what changed and why.
+
+After a release lands on `main`, the suite marketplace pin is updated in the
+[claude-deep-suite](https://github.com/Sungmin-Cho/claude-deep-suite) repository —
+not here.
+
+## Reporting issues
+
+Open a GitHub issue. For security reports, see [`SECURITY.md`](SECURITY.md).

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,883 +1,163 @@
 [English](./README.md) | **한국어**
 
-# Deep Work Plugin
+# deep-work
 
-<!-- Badges (populated after sessions) -->
-<!-- ![Deep Work Quality](https://img.shields.io/badge/deep--work-quality-lightgrey) -->
-<!-- ![Sessions](https://img.shields.io/badge/sessions-0-blue) -->
+[![version](https://img.shields.io/github/package-json/v/Sungmin-Cho/claude-deep-work?label=version)](https://github.com/Sungmin-Cho/claude-deep-work)
+[![license](https://img.shields.io/github/license/Sungmin-Cho/claude-deep-work)](./LICENSE)
+[![part of deep-suite](https://img.shields.io/badge/part%20of-deep--suite-5b8def)](https://github.com/Sungmin-Cho/claude-deep-suite)
 
-**Evidence-Driven Development Protocol** — 단일 커맨드 auto-flow 오케스트레이션, TDD 강제, slice/receipt 시스템으로 모든 코드 변경에 증거를 요구하는 플러그인.
+[Claude Code](https://docs.anthropic.com/en/docs/claude-code)와 Codex를 위한 **Evidence-Driven Development Protocol**. 단일 커맨드가 Brainstorm → Research → Plan → Implement → Test → Integrate 전체 워크플로우를 구동하며, TDD 강제, receipt 기반 증거 수집, 계획과 코딩의 엄격한 분리를 제공합니다.
 
-### 하네스 엔지니어링에서의 역할
+deep-work는 복잡한 작업에서 AI 코딩이 흔히 빠지는 실패 모드를 차단합니다: 기존 아키텍처를 무시한 새 패턴 도입, 이미 존재하는 유틸리티 재구현, 코드베이스를 이해하기 전에 구현 시작, 요청하지 않은 "개선"으로 인한 버그, 검증 없이 완료 처리.
 
-deep-work는 [Deep Suite](https://github.com/Sungmin-Cho/claude-deep-suite) 생태계의 **핵심 하네스 엔진**으로, [Harness Engineering](https://martinfowler.com/articles/harness-engineering.html) 프레임워크(Böckeler/Fowler, 2026)를 구현합니다.
+## deep-suite에서의 역할
 
-2×2 매트릭스(Guide/Sensor × Computational/Inferential)에서 deep-work의 역할:
+deep-work는 [claude-deep-suite](https://github.com/Sungmin-Cho/claude-deep-suite)의 **핵심 하네스 엔진**으로, [Harness Engineering](https://martinfowler.com/articles/harness-engineering.html) 프레임워크(Böckeler/Fowler, 2026)를 구현합니다. Guide/Sensor × Computational/Inferential 매트릭스에서:
 
-- **Computational Guides**: Phase Guard hook(편집 물리적 차단), **Worktree Guard**(P0, worktree 외부 쓰기 hard block), TDD 상태 머신(RED→GREEN), 토폴로지 템플릿(phase별 가이드)
-- **Computational Sensors**: Linter/타입 체크 파이프라인, 커버리지, 뮤테이션 테스팅, 4개 드리프트 센서, fitness 규칙, review-check 센서, **Phase Transition Injector**(P1, 조건 context injection)
-- **Inferential Guides**: Research/plan/brainstorm 문서, Sprint Contract
-- **Self-Correction Loop**: SENSOR_RUN → SENSOR_FIX → SENSOR_CLEAN (센서별 독립 3회 교정)
+- **Computational Guides** — Phase Guard hook(편집 물리적 차단), Worktree Guard(P0, worktree 외부 쓰기 hard-block), TDD RED→GREEN 상태 머신, 토폴로지 템플릿.
+- **Computational Sensors** — linter/typecheck/coverage/mutation 파이프라인, 드리프트 센서, fitness 규칙, review-check 센서, Phase Transition Injector(P1).
+- **Inferential Guides** — research / plan / brainstorm 문서, Sprint Contract.
+- **Self-Correction Loop** — SENSOR_RUN → SENSOR_FIX → SENSOR_CLEAN, 센서별 3-round 제한.
 
-deep-work는 [deep-review](https://github.com/Sungmin-Cho/claude-deep-review)와 [deep-dashboard](https://github.com/Sungmin-Cho/claude-deep-dashboard)가 소비하는 receipt과 health report를 생성합니다.
+[deep-review](https://github.com/Sungmin-Cho/claude-deep-review)와 [deep-dashboard](https://github.com/Sungmin-Cho/claude-deep-dashboard)가 소비하는 receipt과 health report를 생성합니다.
 
-## Codex 호환성
+## 설치
 
-deep-work는 기존 claude-deep-suite marketplace namespace를 유지하면서 Claude Code와 Codex 플러그인 런타임을 모두 지원합니다. Claude Code와 Codex는 각자의 네이티브 manifest를 읽고, skill 호출자는 아래 릴리스 노트에 정리된 동일한 skill-native invocation 모델을 사용합니다.
-
-## v6.9.0 새 기능
-
-### Deep-Memory v0.1.0 consumer 통합 — Phase 1 recall + Phase 5 harvest
-
-이번 릴리스는 deep-work를 새 `deep-memory` 플러그인 (claude-deep-suite v0.1.0) 의 **read-only consumer** 로 연결합니다. opt-in 가능한 두 affordance:
-
-- **Phase 1 Research recall** — `skills/deep-research/SKILL.md` 가 `.deep-memory/latest-brief.md` 존재 여부를 probe 하고, 존재 시 brief 를 verbatim 으로 `research.md` 의 새 `## Cross-project Memory` 섹션에 인용 (deep-memory 의 render 보존을 위해 heading hierarchy +2 shift). Brief 가 **부재** 면 research artifact 는 deep-memory-agnostic 상태 유지 — runtime context 에만 한 줄 안내 emit, `research.md` 에는 아무것도 쓰지 않음. `/deep-memory-brief` 는 절대 자동 호출하지 않음 — recall 은 사용자 주도. Provenance 토큰 (`mem-<ULID>`, Crockford-base32 uppercase) 은 새 `cross_project_memory.cited_memory_ids[]` state 필드로 캡처되어 향후 feedback-hook (Phase 4+) 에 사용.
-- **Phase 5 Integrate harvest** — `skills/deep-integrate/SKILL.md` 가 `deep-memory ∈ plugins.installed` 이고 session 변경 > 0 파일일 때 top-3 LLM 추천과 결정적 B-fallback 리스트에 `/deep-memory-harvest` 를 제안. `detect-plugins.sh` 가 `plugins.installed` / `plugins.missing` 에 deep-memory 를 올바르게 enumerate 하도록 확장.
-
-본 통합은 **forward-compatible**: deep-memory 를 설치하지 않은 프로젝트는 동작 변화 없음. 보류된 `/deep-memory feedback` hook (spec §14.2 item 5) 은 Phase 4+ joint PR 을 위해 `docs/deep-memory-integration-handoff.md` 에 추적됨. 13 개 신규 contract 테스트가 privacy 경계, ULID 정규식, stale-warning wording, heading-shift rule, edge case 등 모든 문서화된 invariant 를 고정.
-
-## v6.8.0 새 기능
-
-### Plan-Quality contract 강제 + CI 견고화 + receipt-tracker 안정성
-
-이번 릴리스는 plan-quality 강제, CI 위생, receipt-tracker 안정성을 세 가지 협업 변경으로 끌어올립니다:
-
-- **Plan-quality contract**: 모든 비-인라인 S/M/L slice는 이제 `failing_test`, `verification_cmd`, `expected_output`, `code_sketch`, `steps`를 반드시 선언해야 합니다. Plan review gate (`skills/shared/references/review-gate.md`)가 이 contract와 정렬됨 — 누락 필드에 대한 "권장" 헷지나 v5.8 하위 호환 fallback이 더 이상 없음. `tests/plan-quality-contract.test.js`가 템플릿과 review-gate 문구 모두를 고정하여 silently 이탈하지 못하도록 함.
-- **CI 견고화**: non-blocking `shellcheck` advisory 스텝이 `hooks/scripts/**/*.sh`를 lint (`tests/ci-workflow-contract.test.js`로 고정). `npm test`가 이제 재귀 `node --test "**/*.test.js"` 글로브로 48+개 테스트를 모두 발견하며, 글로브 지원을 위해 CI Node 20 → 22 (LTS)로 bump.
-- **Receipt-tracker 안정성**: `hooks/scripts/file-tracker.sh`의 pre-lock receipt 초기화를 복원 + `O_CREAT | O_EXCL` (`fs.writeFileSync` `flag: 'wx'`) 적용으로 stale lock으로 in-lock update가 타임아웃되어도 single-write slice가 canonical `SLICE-NNN.json`을 유지. `hooks/scripts/file-tracker-lock-timeout.test.js`가 end-to-end drain contract를 검증.
-
-## v6.7.1 새 기능
-
-### Codex 네이티브 manifest 와 skill entry alias
-
-이번 릴리스는 `.codex-plugin/plugin.json` 과 `AGENTS.md` 를 추가해 Codex가 Claude Code와 같은 플러그인 표면을 읽도록 하며, 내부 orchestrator 이름을 몰라도 auto-flow를 시작할 수 있도록 `$deep-work:deep-work "task"` skill entry alias를 복구합니다.
-
-## v6.7.0 새 기능
-
-### 24개 커맨드를 user-invocable skill 로 승격
-
-24개 command-equivalent 표면이 모두 `skills/` 아래 `user-invocable: true` skill 로 이동했습니다. 기존 `commands/` wrapper는 제거되었고, 내부 참조는 이제 `skills/deep-status/SKILL.md` 및 `skills/deep-receipt/SKILL.md` 같은 skill 파일을 가리킵니다.
-
-## v6.5.0 새 기능
-
-### M3 Cross-Plugin Envelope 채택 (claude-deep-suite Phase 2 #3)
-
-`session-receipt.json` 과 `receipts/SLICE-*.json` 이 M3 envelope-wrapped artifact 로 emit 됩니다 (cf. `claude-deep-suite/docs/envelope-migration.md` §1):
-
-```
-{
-  "schema_version": "1.0",
-  "envelope": {
-    "producer": "deep-work",
-    "producer_version": "6.5.0",
-    "artifact_kind": "session-receipt|slice-receipt",
-    "run_id": "<ULID>",
-    "session_id": "<dw-session-id>",
-    "parent_run_id": "<consumed evolve-insights run_id, optional>",
-    "generated_at": "<RFC 3339>",
-    "schema": { "name": "<same as artifact_kind>", "version": "1.0" },
-    "git": { ... },
-    "provenance": { "source_artifacts": [...], "tool_versions": {...} }
-  },
-  "payload": { /* legacy receipt body */ }
-}
-```
-
-session-receipt 의 `envelope.parent_run_id` 가 consumed `evolve-insights.json` envelope 으로 chain (handoff §3.3 cross-plugin trace), `provenance.source_artifacts[]` 가 모든 slice receipt run_id 를 aggregate (intra-plugin chain). Internal reader (`hooks/scripts/*`) 와 cross-plugin consumer (`gather-signals.sh`, `deep-research/SKILL.md`) 는 envelope 을 감지하고 identity guard 를 적용한 뒤 `.payload` 로 unwrap 후 legacy field 를 읽습니다. Legacy non-envelope receipt 는 forward-compat.
-
-## v6.4.2 새 기능
-
-### 유연한 세션 초기화
-
-`/deep-work`가 이제 단일 "이대로 진행할까요?" 프롬프트 대신 LLM 추천 기본값과 함께 항목별로 물어봅니다:
-
-- **Profile schema v3** + `interactive_each_session` — 매 세션 묻는 항목을 사용자별로 customize
-- **session-recommender sub-agent** (기본 sonnet) — task description과 workspace 컨텍스트에서 최적 `team_mode` / `start_phase` / `tdd_mode` / `git` / `model_routing`을 추론
-- 새 플래그: `--no-ask` (ask + recommender 모두 skip, 가장 빠른 경로), `--recommender=MODEL` (sub-agent 모델 override, allowlist `^(haiku|sonnet|opus)$`), `--no-recommender` (recommender만 skip)
-
-### Profile v2 → v3 자동 마이그레이션
-
-첫 호출 시 v6.4.x 프로필을 자동 업그레이드: atomic write + flock + idempotent + `.v2-backup` + rollback 절차. v6.4.1 `git_branch:` 프로필은 거부되지 않고 변환됩니다.
-
-### 알림 시스템 제거
-
-Slack/Discord/Telegram/webhook 통합이 제거되었습니다. `notify.sh` webhook에 의존하던 경우, v6.4.1을 fork하거나 다른 메커니즘으로 이관해야 합니다.
-
-### 마이그레이션
-
-기존 사용자: 별도 조치 불필요 — 첫 `/deep-work` 호출 시 프로필이 자동 마이그레이션됩니다. Rollback(프로젝트 로컬): `mv .claude/deep-work-profile.yaml.v2-backup .claude/deep-work-profile.yaml`.
-
-전체 변경 내역(breaking change 포함)은 `CHANGELOG.ko.md`를 참조하세요.
-
-## 문제
-
-AI 코딩 도구가 복잡한 작업을 수행할 때 흔히 발생하는 문제:
-- 기존 아키텍처를 무시하고 새로운 패턴을 도입
-- 이미 존재하는 유틸리티를 중복 구현
-- 코드베이스를 충분히 이해하기 전에 구현 시작
-- 요청하지 않은 "개선"을 추가하여 버그 유발
-- 구현 후 검증 없이 완료 처리
-
-## 해결책
-
-**Brainstorm → Research → Plan → Implement → Test → Integrate** 6단계 Evidence-Driven Protocol:
-
-- **Phase 0 (Brainstorm)**: "왜 만드는가" 디자인 탐색 (`--skip-brainstorm`으로 생략 가능)
-- **Phase 1 (Research)**: 코드베이스를 깊이 분석하여 문서화
-- **Phase 2 (Plan)**: Slice 기반 구현 계획 (per-slice TDD 필드 포함), 사용자 승인
-- **Phase 3 (Implement)**: TDD 강제 slice 실행 — failing test → production code → receipt 수집
-- **Phase 4 (Test)**: Receipt 완전성, spec compliance 리뷰, code quality 리뷰, 검증 증거 확인
-- **Phase 5 (Integrate, skippable)**: 추천 루프 — deep-suite 플러그인 아티팩트 기반 최대 3개 다음 단계 제안 (`--skip-integrate`로 생략 가능)
-
-**v6.3.1: Phase Exit Gate** — 5개 주요 phase(Brainstorm, Research, Plan, Implement, Test) 완료 시마다 명시적 사용자 결정을 요구합니다: 다음 phase 진행 / 현재 phase 수정 / 일시정지. "일시정지" 선택 시 `current_phase`가 유지되어 `/deep-resume` 재개 시 Exit Gate가 다시 표시됩니다. Phase 5 Integrate는 기존대로 interactive loop으로 유지됩니다.
-
-Phase 0, 1, 2, 4에서는 **코드 파일 수정이 물리적으로 차단**됩니다 (PreToolUse 훅). **Bash 파일 쓰기 명령**(`echo >`, `sed -i`, `cp`)도 차단됩니다. Phase 3에서는 **파일 변경과 receipt 데이터가 자동 수집**됩니다 (PostToolUse 훅).
-
-## 사용법 (Skill-Native Auto-Flow)
+`claude-deep-suite` 마켓플레이스 (권장):
 
 ```bash
-# skill 호출 하나로 전체 워크플로우가 자동 진행됩니다
+/plugin marketplace add Sungmin-Cho/claude-deep-suite
+/plugin install deep-work@Sungmin-Cho-claude-deep-suite
+```
+
+이 저장소에서 단독 설치:
+
+```bash
+/plugin marketplace add Sungmin-Cho/claude-deep-work
+/plugin install deep-work@Sungmin-Cho-claude-deep-work
+```
+
+deep-work는 Claude Code와 Codex 플러그인 런타임 모두에서 동작합니다 — 각자 native manifest를 읽고, skill 호출자는 동일한 skill-native invocation 모델을 사용합니다.
+
+> **Windows**: hook 스크립트는 PATH에 `bash`가 필요합니다 (Git for Windows 또는 WSL).
+
+## 사용법
+
+전체 워크플로우가 skill 호출 하나로 실행되며, plan 승인이 유일한 필수 인터랙션입니다.
+
+```bash
+# 전체 auto-flow 실행: Brainstorm → Research → Plan → [승인] → Implement → Test → Integrate → Report
 $deep-work:deep-work "JWT 기반 사용자 인증 구현"
 
-# Auto-flow가 자동 오케스트레이션: Brainstorm → Research → Plan → [사용자 승인] → Implement → Test → Integrate → Report
-# Plan 승인이 유일한 필수 인터랙션입니다
-
-# 통합 상태 조회 — 플래그는 standalone report/receipt/history/assumptions skill과 동일한 구현으로 라우팅됨
+# 통합 상태 조회 — 플래그는 standalone skill과 동일한 구현으로 라우팅됨
 $deep-work:deep-status              # 현재 진행 상태
 $deep-work:deep-status --report     # 세션 리포트
 $deep-work:deep-status --receipts   # receipt 대시보드
 $deep-work:deep-status --history    # 크로스 세션 트렌드
 $deep-work:deep-status --assumptions # 가설 건강도
 $deep-work:deep-status --all        # 전체 통합 뷰
-
-# 두 세션 비교
-$deep-work:deep-status --compare
+$deep-work:deep-status --compare    # 두 세션 비교
 ```
 
-## Skill 호출
+Claude Code에서는 동일한 표면을 슬래시 커맨드로도 사용할 수 있으며, Codex 등 다른 호스트에서는 `$deep-work:<verb>` skill 형태를 사용합니다.
 
-### Primary Skills (7개)
+## v6.9.0 새 기능
+
+deep-work v6.9.0은 새 `deep-memory` 플러그인에 Phase 1 recall과 Phase 5 harvest 추천을 read-only opt-in consumer로 연결합니다. 전체 릴리스 히스토리는 [CHANGELOG](CHANGELOG.ko.md)를 참조하세요.
+
+## Skills
+
+deep-work는 24개 command-equivalent skill을 노출합니다. 가장 많이 쓰는 것:
 
 | Skill | 설명 |
-|-------|------|
-| `$deep-work:deep-work <task>` | **Auto-flow 오케스트레이션** — Brainstorm → Research → Plan → Implement → Test → Integrate 전체 파이프라인을 자동 실행. Plan 승인이 유일한 필수 인터랙션. |
-| `$deep-work:deep-research` | 수동 오버라이드 — Phase 1 (Research): 코드베이스 심층 분석 |
-| `$deep-work:deep-plan` | 수동 오버라이드 — Phase 2 (Plan): slice 기반 구현 계획 |
-| `$deep-work:deep-implement` | 수동 오버라이드 — Phase 3 (Implement): TDD 강제 slice 실행 |
-| `$deep-work:deep-test` | Phase 4: Receipt 검증 → spec compliance → code quality → quality gates. drift-check, SOLID 리뷰, insight 분석을 자동 실행. |
-| `$deep-work:deep-status` | **통합 뷰** — 현재 진행 상태, 리포트, receipt, 히스토리, 가설 건강도. 플래그: `--report`, `--receipts`, `--history`, `--assumptions`, `--all`, `--compare` |
-| `$deep-work:deep-debug` | 체계적 디버깅: investigate → analyze → hypothesize → fix (실패 시 자동 진입) |
+|---|---|
+| `$deep-work:deep-work <task>` | Auto-flow 오케스트레이션 — 전체 파이프라인 실행; plan 승인이 유일한 필수 인터랙션 |
+| `$deep-work:deep-research` | Phase 1 (Research) — 코드베이스 심층 분석 |
+| `$deep-work:deep-plan` | Phase 2 (Plan) — slice 기반 구현 계획 |
+| `$deep-work:deep-implement` | Phase 3 (Implement) — TDD 강제 slice 실행 |
+| `$deep-work:deep-test` | Phase 4 (Test) — receipt + spec + quality gate; drift-check·SOLID·insight 자동 실행 |
+| `$deep-work:deep-integrate` | Phase 5 (Integrate) — 크로스 플러그인 다음 단계 추천 루프 |
+| `$deep-work:deep-status` | 통합 뷰 (`--report` / `--receipts` / `--history` / `--assumptions` / `--all` / `--compare`) |
+| `$deep-work:deep-finish` | 세션 종료 — worktree merge / PR / keep / discard |
+| `$deep-work:deep-debug` | 체계적 디버깅: investigate → analyze → hypothesize → fix |
 
-### Special Utility (4개)
+그 외 skill은 quality gate(`drift-check`, `solid-review`, `deep-insight`), 세션 유틸리티(`deep-fork`, `deep-resume`, `deep-cleanup`, `deep-slice`), 툴체인 헬퍼(`deep-mutation-test`, `deep-sensor-scan`, `deep-phase-review`), read-only status 서브 skill(`deep-report`, `deep-receipt`, `deep-history`, `deep-assumptions`)을 다룹니다. 모두 수동 호출 가능하며, 다수는 auto-flow 내에서 자동 실행됩니다.
 
-Phase나 툴체인 헬퍼. 필요할 때 수동으로 호출합니다.
+## 워크플로우
 
-| Skill | 용도 |
-|-------|------|
-| `$deep-work:deep-fork` | 세션을 fork하여 다른 접근법 탐색 |
-| `$deep-work:deep-mutation-test` | 변경 파일 대상 mutation testing |
-| `$deep-work:deep-phase-review` | brainstorm/research/plan 문서 수동 리뷰 |
-| `$deep-work:deep-sensor-scan` | 린터/타입체커/커버리지를 독립 실행 |
+| Phase | 역할 |
+|---|---|
+| **0 — Brainstorm** | 선택적 디자인 탐색, "왜 만드는가" (`--skip-brainstorm`으로 생략) |
+| **1 — Research** | 아키텍처·패턴·데이터·API·인프라·리스크 전반의 코드베이스 분석; `research.md` 산출 |
+| **2 — Plan** | per-slice TDD 필드를 갖춘 slice 기반 계획, 사용자 승인 필요; `plan.md` 산출 |
+| **3 — Implement** | TDD 강제 slice 실행: failing test → production code → receipt |
+| **4 — Test** | receipt 완전성·spec compliance·code quality·검증 증거, 최대 3회 implement→test 재시도 |
+| **5 — Integrate** | deep-suite 플러그인 아티팩트를 읽어 최대 3개 다음 단계 제안하는 skippable 루프 (`--skip-integrate`로 생략) |
 
-### Quality Gate (3개) — `$deep-work:deep-test` 자동 실행, standalone 가능
-
-| Skill | `$deep-work:deep-test` 내 역할 | Standalone |
-|-------|----------------------------------|------------|
-| `$deep-work:drift-check` | Required Gate — plan 정합성 | `$deep-work:drift-check [plan-file]` |
-| `$deep-work:solid-review` | Advisory Gate — SOLID 원칙 | `$deep-work:solid-review [target]` |
-| `$deep-work:deep-insight` | Insight Tier — 메트릭/복잡도 | `$deep-work:deep-insight [target]` |
-
-### Internal (7개) — 자동 호출, 수동도 공식 경로
-
-orchestrator 또는 `$deep-work:deep-status`가 호출합니다. 수동 호출도 일등급 경로입니다 (특히 test 통과 후 `$deep-work:deep-finish`, Phase 4 이후 `$deep-work:deep-integrate`).
-
-| Skill | 호출 주체 |
-|-------|-----------|
-| `$deep-work:deep-brainstorm` | orchestrator Phase 0 (`Skill` dispatch) |
-| `$deep-work:deep-integrate` | orchestrator Phase 5 (`Skill` dispatch); test 통과 후 수동 호출 |
-| `$deep-work:deep-finish` | orchestrator Step 3-6 (`Read`); test 통과 후 수동 호출 |
-| `$deep-work:deep-report` | `$deep-work:deep-status --report` (`Read`) |
-| `$deep-work:deep-receipt` | `$deep-work:deep-status --receipts` (`Read`) |
-| `$deep-work:deep-history` | `$deep-work:deep-status --history` (`Read`) |
-| `$deep-work:deep-assumptions` | `$deep-work:deep-status --assumptions` (`Read`) |
-
-### Escape Hatch (1개)
-
-| Skill | 노출 위치 |
-|-------|-----------|
-| `$deep-work:deep-slice` | `phase-guard` TDD 블록 안내 메시지 (`spike`, `reset`) |
-
-### Utility (2개) — standalone, 기능 이관 예정
-
-특정 동작의 유일한 경로인 skill입니다. 기능이 이관되면 삭제 예정 (`$deep-work:deep-work --resume=<session-id>`, `$deep-work:deep-status --cleanup` 로드맵 참고).
-
-| Skill | 고유 기능 |
-|-------|-----------|
-| `$deep-work:deep-cleanup` | `git worktree list` 스캔, stale/active 분류, fork/registry 정리 |
-| `$deep-work:deep-resume` | active 세션 선택, worktree 컨텍스트 복원, phase별 resume dispatch |
+5개 주요 phase는 각각 명시적 Exit Gate(진행 / 수정 / 일시정지)로 끝납니다. Brainstorm·Research·Plan·Test에서는 코드 파일 편집이 물리적으로 차단되며(`echo >`, `sed -i`, `cp` 같은 파일 쓰기 Bash 명령 포함), Implement에서는 파일 변경과 receipt 데이터가 자동 수집됩니다.
 
 ## 산출물
 
 각 세션의 산출물은 `.deep-work/<작업폴더>/`에 저장됩니다:
 
 | 파일 | 생성 시점 | 설명 |
-|------|----------|------|
-| `research.md` | Phase 1 완료 | 코드베이스 분석 결과 (Executive Summary 먼저) |
-| `plan.md` | Phase 2 완료 | 상세 구현 계획 (Plan Summary 먼저, per-slice contract + acceptance_threshold 필드) |
-| `plan.v{N}.md` | Plan 재작성 시 | 이전 Plan 버전 백업 |
-| `test-results.md` | Phase 4 완료 | 검증 결과 (시도별 누적) |
-| `report.md` | 세션 완료 | 전체 세션 리포트 (Phase별 소요 시간 포함) |
-| `quality-gates.md` | Phase 4 완료 | Quality Gate 결과 상세 (required/advisory) |
-| `drift-report.md` | Phase 4 완료 | Plan 정합성 검증 결과 |
-| `solid-review.md` | Phase 4 완료 | SOLID 설계 리뷰 스코어카드 및 제안 |
-| `insight-report.md` | Phase 4 완료 | 코드 메트릭, 복잡도, 의존성 분석 |
-| `file-changes.log` | Phase 3 진행 중 | PostToolUse 훅 자동 파일 변경 추적 (slice 매핑 포함) |
-| `plan-diff.md` | Plan 재작성 시 | Plan 버전 간 구조적 변경 비교 |
-| `brainstorm.md` | Phase 0 완료 | 디자인 스펙: 문제 정의, 접근법 비교, 성공 기준 |
-| `receipts/SLICE-NNN.json` | Phase 3 진행 중 | Per-slice 증거: TDD 출력, git diff, spec 체크, 리뷰, 사용 모델 |
-| `session-receipt.json` | 세션 완료 | 크로스 slice 세션 요약 — slice receipt에서 파생된 캐시 |
+|---|---|---|
+| `research.md` | Phase 1 | 코드베이스 분석 (Executive Summary 먼저) |
+| `plan.md` | Phase 2 | 구현 계획 (per-slice contract + acceptance 필드) |
+| `plan.v{N}.md` / `plan-diff.md` | Plan 재작성 | 이전 plan 백업 / 구조적 변경 비교 |
+| `brainstorm.md` | Phase 0 | 문제 정의, 접근법 비교, 성공 기준 |
+| `receipts/SLICE-NNN.json` | Phase 3 | Per-slice 증거: TDD 출력, git diff, spec check, 리뷰, 모델 |
+| `file-changes.log` | Phase 3 | slice 매핑을 갖춘 자동 파일 변경 추적 |
+| `test-results.md` | Phase 4 | 검증 결과 (시도별 누적) |
+| `quality-gates.md` / `drift-report.md` / `solid-review.md` / `insight-report.md` | Phase 4 | Quality gate, plan 정합성, SOLID, 메트릭 리포트 |
+| `report.md` | 세션 완료 | Phase 소요 시간 포함 전체 세션 리포트 |
+| `session-receipt.json` | 세션 종료 | 크로스 slice 세션 요약 (M3 envelope) |
 | `debug-log/RC-NNN.md` | Phase 3 (디버깅) | Root cause 분석 노트 |
-| `harness-history/harness-sessions.jsonl` | 세션 종료 | Per-session assumption engine 데이터 — per-slice 증거, 모델, 신뢰도 신호 |
+| `harness-history/harness-sessions.jsonl` | 세션 종료 | Per-session assumption-engine 데이터 |
 
-## 세션 상태
-
-`.claude/deep-work.local.md`에 YAML frontmatter로 저장:
-
-| 필드 | 설명 |
-|------|------|
-| `current_phase` | 현재 단계 (idle / brainstorm / research / plan / implement / test) |
-| `work_dir` | 작업 폴더 경로 |
-| `task_description` | 작업 설명 |
-| `team_mode` | 작업 모드 (solo / team) |
-| `project_type` | 프로젝트 타입 (existing / zero-base) |
-| `git_branch` | 생성된 Git 브랜치명 |
-| `test_retry_count` | 테스트 재시도 횟수 |
-| `test_passed` | 최종 테스트 통과 여부 |
-| `*_started_at`, `*_completed_at` | Phase별 시작/완료 타임스탬프 |
-| `model_routing` | Phase별 모델 설정 (research/plan/implement/test) |
-| `last_research_commit` | 마지막 리서치 시점의 git commit hash |
-| `quality_gates_passed` | Quality Gate 전체 통과 여부 |
-| `preset` | 활성 프리셋 이름 |
-| `plan_approved_at` | Plan 승인 시점 타임스탬프 (Drift Detection 기준) |
-| `tdd_mode` | TDD 강제 모드 (strict / relaxed / coaching / spike) |
-| `active_slice` | 현재 활성 slice ID (예: SLICE-001) |
-| `tdd_state` | 현재 TDD 상태 (PENDING / RED / RED_VERIFIED / GREEN_ELIGIBLE / GREEN / REFACTOR / SPIKE) |
-| `tdd_override` | Slice 단위 TDD override — 사용자가 AskUserQuestion으로 TDD를 건너뛸 때 활성 slice ID로 설정 |
-| `debug_mode` | 체계적 디버깅 활성 여부 |
-| `brainstorm_started_at`, `brainstorm_completed_at` | Phase 0 타임스탬프 |
-| `worktree_enabled` | Worktree 격리 활성 여부 |
-| `worktree_path` | Worktree 디렉토리 절대 경로 |
-| `worktree_branch` | Worktree 내부 브랜치명 |
-| `worktree_base_branch` | Worktree 생성 전 원본 브랜치 |
-| `worktree_base_commit` | Worktree 생성 시점 commit hash |
-| `evaluator_model` | 서브에이전트 기본 평가자 모델 — `"sonnet"` |
-| `plan_review_retries` | Plan 리뷰 auto-loop 재시도 횟수 — `0` |
-| `plan_review_max_retries` | Plan auto-loop 최대 재시도 횟수 — `3` |
-| `auto_loop_enabled` | Auto-loop 평가 활성 여부 — `true` |
-| `skipped_phases` | `--skip-to-implement`로 건너뛴 단계 — `[]` |
-| `assumption_adjustments` | Assumption Engine 활성 조정 목록 — `[]` |
-
-## 워크플로우 상세
-
-### Phase 1: Research
-
-**크로스 플러그인 컨텍스트 (v6.2):** Research 시작 시 외부 플러그인 데이터를 참조:
-- `.deep-dashboard/harnessability-report.json` — 점수 낮은 차원(< 5.0)을 context에 포함 (7일 이상 경과 시 skip)
-- `.deep-evolve/evolve-insights.json` — meta-archive 기반 인사이트를 참고 수준으로 포함
-
-코드베이스를 6개 영역으로 체계적으로 분석합니다:
-
-1. **Architecture & Structure** — 프로젝트 구조, 아키텍처 패턴, 모듈 경계
-2. **Code Patterns & Conventions** — 네이밍 컨벤션, 에러 처리, 테스팅 패턴
-3. **Data Layer** — ORM/DB 스키마, 마이그레이션, 캐싱 전략
-4. **API & Integration** — API 구조, 인증/인가, 외부 서비스 연동
-5. **Shared Infrastructure** — 공통 유틸리티, 설정 관리, 빌드 시스템
-6. **Dependencies & Risks** — 의존성 충돌, 호환성, 보안 리스크
-
-**v3.0 신규 기능:**
-- **Executive Summary 먼저 제시** — 피라미드 원칙: 결론 → 근거 → 세부사항
-- **제로베이스 모드** — 기술 스택 선정, 스캐폴딩 설계 등 새 프로젝트용 Research
-- **부분 재실행** — `/deep-research --scope=api,data`로 특정 영역만 재분석
-- **Research 캐싱** — 이전 세션 Research를 베이스라인으로 활용, 변경 영역만 재분석
-- **Team 모드 진행 알림** — 에이전트 완료 시 `[2/3] pattern-analyst 완료 ✅` 표시
-
-**v3.1 신규 기능:**
-- **증분 리서치** — `/deep-research --incremental`로 git diff 기반 변경 영역만 재분석 (시간 60~80% 절감)
-- **모델 라우팅** — Research Phase를 sonnet 모델 Agent에 위임하여 토큰 절감
-
-**v5.5 신규 기능:**
-- **Cross-Model Review** — codex/gemini가 research 결과를 전용 rubric으로 독립 평가
-- **종합 판단** — Claude가 모든 리뷰 결과를 종합 분석, 사용자 일괄 확인 후 진행
-
-### Phase 2: Plan
-
-연구 결과를 바탕으로 구체적인 구현 계획을 작성합니다:
-
-- Plan Summary (접근법, 변경 범위, 리스크, 핵심 결정) 먼저 제시
-- 변경할 파일 목록과 각 파일의 구체적 변경 내용
-- 코드 스케치, 실행 순서, 트레이드오프 분석, 롤백 전략
-- Slice 체크리스트: per-slice TDD 필드 (failing_test, verification_cmd, spec_checklist)
-
-**v3.0 신규 기능:**
-- **대화형 Plan 리뷰** — 채팅으로 "3번 항목 변경해줘" → plan.md 자동 수정
-- **Plan 템플릿** — API 엔드포인트, UI 컴포넌트, DB 마이그레이션 등 6종
-- **Plan 변경 이력** — 재작성 시 `plan.v{N}.md`로 백업, Change Log 추가
-- **모드 전환 제안** — Plan 분석 결과에 따라 Team↔Solo 전환 추천
-- **"승인" 입력 시 구현이 자동으로 시작됩니다.**
-
-**v3.1 신규 기능:**
-- **Plan Diff 시각화** — Plan 재작성 시 태스크/파일/아키텍처/리스크 변경을 `plan-diff.md`로 자동 비교
-
-**v5.5 신규 기능:**
-- **Claude 자체 재검토** — structural review 전 자동 품질 점검 — placeholder, 일관성, research 정합성
-- **종합 판단** — cross-review 결과를 Claude 판단과 함께 제시, 사용자 확인 후 plan 수정
-
-**v5.5.1 신규 기능:**
-- **Team research 교차 검증** — `team_mode: team`일 때 plan 단계에서 부분 리서치 파일(`research-architecture.md`, `research-patterns.md`, `research-dependencies.md`)을 보조 참조로 로드하여 합성본과 교차 확인
-
-**v5.5.2 신규 기능:**
-- **확장된 bash 파일 쓰기 감지** — 20+ 신규 패턴: perl in-place, node -e `fs.writeFileSync`, python -c, ruby -e, awk, swift, git 파괴 연산, curl/wget 출력, ln, tar/unzip/cpio, rsync
-- **보안: file-write-first 감지 순서** — FILE_WRITE 패턴을 SAFE 패턴보다 먼저 검사하여 우회 방지
-- **확장된 테스트 파일 패턴** — Dart, Elixir, Lua, Vue, `fixtures/`, `__mocks__/`, `spec/` 디렉토리
-- **확장된 TDD exempt 패턴** — `.toml`, `.ini`, `.cfg`, `.lock`, `.editorconfig`, 이미지 파일 (`.svg`, `.png`, `.jpg`, `.gif`)
-- **TDD state 검증** — 알 수 없는 TDD 상태값 차단 + 안내 메시지
-- **Backtick/subshell 처리** — `splitCommands`가 backtick과 `$()` 깊이 추적
-- **에러 로깅** — hook 에러를 `.claude/deep-work-guard-errors.log`에 기록 (기존 묵살 대신)
-
-### Phase 3: Implement
-
-Slice 단위 TDD 강제 실행:
-
-- Slice별 TDD 사이클: RED (failing test) → GREEN (minimal code) → REFACTOR
-- **TDD State Machine** 기반 hook 강제 — failing test output 없이 production 코드 수정 차단
-- 각 slice 완료 시 **receipt JSON** 자동 수집 (test output, git diff, spec checklist)
-- 예기치 않은 테스트 실패 시 **debug 모드 자동 진입** (`/deep-debug`)
-- **Spike 모드**: 탐색적 코딩 허용, 종료 시 자동 git stash + TDD 재시작
-- **Coaching 모드**: TDD 초보자를 위한 교육적 메시지 제공 (차단 대신 가이드)
-- **TDD Override**: TDD가 production 수정을 차단하면 Claude가 사용자에게 테스트 작성 또는 TDD 건너뛰기를 질문 (override된 slice는 merge 가능하되 receipt에 경고 표시)
-- **차단 메시지에 탈출구 안내**: `/deep-slice spike`, `/deep-slice reset` 등 대안을 차단 시 표시
-- **TDD state 업데이트 필수화** — B-1 (RED_VERIFIED), B-2 (GREEN) state file 업데이트를 필수로 명시하고 phase guard 차단 경고 추가
-- **구현 완료 후 자동으로 Test 단계 진입**
-
-### Phase 4: Test
-
-구현 결과를 자동으로 검증합니다:
-
-- 프로젝트 설정 파일에서 테스트/린트/타입체크 명령어 자동 감지
-- 순차 실행 후 결과 기록 (`test-results.md`)
-- **모두 통과**: 세션 완료 → 리포트 자동 생성
-- **실패 시**: implement 단계로 복귀 → 수정 → 재테스트 (최대 3회)
-- 재시도 횟수 초과 시 루프 중단, 수동 개입 요청
-
-```
-implement → test → (통과) → idle + report
-                 → (실패) → implement → test → ...
-```
-
-**v3.1 신규 기능:**
-- **Quality Gate 시스템** — plan.md에 게이트 정의 (required ✅ / advisory ⚠️), `quality-gates.md` 산출물
-- **모델 라우팅** — Test Phase를 haiku 모델 Agent에 위임하여 비용 최소화
-
-**v3.2 신규 기능:**
-- **3계층 Quality Gate 시스템** — Required (차단) / Advisory (경고) / Insight (정보)
-- **Plan Alignment (Drift Detection)** — 내장 Required 게이트. Plan 대비 구현 정합성 자동 검증. 미구현 항목, 범위 초과, 설계 이탈 감지. `drift-report.md` 산출물.
-- **SOLID Design Review** — Advisory 게이트. SRP, OCP, LSP, ISP, DIP 기준 설계 품질 리뷰. 파일별 스코어카드, Top 5 리팩토링 제안. `solid-review.md` 산출물.
-
-**v3.3 신규 기능:**
-- **Insight 계층 Quality Gate** — `/deep-insight` 커맨드 및 내장 Insight 게이트. 파일 메트릭, 복잡도 지표, 의존성 그래프, 변경 요약 분석. `insight-report.md` 산출물. 워크플로우 차단 없음.
-- **PostToolUse 파일 추적** — Implement 단계에서 파일 수정을 자동으로 `file-changes.log`에 기록. `/deep-report`와 `/deep-insight`에서 활용.
-- **Stop 훅** — CLI 세션 종료 시 활성 deep-work 세션이 있으면 알림 메시지 출력 및 알림 전송.
-
-**v3.3.3 신규 기능:**
-- **멀티 프리셋 Profile System** — 작업 스타일별 Named 프리셋 (`dev`, `quick`, `review`) 생성. 프리셋 2개 이상 시 인터랙티브 선택. v1 단일 프로필 → v2 멀티 프리셋 자동 마이그레이션.
-
-**v4.0 신규 기능 (Evidence-Driven Protocol):**
-- **Receipt Completeness Gate** (Required) — 모든 slice에 receipt 존재 확인
-- **Spec Compliance Review** (Required) — plan의 spec_checklist 대비 구현 검증 (서브에이전트)
-- **Code Quality Review** (Advisory) — 코드 품질, 패턴, 에러 처리 리뷰 (서브에이전트)
-- **Verification Evidence Gate** (Required) — 실제 테스트 실행 증거(receipt) 확인
-
-### Phase 5: Integrate (v6.3.0, skippable)
-
-Test 통과 후 Deep Work는 옵션으로 **추천 루프**를 실행할 수 있다. 설치된 deep-suite 플러그인(`deep-review`, `deep-docs`, `deep-wiki`, `deep-dashboard`, `deep-evolve`) 아티팩트를 읽어 AI가 최대 3개의 다음 단계를 rationale과 함께 제안한다. 사용자가 선택 → 실행 → 복귀 → 루프 계속 (최대 5 라운드), `finish` 선택 시 `/deep-finish`로 인계.
-
-`--skip-integrate`로 건너뛰거나 Phase 4 이후 언제든 `/deep-integrate`로 수동 호출.
-
-### Session Report
-
-세션 완료 후 자동 생성되는 리포트:
-
-- **Session Overview** — 작업명, 모드, 프로젝트 타입, Git 브랜치
-- **Phase Duration** — 각 Phase별 소요 시간
-- **Research/Plan Summary** — 핵심 분석 결과, 접근법
-- **Implementation Results** — 태스크별 실행 결과
-- **Verification Results** — 테스트/린트/타입체크 결과
-- **Test Retry History** — 시도별 결과 이력
-
-### Model Routing
-
-Phase별 최적 모델을 배정하여 토큰 비용을 30~40% 절감합니다.
-
-**v4.1: Slice 복잡도 기반 자동 라우팅** — Implement phase에서 각 slice의 크기에 따라 모델을 자동 선택:
-
-| Slice 크기 | 기본 모델 | 근거 |
-|-----------|----------|------|
-| S (Small) | haiku | 간단한 설정, 1-2 파일, 보일러플레이트 |
-| M (Medium) | sonnet | 표준 기능, 3-5 파일 |
-| L (Large) | sonnet | 복잡한 기능, 5+ 파일 |
-| XL (Extra-Large) | opus | 아키텍처 변경, 10+ 파일 |
-
-슬라이스별 override: `/deep-slice model SLICE-NNN opus`. 프리셋의 `routing_table` 필드로 라우팅 테이블 커스터마이즈 가능.
-
-**Phase별 기본값:**
-
-| Phase | 기본 모델 | 방식 | 근거 |
-|-------|----------|------|------|
-| Research | sonnet | Agent 위임 | 탐색/분석에 충분 |
-| Plan | 메인 세션 | 직접 실행 | 대화형 피드백 필요 |
-| Implement | **auto** | 크기 기반 선택 | 슬라이스별 비용 최적화 |
-| Test | haiku | Agent 위임 | 테스트 실행만 수행 |
-
-### Quality Gates
-
-plan.md에 Quality Gates를 정의하면 Test Phase에서 자동 실행됩니다:
-
-```markdown
-## Quality Gates
-
-| Gate | 명령어 | 필수 | 임계값 |
-|------|--------|------|--------|
-| Type Check | `npx tsc --noEmit` | ✅ | — |
-| Coverage | `npm test -- --coverage` | ⚠️ | ≥80% |
-```
-
-- **✅ 필수(required)**: 실패 시 implement 복귀
-- **⚠️ 권고(advisory)**: 경고만 기록, 차단 없음
-- **ℹ️ 인사이트(insight)**: 결과 기록만
-- 미정의 시 기존 auto-detection 유지
-
-## 다국어 지원
-
-모든 커맨드가 사용자의 언어를 자동으로 감지하여 해당 언어로 메시지를 출력합니다. 별도 설정 불필요.
-
-- **한국어**: 기본 참조 템플릿
-- **영어**: 자동 번역
-- **기타 언어**: 일본어, 중국어 등 Claude가 지원하는 모든 언어
-
-사용자 메시지 또는 Claude Code `language` 설정에서 언어를 감지합니다.
+세션 상태는 `.claude/deep-work.local.md`에 YAML frontmatter로 저장됩니다 (current phase, work dir, TDD state, model routing, worktree 정보, quality gate, health report 등).
 
 ## Hooks
 
-세션 라이프사이클과 computational enforcement를 관리하는 훅.
-
-> **Windows**: Hook 스크립트 실행에 `bash`가 PATH에 필요합니다 (Git for Windows 또는 WSL).
-
-| 훅 | 스크립트 | 트리거 | 용도 |
-|-----|--------|--------|------|
-| SessionStart | `update-check.sh` | 세션 시작 | Git 기반 자동 업데이트 확인 |
-| PreToolUse | `phase-guard.sh` | Write/Edit/MultiEdit/**Bash** | Phase 차단 + TDD 강제 + **P0 Worktree Guard** (worktree 외부 쓰기 hard block) |
-| PostToolUse | `file-tracker.sh` | Write/Edit/MultiEdit/**Bash** | 파일 변경 추적 + receipt 수집 |
-| PostToolUse | `sensor-trigger.js` | Write/Edit/MultiEdit/**Bash** | 센서 파이프라인 트리거 (lint, typecheck, review-check) |
-| PostToolUse | `phase-transition.sh` | Write/Edit/MultiEdit | **P1 Phase Transition Injector** — phase 전환 시 조건 context injection |
-| Stop | `session-end.sh` | CLI 세션 종료 | 활성 세션 알림 + phase cache 정리 |
-
-### Phase Guard
-
-| 단계 | 코드 수정 | Bash 파일쓰기 | 문서 수정 | 파일 추적 |
-|------|----------|-------------|----------|----------|
-| Brainstorm | ❌ 차단 | ❌ 차단 | ✅ 허용 | — |
-| Research | ❌ 차단 | ❌ 차단 | ✅ 허용 | — |
-| Plan | ❌ 차단 | ❌ 차단 | ✅ 허용 | — |
-| Implement | ✅ 허용 (TDD 강제) | ✅ 허용 (TDD 강제) | ✅ 허용 | ✅ 추적 + receipt |
-| Test | ❌ 차단 | ❌ 차단 | ✅ 허용 | — |
-| Idle | ✅ 허용 | ✅ 허용 | ✅ 허용 | — |
-
-## Profile System
-
-첫 실행 시 설정 질문을 받고 `default` 프리셋으로 저장됩니다. 이후 실행 시 프리셋이 자동 적용되어 작업 설명만 입력하면 됩니다.
-
-**멀티 프리셋 지원:** 작업 스타일별로 Named 프리셋을 생성할 수 있습니다. 프리셋이 2개 이상이면 세션 시작 시 선택합니다.
-
-```bash
-# 특정 프리셋 사용
-/deep-work --profile=quick "로그인 버그 수정"
-
-# 프리셋 관리 (생성, 수정)
-/deep-work --setup
-
-# 단일 세션 오버라이드
-/deep-work --team "대규모 리팩토링"
-```
-
-| 플래그 | 동작 |
-|--------|------|
-| `--profile=X` | 프리셋 X 직접 사용 |
-| `--setup` | 프리셋 관리 (생성/수정) |
-| `--team` | Team 모드 오버라이드 |
-| `--zero-base` | 제로베이스 오버라이드 |
-| `--skip-research` | Plan 단계부터 시작 |
-| `--skip-brainstorm` | Brainstorm 단계 생략, Research부터 시작 |
-| `--tdd=MODE` | TDD 모드 설정 (strict / relaxed / coaching / spike) |
-| `--skip-to-implement` | Implement 단계로 바로 진입 (인라인 slice 필요) |
-| `--no-branch` | Git 브랜치 생성 스킵 |
-
-## 세션 초기화 옵션
-
-`/deep-work` 실행 시 다음 옵션을 선택합니다 (또는 프리셋에 저장):
-
-| 옵션 | 선택지 | 설명 |
-|------|--------|------|
-| 작업 모드 | Solo / Team | 에이전트 병렬 실행 여부 |
-| 프로젝트 타입 | 기존 코드 / 제로베이스 | 새 프로젝트 여부 |
-| 시작 단계 | Research / Plan | 익숙한 코드면 Research 생략 가능 |
-| Git 브랜치 | 생성 / 건너뜀 | 세션용 브랜치 자동 생성 |
-| 모델 라우팅 | 기본값 / 커스텀 | Phase별 모델 배정 |
-
-## Team/Solo 모드 (v6.4.1)
-
-### 의미론
-- `--team` → 병렬도 = N (Research/Implement에 parallel subagent)
-- `--solo` (기본값) → 병렬도 = 1 (단일 subagent)
-
-### 작업 실행 위치
-모든 실제 작업은 기본적으로 **Claude Code subagent**에서 실행됩니다. 메인 세션은 오케스트레이터 역할만 합니다.
-
-### Escape hatches (Implement 전용)
-| 상황 | 동작 |
-|------|------|
-| `tdd_mode=spike` | 자동 inline |
-| `--skip-plan` + trivial slice 1개 | 자동 inline |
-| `--exec=inline` | inline 강제 |
-| `--exec=delegate` | delegate 강제 |
-| verify-receipt 실패 → "수동 수정" | Inline takeover |
-
-### Agent Team (선택 사항)
-`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`가 설정된 경우, team Implement 실행 시 classic Agent Team과 parallel subagent dispatch 중 선택을 요청합니다.
-
-## 복잡도별 사용 가이드
-
-| 복잡도 | 권장 워크플로우 | 기준 |
-|--------|---------------|------|
-| 높음 | Research → Plan → Implement → Test | 5+ 파일, 아키텍처 변경, 낯선 코드베이스 |
-| 중간 | Plan → Implement → Test (Research 생략) | 2-4 파일, 익숙한 영역의 확장 |
-| 낮음 | 워크플로우 불필요 | 단일 파일 수정, 설정 변경 |
-
-### Worktree 격리
-
-세션이 기본적으로 격리된 git worktree에서 실행됩니다. 개발 중 main 브랜치에 대한 우발적 변경을 방지합니다.
-
-- `/deep-work`이 `.worktrees/dw/<slug>/`에 전용 브랜치로 worktree 생성
-- 모든 작업이 worktree 내에서 진행 — main 브랜치는 깨끗하게 유지
-- `/deep-finish`에서 4가지 완료 옵션 제공: merge, PR, 브랜치 유지, 삭제
-- `/deep-cleanup`으로 오래된 worktree 정리 (7일 이상, 비활성 세션) — **standalone utility**
-- `/deep-resume`으로 worktree 컨텍스트 복원 및 phase 자동 dispatch — **standalone utility**; `/deep-work` init도 stale 세션을 자동 감지
-- `--no-branch` 플래그 또는 프리셋의 `git_branch: false`로 비활성화
-
-### 세션 라이프사이클
-
-완전한 세션 라이프사이클 관리:
-
-```
-/deep-work (시작) → worktree 생성 → phases 실행 → /deep-finish (종료)
-                                                        ├── merge
-                                                        ├── PR
-                                                        ├── keep
-                                                        └── discard
-```
-
-### Receipt 검증
-
-- Receipt 스키마 v1.0: `schema_version`, `model_used`, `git_before`/`git_after`, `estimated_cost`
-- `receipt-migration.js`로 v4.1 이전 receipt 자동 변환
-- `validate-receipt.sh`로 receipt 체인 무결성 검증
-- `templates/deep-work-ci.yml` — GitHub Actions CI/CD receipt 검증 워크플로우
-- `/deep-receipt export --format=ci`로 CI 친화적 번들 내보내기
-
-### 세션 히스토리
-
-`/deep-history`로 크로스 세션 트렌드 확인:
-- 과거 세션 목록: 모델 사용량, TDD 준수율, 완료율
-- 집계 통계 및 트렌드 지표
-- 모델 비용 추적 (slice 및 세션별 `estimated_cost`)
-
-## 멀티 모델 검증
-
-deep-work v4.2는 구현 전에 설계 결함을 잡기 위한 적대적 멀티 모델 리뷰를 추가합니다.
-
-### 작동 방식
-1. **구조적 리뷰** — 모든 페이즈 문서(brainstorm, research, plan)가 Claude haiku 서브에이전트로 페이즈별 차원으로 리뷰됨
-2. **적대적 리뷰** (plan만) — codex 및/또는 gemini-cli가 독립적으로 계획서를 리뷰. 갈등은 투명하게 표시되어 사용자가 해결
-3. **리뷰 게이트** — 낮은 구조적 점수 또는 비판적 합의 이슈가 있으면 자동 구현 차단
-
-### 설정
-크로스 모델 리뷰는 [codex](https://github.com/openai/codex) 및/또는 [gemini-cli](https://github.com/google/gemini-cli) 설치가 필요합니다. deep-work가 세션 초기화 시 자동 감지합니다.
-
-```bash
-# codex 설치 (선택)
-npm install -g @openai/codex
-
-# gemini-cli 설치 (선택)
-npm install -g @google/gemini-cli
-```
-
-두 도구 모두 미설치 시, deep-work는 구조적 리뷰만으로 정상 동작합니다.
-
-### 플래그
-- `--skip-review` — 모든 리뷰 건너뛰기 (spike/실험 작업에 유용)
-
-### 커맨드
-- `/deep-phase-review` — 현재 페이즈 문서에 리뷰 수동 트리거
-- `/deep-phase-review --adversarial` — 적대적 크로스 모델 리뷰만 실행
-
-## Auto-Loop 평가 & Contract 협상
-
-deep-work v5.1은 자기 교정 평가 루프와 contract 기반 slice 협상을 추가합니다.
-
-### Auto-Loop 평가
-- **Plan 리뷰 auto-loop** — Plan 작성 후 서브에이전트 평가자가 자동으로 리뷰합니다. 리뷰 점수가 임계값 미만이면 plan을 수정하고 재리뷰합니다 (최대 `plan_review_max_retries`회). 사용자 개입 불필요.
-- **Test phase auto-retry** — 테스트 실패 시 implement→test 사이클이 평가자 피드백과 함께 자동 재실행되어 수동 반복을 줄입니다.
-- 세션 상태의 `auto_loop_enabled`로 토글 (기본값: `true`).
-
-### Contract 협상
-`plan.md`의 각 slice에 `contract`와 `acceptance_threshold` 필드를 포함할 수 있습니다:
-- **`contract`** — slice의 예상 입력, 출력, 불변 조건 정의
-- **`acceptance_threshold`** — 평가자가 충족해야 하는 수치 임계값 (0.0–1.0)
-
-평가자가 test phase에서 각 slice를 contract 대비 검증합니다. 임계값 미달 slice는 수정 대상으로 플래그됩니다.
-
-### Assumption Engine Auto-Apply
-세션 시작 시 Assumption Engine이 과거 증거를 기반으로 자동 조정을 적용합니다. 이전에는 수동 `/deep-assumptions` 조정이 필요했으나, 이제 신뢰도가 충분히 높으면 사전에 제안 및 적용됩니다.
-
-### 적응형 평가자 모델
-- 기본 평가자 모델: **sonnet** (세션 상태의 `evaluator_model`로 설정 가능)
-- 엔진이 작업 복잡도와 과거 정확도 신호를 기반으로 평가자 모델을 자동 조정할 수 있습니다.
-
-### Phase 스킵 유연성
-- **`--skip-to-implement`** 플래그 — `/deep-work`에서 brainstorm, research, plan 단계를 건너뛰고 implement로 바로 진입. 작업 설명에 인라인 slice 정의 필요.
-- 건너뛴 단계는 `skipped_phases`에 기록되어 리포트와 receipt에서 추적 가능.
-
-## Auto-Flow 오케스트레이션
-
-deep-work v5.2는 전체 워크플로우를 단일 `/deep-work` 커맨드로 통합합니다. 각 Phase를 수동으로 호출하는 대신, auto-flow가 전체 파이프라인을 자동으로 오케스트레이션합니다.
-
-### 작동 방식
-1. `/deep-work "작업 설명"`으로 세션을 시작하면 auto-flow 시작
-2. Brainstorm → Research → Plan이 자동 실행
-3. **Plan 승인이 유일한 필수 인터랙션** — 계획서 검토, 피드백 제공, "승인" 입력
-4. 승인 후 Implement → Test → Report가 자동 실행
-5. `/deep-test`에서 drift-check, SOLID 리뷰, insight 분석이 내장 게이트로 자동 실행
-6. `/deep-status`가 모든 세션 정보를 통합 제공하는 대시보드로 확장
-
-### 변경 사항
-- **SKILL.md 축소**: 461줄 → 280줄 (더 명확하고 덜 중복)
-- **13개 커맨드 재분류 (v6.2.1)**: Quality Gate (3) / Internal (6) / Escape hatch (1) / Utility (2) / Special utility (1 이동). 삭제된 커맨드 없음; 수동 호출은 계속 공식 경로입니다.
-- **`/deep-status` 확장**: `--report` / `--receipts` / `--history` / `--assumptions` 플래그가 standalone 커맨드와 동일 구현으로 라우팅됩니다. 양쪽 경로 모두 동작합니다.
-- **`/deep-test` 확장**: drift-check, SOLID 리뷰, insight 분석을 자동 실행
-
-### v5.1에서 마이그레이션
-별도 작업 불필요. 기존 프리셋과 세션 상태는 완전히 호환됩니다. 이전에 "Deprecated"로 표기되었던 커맨드는 v6.2.1에서 Quality Gate / Internal / Escape hatch / Utility로 재분류되었고, 수동 호출이 여전히 공식 경로인 경우도 있습니다 (예: test 통과 후 `/deep-finish`).
-
-## Health Engine + 아키텍처 Fitness
-
-Phase 1 Research에서 자동 **Health Check**을 실행하여 코드베이스 드리프트를 감지하고 아키텍처 fitness 규칙을 검증합니다.
-
-### 드리프트 센서 (Phase 1, 자동)
-
-| 센서 | 감지 대상 | 스코프 |
-|------|----------|--------|
-| dead-export | 어디서도 import되지 않는 미사용 export | JS/TS |
-| stale-config | tsconfig, package.json, .eslintrc 깨진 경로 참조 | JS/TS |
-| dependency-vuln | `npm audit` 기반 high/critical 취약점 | JS/TS (Required gate) |
-| coverage-trend | 이전 세션 baseline 대비 커버리지 퇴화 | 범용 |
-
-### 아키텍처 Fitness Function (fitness.json)
-
-`.deep-review/fitness.json`에 계산적 아키텍처 규칙 선언:
-- **자동 생성**: fitness.json 미존재 시 Phase 1에서 프로젝트 분석 후 규칙 제안 (ecosystem-aware)
-- **규칙 타입**: `dependency` (dep-cruiser), `file-metric`, `forbidden-pattern`, `structure`
-- **Phase 4 게이트**: Fitness Delta (Advisory) + Health Required (Required)
-- **Baseline 관리**: commit/branch 기반 스코핑, 브랜치 전환/rebase 시 자동 무효화
-
-### deep-review 연동
-
-deep-review 설치 시:
-- fitness.json 규칙이 리뷰 에이전트 프롬프트에 주입되어 아키텍처 의도 기반 리뷰
-- receipt의 health_report가 scan_commit 기반 stale 체크 후 리뷰 컨텍스트로 활용
-
-## 토폴로지 템플릿
-
-Phase 1 Research에서 서비스 토폴로지를 자동 감지하고, 토폴로지별 가이드·센서 설정·fitness 기본값을 제공하는 매칭 템플릿을 로드합니다.
-
-### 토폴로지 감지
-
-`topology-detector.js`는 기존 ecosystem 감지 위에서 실행됩니다. 6개 내장 토폴로지를 우선순위 순으로 평가하여 첫 번째 일치 항목을 반환합니다:
-
-| 토폴로지 | 감지 기준 |
-|----------|----------|
-| `nextjs-app` | package.json의 `next` 의존성 |
-| `react-spa` | `react` 있고 `next`/`express` 없음 |
-| `express-api` | `express` 의존성 |
-| `python-web` | requirements의 `fastapi` / `django` / `flask` |
-| `python-lib` | 웹 프레임워크 없는 Python 프로젝트 |
-| `generic` | 그 외 모든 프로젝트 폴백 |
-
-감지 결과는 세션 상태에 저장되어 워크플로우 전반에 사용됩니다.
-
-### 템플릿 구조
-
-각 토폴로지 템플릿(`templates/topologies/<name>.json`)의 구성:
-
-```json
-{
-  "topology": "nextjs-app",
-  "guides": ["...토폴로지별 구현 가이드..."],
-  "sensors": { "dead-export": true, "stale-config": true },
-  "fitness_defaults": [
-    { "id": "no-circular-deps", "type": "dependency", "severity": "required" }
-  ],
-  "harnessability_hints": ["...리뷰 에이전트용 참고사항..."]
-}
-```
-
-- **`guides`** — Phase 1 연구 컨텍스트 및 Phase 3 구현 프롬프트에 주입
-- **`sensors`** — 토폴로지별 센서 활성화/비활성화 힌트
-- **`fitness_defaults`** — 기존 규칙과 충돌하지 않을 때 자동 생성 `fitness.json`에 병합
-- **`harnessability_hints`** — deep-review에 전달되어 토폴로지 인식 코드 리뷰 수행
-
-### 커스텀 토폴로지 Override
-
-`.deep-work/custom/<name>.json`에 동일 스키마로 파일을 배치합니다. 템플릿 로더는 **deep merge**를 수행(custom 값 우선)하므로 전체 템플릿을 재작성하지 않고도 원하는 필드만 덮어쓸 수 있습니다.
-
-```bash
-# 예시: nextjs-app 프로젝트의 fitness_defaults override
-.deep-work/custom/nextjs-app.json
-```
-
-### Phase 통합
-
-- **Phase 1/3**: 토폴로지 가이드가 연구 및 구현 컨텍스트에 주입
-- **Fitness generator**: 매칭 템플릿의 `fitness_defaults`가 자동 생성 `fitness.json` 초기값으로 사용 (토폴로지 적합 규칙만 포함)
-- **deep-review**: `harnessability_hints`가 리뷰 에이전트 프롬프트로 전달
-
-## 자기 교정 루프
-
-lint 및 typecheck 이후 새로운 `review-check` 센서가 자동 실행되어 Phase 4 이전에 두 레이어의 교정을 제공합니다.
-
-### review-check 센서
-
-`sensors/review-check.js`는 두 개의 독립 레이어로 동작합니다:
-
-| 레이어 | 트리거 | 검사 대상 |
-|--------|--------|----------|
-| **Always-on** | 모든 세션 | 토폴로지 가이드 준수 — 구현이 토폴로지별 패턴을 따르는지 확인 |
-| **Fitness** | `fitness.json` 존재 시 | 현재 구현으로 추가된 fitness 규칙 위반 |
-
-센서는 표준 파이프라인에 추가됩니다:
-
-```
-lint → typecheck → review-check
-```
-
-### 센서별 교정 제한
-
-각 센서(`review-check` 포함)는 독립적인 3회 교정 제한을 가집니다. 3회 자기 교정 후에도 센서가 실패하면 무한 루프 대신 수동 개입으로 에스컬레이션합니다.
-
-```
-1라운드: 센서 실패 → 자기 교정
-2라운드: 센서 실패 → 자기 교정
-3라운드: 센서 실패 → 자기 교정
-4라운드: 센서 실패 → 에스컬레이션 (수동 개입 필요)
-```
-
-제한은 센서별로 독립적입니다 — `review-check` 실패는 lint 또는 typecheck의 교정 횟수를 소모하지 않습니다.
-
-### review-check 비활성화
-
-`.deep-work/config.json`에 추가:
-
-```json
-{
-  "review_check": false
-}
-```
-
-always-on 레이어와 fitness 레이어가 모두 비활성화됩니다. v1에서는 레이어별 개별 비활성화를 지원하지 않습니다.
-
-### v1 범위
-
-- 계산적 검사만 수행 (패턴 매칭, fitness 규칙 평가)
-- 전체 프로젝트 fitness 검사 (증분 diff 방식 아님)
-- Receipt 스키마에 `review_check` 필드 추가 — 레이어 결과 및 사용된 교정 횟수 기록
-
-## 품질 측정
-
-모든 세션은 5가지 결과 메트릭을 기반으로 **세션 품질 점수** (0-100)를 산출합니다:
-
-| 메트릭 | 비중 | 측정 대상 |
-|--------|------|----------|
-| 테스트 통과율 | 25% | 첫 시도에 테스트가 통과하는 빈도 |
-| 재작업 사이클 | 20% | implement→test 루프 반복 횟수 |
-| Plan Fidelity | 25% | 구현이 승인된 Plan에 얼마나 부합하는지 |
-| 센서 클린율 | 15% | Lint/typecheck 센서 통과율 (not_applicable 제외) |
-| Mutation Score | 15% | Mutation testing 효과성 (not_applicable 제외) |
-
-Health Check 결과는 품질 점수에 포함되지 않음 — 코드베이스 상태 진단이지 세션 작업 품질이 아님. receipt에 별도 표시.
-
-추가 진단 메트릭 (코드 효율성, Phase 밸런스)도 참고용으로 추적됩니다.
-
-### 품질 트렌드
-`/deep-status --history`로 세션 간 품질 점수 추세를 확인하세요. 워크플로우가 시간에 따라 개선되고 있는지 파악할 수 있습니다.
-
-### 품질 뱃지
-`/deep-status --badge`로 최근 품질 추세(최근 5세션)를 반영하는 shield 뱃지를 생성합니다. 뱃지 레벨: Excellent (90+), Good (75-89), Improving (60-74), Developing (<60).
-
-## 자기 진화 규칙
-
-**Assumption Engine**은 각 강제 규칙(phase guard, TDD, research 요구 등)이 실제로 결과를 개선하는지 추적합니다. 각 세션 시작 시 **assumption snapshot**을 캡처합니다 — 모든 규칙의 강제 수준입니다. 세션 종료 시 품질 점수가 snapshot과 함께 기록됩니다.
-
-시간이 지나면서 엔진은 규칙이 활성화된 세션과 비활성화된 세션의 품질 점수를 비교합니다. 증거가 규칙이 도움이 되지 않거나 해가 된다면, 완화하거나 제거를 제안합니다. 규칙이 일관되게 높은 품질과 상관관계를 보이면, 강화를 제안합니다.
-
-이는 피드백 루프를 생성합니다: 가치를 증명한 규칙은 유지되고, 그렇지 않은 규칙은 조정됩니다. 워크플로우가 도그마가 아닌 증거를 기반으로 진화합니다.
-
-## 설치
-
-### 사전 요구사항
-
-- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) CLI 설치 및 설정 완료
-
-### Deep Suite 마켓플레이스 (권장)
-
-```bash
-# 1. 마켓플레이스 추가
-/plugin marketplace add Sungmin-Cho/claude-deep-suite
-
-# 2. 플러그인 설치
-/plugin install deep-work@Sungmin-Cho-claude-deep-suite
-```
-
-### 단독 설치
-
-```bash
-# 1. 이 레포를 마켓플레이스로 추가
-/plugin marketplace add Sungmin-Cho/claude-deep-work
-
-# 2. 설치
-/plugin install deep-work@Sungmin-Cho-claude-deep-work
-```
+훅은 세션 라이프사이클과 computational enforcement를 관리합니다.
+
+| 훅 | 트리거 | 용도 |
+|---|---|---|
+| SessionStart (`update-check.sh`) | 시작/재개 | Git 기반 버전 업데이트 확인 |
+| PreToolUse (`phase-guard.sh`) | Write/Edit/MultiEdit/Bash | Phase 기반 편집 차단 + P0 Worktree Path Guard + non-implement dangerous-command denylist |
+| PostToolUse (`file-tracker.sh`) | Write/Edit/MultiEdit/Bash | Implement 중 파일 변경 추적, receipt 업데이트 |
+| PostToolUse (`sensor-trigger.js`) | Write/Edit/MultiEdit/Bash | computational 센서 파이프라인 트리거 (lint, typecheck, review-check) |
+| PostToolUse (`phase-transition.sh`) | Write/Edit/MultiEdit | P1 Phase Transition Injector — phase 전환 시 worktree/team/cross-model context 주입 |
+| Stop (`session-end.sh`) | CLI 세션 종료 | 활성 세션 알림, worktree 정보, phase cache 정리 |
+
+Phase Guard denylist는 위험한 non-implement Bash도 차단합니다 (예: `curl | sh`, 보호 경로의 `rm -rf`, `npm publish`, 파괴적 `kubectl`/SQL, `dd`/`mkfs`). 각 family에는 `CLAUDE_ALLOW_*` override 환경변수가 있습니다.
+
+## 주요 기능
+
+- **TDD 강제** — hook 강제 상태 머신(PENDING → RED → RED_VERIFIED → GREEN_ELIGIBLE → GREEN → REFACTOR)이 failing test가 존재할 때까지 production 코드 편집을 차단. 모드: `strict`, `relaxed`, `coaching`, `spike` + slice-scoped TDD override.
+- **Worktree 격리** — 세션이 기본적으로 격리된 git worktree(`.worktrees/dw/<slug>/`)에서 실행; `/deep-finish`가 merge / PR / keep / discard 제공. `--no-branch`로 opt-out.
+- **Model routing** — phase별·slice별 모델 배정(S→haiku, M/L→sonnet, XL→opus)으로 토큰 비용 절감; slice별 또는 preset routing table로 override.
+- **M3 envelope receipt** — `session-receipt.json`과 slice receipt이 identity-triplet guard와 chained provenance를 갖춘 크로스 플러그인 envelope으로 emit되며, `validate-receipt.sh`와 CI 템플릿으로 검증.
+- **Health Engine + 아키텍처 fitness** — Phase 1이 병렬 드리프트 센서(dead-export, stale-config, dependency-vuln, coverage-trend)를 실행하고 `.deep-review/fitness.json`의 선언적 규칙을 검증; Phase 4에 Fitness Delta(advisory)와 Health Required(required) 게이트 추가.
+- **품질 측정** — 모든 세션이 Session Quality Score(테스트 통과율, 재작업 사이클, plan fidelity, 센서 클린율, mutation score)를 산출하고 세션 간 추세를 추적.
+- **자기 진화 규칙** — Assumption Engine이 각 강제 규칙을 반증 가능 가설로 취급하고 세션 품질 증거에 따라 완화 또는 강화를 제안.
+- **멀티 모델 리뷰** — phase 문서를 structural review하고, codex 및/또는 gemini-cli 설치 시 plan에 adversarial cross-model 리뷰 적용(`--skip-review`로 생략). [codex](https://github.com/openai/codex) · [gemini-cli](https://github.com/google/gemini-cli).
+- **프로필 & 플래그** — named preset(`--profile=X`, `--setup`)과 세션별 override(`--team`, `--zero-base`, `--skip-research`, `--skip-to-implement`, `--tdd=MODE`).
+- **다국어 지원** — 모든 메시지가 사용자 언어를 자동으로 따름(한국어 참조 템플릿, 실시간 번역).
 
 ## 플러그인 연동
 
-deep-work는 Claude Deep Suite의 다른 플러그인이 설치된 경우 연동됩니다:
+deep-work는 sibling 플러그인이 설치된 경우 연동되며, 모든 동작 전 사용자 확인을 거칩니다:
 
-### deep-review
-- **Sprint Contract** (Phase 2): plan 승인 후 슬라이스 기준에서 `.deep-review/contracts/` 자동 생성
-- **슬라이스 리뷰** (Phase 3): 각 슬라이스가 GREEN 도달 시 `/deep-review --contract SLICE-NNN` 실행 제안
-- **전체 리뷰** (Phase 4): quality gate 전 종합 리뷰를 위한 `/deep-review` 실행 제안
+- **deep-review** — 승인된 slice에서 `.deep-review/contracts/` 생성, slice·전체 리뷰 제안, 아키텍처 인식 리뷰를 위해 `fitness.json` + `health_report` 공유.
+- **deep-wiki** — 세션 후 research와 설계 결정 아카이브를 위해 `/wiki-ingest report.md` 제안.
+- **deep-memory** — Phase 1에서 크로스 프로젝트 brief recall, Phase 5에서 `/deep-memory-harvest` 추천(opt-in, read-only).
 
-### deep-wiki
-- **지식 캡처** (Phase 4): 세션 완료 후 리서치 및 설계 결정 사항 아카이브를 위해 `/wiki-ingest report.md` 실행 제안
+## 링크
 
-모든 연동은 선택적입니다 — 해당 플러그인이 감지된 경우에만 활성화되며, 항상 실행 전 사용자 확인이 필요합니다.
+- [CHANGELOG](CHANGELOG.ko.md) — 릴리스 히스토리
+- [claude-deep-suite](https://github.com/Sungmin-Cho/claude-deep-suite) — 마켓플레이스와 sibling 플러그인
+- [CONTRIBUTING](CONTRIBUTING.md) · [SECURITY](SECURITY.md)
 
 ## 라이선스
 

--- a/README.md
+++ b/README.md
@@ -1,907 +1,163 @@
 **English** | [한국어](./README.ko.md)
 
-# Deep Work Plugin
+# deep-work
 
-<!-- Badges (populated after sessions) -->
-<!-- ![Deep Work Quality](https://img.shields.io/badge/deep--work-quality-lightgrey) -->
-<!-- ![Sessions](https://img.shields.io/badge/sessions-0-blue) -->
+[![version](https://img.shields.io/github/package-json/v/Sungmin-Cho/claude-deep-work?label=version)](https://github.com/Sungmin-Cho/claude-deep-work)
+[![license](https://img.shields.io/github/license/Sungmin-Cho/claude-deep-work)](./LICENSE)
+[![part of deep-suite](https://img.shields.io/badge/part%20of-deep--suite-5b8def)](https://github.com/Sungmin-Cho/claude-deep-suite)
 
-A Claude Code plugin that implements an **Evidence-Driven Development Protocol** — a single-command auto-flow orchestration (Brainstorm → Research → Plan → Implement → Test → Integrate) with TDD enforcement, receipt-based evidence collection, and strict separation of planning and coding.
+An **Evidence-Driven Development Protocol** for [Claude Code](https://docs.anthropic.com/en/docs/claude-code) and Codex. A single command drives a full Brainstorm → Research → Plan → Implement → Test → Integrate workflow with TDD enforcement, receipt-based evidence collection, and a hard separation between planning and coding.
 
-### Role in Harness Engineering
+deep-work fights the common failure modes of AI coding on complex tasks: introducing new patterns that ignore the existing architecture, reimplementing utilities that already exist, jumping into code before understanding the codebase, adding unrequested "improvements" that cause bugs, and marking work done without verification.
 
-deep-work is the **core harness engine** in the [Deep Suite](https://github.com/Sungmin-Cho/claude-deep-suite) ecosystem, implementing the [Harness Engineering](https://martinfowler.com/articles/harness-engineering.html) framework (Böckeler/Fowler, 2026).
+## Role in deep-suite
 
-In the 2×2 matrix (Guide/Sensor × Computational/Inferential), deep-work covers:
+deep-work is the **core harness engine** of the [claude-deep-suite](https://github.com/Sungmin-Cho/claude-deep-suite), implementing the [Harness Engineering](https://martinfowler.com/articles/harness-engineering.html) framework (Böckeler/Fowler, 2026). Across the Guide/Sensor × Computational/Inferential matrix it provides:
 
-- **Computational Guides**: Phase Guard hook (physically blocks edits), **Worktree Guard** (P0, hard-blocks writes outside worktree), TDD state machine (RED→GREEN), topology templates (phase-specific guides)
-- **Computational Sensors**: Linter/typecheck pipeline, coverage, mutation testing, 4 drift sensors, fitness rules, review-check sensor, **Phase Transition Injector** (P1, condition context injection)
-- **Inferential Guides**: Research/plan/brainstorm documents, Sprint Contract
-- **Self-Correction Loop**: SENSOR_RUN → SENSOR_FIX → SENSOR_CLEAN with per-sensor 3-round independent limit
+- **Computational Guides** — Phase Guard hook (physically blocks edits), Worktree Guard (P0, hard-blocks writes outside the worktree), the TDD RED→GREEN state machine, and topology templates.
+- **Computational Sensors** — linter/typecheck/coverage/mutation pipeline, drift sensors, fitness rules, the review-check sensor, and the Phase Transition Injector (P1).
+- **Inferential Guides** — research / plan / brainstorm documents and the Sprint Contract.
+- **Self-Correction Loop** — SENSOR_RUN → SENSOR_FIX → SENSOR_CLEAN with a per-sensor 3-round limit.
 
-deep-work also produces receipts and health reports consumed by [deep-review](https://github.com/Sungmin-Cho/claude-deep-review) and [deep-dashboard](https://github.com/Sungmin-Cho/claude-deep-dashboard).
+It emits receipts and health reports that [deep-review](https://github.com/Sungmin-Cho/claude-deep-review) and [deep-dashboard](https://github.com/Sungmin-Cho/claude-deep-dashboard) consume.
 
-## Codex Compatibility
+## Install
 
-deep-work supports both Claude Code and Codex plugin runtimes while preserving the existing claude-deep-suite marketplace namespace. Claude Code and Codex read their native manifests, and skill callers use the same skill-native invocation model described in the release notes below.
-
-## What's New in v6.9.0
-
-### Deep-Memory v0.1.0 Consumer Integration — Phase 1 Recall + Phase 5 Harvest
-
-This release wires deep-work into the new `deep-memory` plugin (claude-deep-suite v0.1.0) as a **read-only consumer with two opt-in affordances**:
-
-- **Phase 1 Research recall** — `skills/deep-research/SKILL.md` now probes for `.deep-memory/latest-brief.md` and, when present, quotes the brief verbatim under a new `## Cross-project Memory` section in `research.md` (heading hierarchy shifted by +2 to preserve deep-memory's rendering). When the brief is **absent**, the research artifact stays deep-memory-agnostic — only a runtime-only suggestion is emitted, never written to `research.md`. `/deep-memory-brief` is never auto-invoked; recall stays user-driven. Provenance tokens (`mem-<ULID>`, Crockford-base32 uppercase) are captured into the new `cross_project_memory.cited_memory_ids[]` state field for downstream feedback-hook consumption (Phase 4+).
-- **Phase 5 Integrate harvest** — `skills/deep-integrate/SKILL.md` proposes `/deep-memory-harvest` in the top-3 LLM recommendations and the deterministic B-fallback list when `deep-memory ∈ plugins.installed` and the session changed > 0 files. `detect-plugins.sh` extended so `plugins.installed` / `plugins.missing` correctly enumerates deep-memory.
-
-The integration is **fully forward-compatible**: projects that never install deep-memory see no behavior change, and the deferred `/deep-memory feedback` hook (spec §14.2 item 5) is tracked in `docs/deep-memory-integration-handoff.md` for a Phase 4+ joint PR. 13 new contract tests pin every documented invariant (privacy boundary, ULID regex, stale-warning wording, heading-shift rule, edge cases).
-
-## What's New in v6.8.0
-
-### Plan-Quality Contract Enforcement + CI Hardening + Receipt-Tracker Robustness
-
-This release lifts plan-quality enforcement, CI hygiene, and receipt-tracker robustness through three coordinated changes:
-
-- **Plan-quality contract**: every non-inline S/M/L slice now must declare `failing_test`, `verification_cmd`, `expected_output`, `code_sketch`, and `steps`. The plan review gate (`skills/shared/references/review-gate.md`) is aligned with this contract — no more "recommended" hedge or v5.8 backward-compat fallback for missing fields. `tests/plan-quality-contract.test.js` pins both the templates and the review-gate wording so they cannot drift.
-- **CI hardening**: a non-blocking `shellcheck` advisory step now lints `hooks/scripts/**/*.sh` (pinned by `tests/ci-workflow-contract.test.js`). `npm test` now discovers all 48+ test files via a recursive `node --test "**/*.test.js"` glob, with CI Node bumped from 20 to 22 (LTS) to support the glob form.
-- **Receipt-tracker robustness**: the pre-lock receipt init in `hooks/scripts/file-tracker.sh` is restored and made `O_CREAT | O_EXCL` (`fs.writeFileSync` `flag: 'wx'`) so single-write slices retain a canonical `SLICE-NNN.json` even when the in-lock update path times out on a stale lock. `hooks/scripts/file-tracker-lock-timeout.test.js` verifies the end-to-end drain contract.
-
-## What's New in v6.7.1
-
-### Codex-Native Manifest And Skill Entry Alias
-
-This release adds `.codex-plugin/plugin.json` and `AGENTS.md` so Codex can read the same plugin surfaces as Claude Code, and it restores `$deep-work:deep-work "task"` as the skill-native entry alias for starting the auto-flow without knowing the internal orchestrator name.
-
-## What's New in v6.7.0
-
-### 24 Commands Promoted To User-Invocable Skills
-
-All 24 command-equivalent surfaces now live as `user-invocable: true` skills under `skills/`. The old `commands/` wrappers were removed, and internal references now point at skill files such as `skills/deep-status/SKILL.md` and `skills/deep-receipt/SKILL.md`.
-
-## What's New in v6.5.0
-
-### M3 Cross-Plugin Envelope Adoption (claude-deep-suite Phase 2 #3)
-
-`session-receipt.json` and `receipts/SLICE-*.json` are now emitted as M3 envelope-wrapped artifacts (cf. `claude-deep-suite/docs/envelope-migration.md` §1):
-
-```
-{
-  "schema_version": "1.0",
-  "envelope": {
-    "producer": "deep-work",
-    "producer_version": "6.5.0",
-    "artifact_kind": "session-receipt|slice-receipt",
-    "run_id": "<ULID>",
-    "session_id": "<dw-session-id>",
-    "parent_run_id": "<consumed evolve-insights run_id, optional>",
-    "generated_at": "<RFC 3339>",
-    "schema": { "name": "<same as artifact_kind>", "version": "1.0" },
-    "git": { ... },
-    "provenance": { "source_artifacts": [...], "tool_versions": {...} }
-  },
-  "payload": { /* legacy receipt body */ }
-}
-```
-
-The session-receipt's `envelope.parent_run_id` chains to the consumed `evolve-insights.json` envelope (handoff §3.3 cross-plugin trace), and `provenance.source_artifacts[]` aggregates all slice receipt run_ids (intra-plugin chain). Internal readers (`hooks/scripts/*`) and cross-plugin consumers (`gather-signals.sh`, `deep-research/SKILL.md`) detect the envelope, enforce identity guard, and unwrap to `.payload` before reading legacy fields. Legacy non-envelope receipts are forward-compatible.
-
-## What's New in v6.4.2
-
-### Flexible Session Init
-
-`/deep-work` now asks per-item with LLM-suggested defaults instead of a single "use profile or change?" prompt:
-
-- **Profile schema v3** with `interactive_each_session` — per-user customization of which items to ask each session
-- **session-recommender sub-agent** (sonnet by default) infers ideal `team_mode` / `start_phase` / `tdd_mode` / `git` / `model_routing` from the task description and workspace context
-- New flags: `--no-ask` (skip ask + recommender, fastest path), `--recommender=MODEL` (override sub-agent model with allowlist `^(haiku|sonnet|opus)$`), `--no-recommender` (skip recommender only)
-
-### Profile v2 → v3 Auto-migration
-
-First call upgrades v6.4.x profiles automatically: atomic write + flock + idempotent + `.v2-backup` + rollback procedure. v6.4.1 `git_branch:` profiles are translated, not rejected.
-
-### Notification System Removed
-
-Slack/Discord/Telegram/webhook integrations removed. If you depended on `notify.sh` webhooks, you must fork v6.4.1 or migrate to a different mechanism.
-
-### Migration
-
-Existing users: no manual action — first `/deep-work` call auto-migrates the profile. Rollback (project-local): `mv .claude/deep-work-profile.yaml.v2-backup .claude/deep-work-profile.yaml`.
-
-See `CHANGELOG.md` for the full list including breaking-change notes.
-
-## The Problem
-
-Common pitfalls when AI coding tools tackle complex tasks:
-- Introducing new patterns while ignoring the existing architecture
-- Reimplementing utilities that already exist
-- Jumping into implementation before understanding the codebase
-- Adding unrequested "improvements" that cause bugs
-- Marking work as done without verification
-
-## The Solution
-
-The **Brainstorm → Research → Plan → Implement → Test → Integrate** workflow enforces evidence-driven development:
-
-- **Phase 0 (Brainstorm)**: Optional design exploration — "why before how" (skip with `--skip-brainstorm`)
-- **Phase 1 (Research)**: Deep analysis and documentation of the codebase
-- **Phase 2 (Plan)**: Slice-based implementation plan with per-slice TDD fields, requiring user approval
-- **Phase 3 (Implement)**: TDD-enforced slice execution — failing test → production code → receipt collection
-- **Phase 4 (Test)**: Receipt completeness, spec compliance review, code quality review, verification evidence
-- **Phase 5 (Integrate, skippable)**: Recommendation loop — reads deep-suite plugin artifacts and proposes up to 3 next steps per round (skip with `--skip-integrate`)
-
-**v6.3.1: Phase Exit Gates** — Each of the 5 main phases (Brainstorm, Research, Plan, Implement, Test) now ends with an explicit user decision: proceed to next phase, revise current phase, or pause. Selecting "pause" keeps `current_phase` unchanged so `/deep-resume` re-presents the Exit Gate instead of auto-entering the next phase. Phase 5 Integrate remains interactive as before.
-
-Code file modifications are **physically blocked** during Phases 0, 1, 2, and 4 (via PreToolUse hook). **Bash file-writing commands** (`echo >`, `sed -i`, `cp`) are also intercepted. File changes and receipt data are **automatically collected** during Phase 3 (via PostToolUse hook).
-
-## Usage (Skill-Native Auto-Flow)
+Via the `claude-deep-suite` marketplace (recommended):
 
 ```bash
-# Just one skill invocation — the entire workflow runs automatically
+/plugin marketplace add Sungmin-Cho/claude-deep-suite
+/plugin install deep-work@Sungmin-Cho-claude-deep-suite
+```
+
+Standalone, from this repository:
+
+```bash
+/plugin marketplace add Sungmin-Cho/claude-deep-work
+/plugin install deep-work@Sungmin-Cho-claude-deep-work
+```
+
+deep-work runs in both the Claude Code and Codex plugin runtimes — each reads its native manifest, and skill callers use the same skill-native invocation model.
+
+> **Windows**: hook scripts require `bash` in PATH (Git for Windows or WSL).
+
+## Usage
+
+The entire workflow runs from one skill invocation; plan approval is the only required interaction.
+
+```bash
+# Run the full auto-flow: Brainstorm → Research → Plan → [approve] → Implement → Test → Integrate → Report
 $deep-work:deep-work "Implement JWT-based user authentication"
 
-# The auto-flow orchestrates: Brainstorm → Research → Plan → [user approves] → Implement → Test → Integrate → Report
-# Plan approval is the ONLY required interaction
-
-# Unified status — flags route to the same implementations as the standalone report/receipt/history/assumptions skills
+# Unified status — flags route to the same implementations as the standalone skills
 $deep-work:deep-status              # current progress
 $deep-work:deep-status --report     # session report
 $deep-work:deep-status --receipts   # receipt dashboard
 $deep-work:deep-status --history    # cross-session trends
 $deep-work:deep-status --assumptions # assumption health
 $deep-work:deep-status --all        # everything at once
-
-# Compare two sessions
-$deep-work:deep-status --compare
+$deep-work:deep-status --compare    # compare two sessions
 ```
 
-## Skill Invocations
+In Claude Code the same surfaces are also available as slash commands (e.g. typing the command name); in Codex and other hosts use the `$deep-work:<verb>` skill form.
 
-### Primary Skills (7)
+## What's New in v6.9.0
+
+deep-work v6.9.0 wires Phase 1 recall and Phase 5 harvest recommendation into the new `deep-memory` plugin as a read-only, opt-in consumer. See the [CHANGELOG](CHANGELOG.md) for full release history.
+
+## Skills
+
+deep-work exposes 24 command-equivalent skills. The most-used are:
 
 | Skill | Description |
-|-------|-------------|
-| `$deep-work:deep-work <task>` | **Auto-flow orchestration** — runs the entire Brainstorm → Research → Plan → Implement → Test → Integrate pipeline automatically. Plan approval is the only required interaction. |
-| `$deep-work:deep-research` | Manual override for Phase 1 (Research) — deep codebase analysis |
-| `$deep-work:deep-plan` | Manual override for Phase 2 (Plan) — slice-based implementation planning |
-| `$deep-work:deep-implement` | Manual override for Phase 3 (Implement) — TDD-enforced slice execution |
-| `$deep-work:deep-test` | Phase 4: Receipt check → spec compliance → code quality → quality gates. Now auto-runs drift-check, SOLID review, and insight analysis. |
-| `$deep-work:deep-status` | **Unified view** — current progress, report, receipts, history, assumptions. Flags: `--report`, `--receipts`, `--history`, `--assumptions`, `--all`, `--compare` |
-| `$deep-work:deep-debug` | Systematic debugging: investigate → analyze → hypothesize → fix (auto-triggers on failures) |
+|---|---|
+| `$deep-work:deep-work <task>` | Auto-flow orchestration — runs the entire pipeline; plan approval is the only required interaction |
+| `$deep-work:deep-research` | Phase 1 (Research) — deep codebase analysis |
+| `$deep-work:deep-plan` | Phase 2 (Plan) — slice-based implementation planning |
+| `$deep-work:deep-implement` | Phase 3 (Implement) — TDD-enforced slice execution |
+| `$deep-work:deep-test` | Phase 4 (Test) — receipt + spec + quality gates; auto-runs drift-check, SOLID review, insight |
+| `$deep-work:deep-integrate` | Phase 5 (Integrate) — cross-plugin next-step recommendation loop |
+| `$deep-work:deep-status` | Unified view (`--report` / `--receipts` / `--history` / `--assumptions` / `--all` / `--compare`) |
+| `$deep-work:deep-finish` | Close a session — merge, PR, keep, or discard the worktree |
+| `$deep-work:deep-debug` | Systematic debugging: investigate → analyze → hypothesize → fix |
 
-### Special Utility (4)
+Other skills cover quality gates (`drift-check`, `solid-review`, `deep-insight`), session utilities (`deep-fork`, `deep-resume`, `deep-cleanup`, `deep-slice`), and toolchain helpers (`deep-mutation-test`, `deep-sensor-scan`, `deep-phase-review`), plus the read-only status sub-skills (`deep-report`, `deep-receipt`, `deep-history`, `deep-assumptions`). All can be invoked manually; many also run automatically inside the auto-flow.
 
-Phase or toolchain helpers, run manually when needed.
+## The workflow
 
-| Skill | Purpose |
-|-------|---------|
-| `$deep-work:deep-fork` | Fork a session to explore a different approach |
-| `$deep-work:deep-mutation-test` | Mutation testing on changed files |
-| `$deep-work:deep-phase-review` | Manual Phase document review (brainstorm/research/plan) |
-| `$deep-work:deep-sensor-scan` | Run linters, type checkers, coverage tools independently |
+| Phase | Role |
+|---|---|
+| **0 — Brainstorm** | Optional design exploration, "why before how" (skip with `--skip-brainstorm`) |
+| **1 — Research** | Deep codebase analysis across architecture, patterns, data, API, infra, and risks; output `research.md` |
+| **2 — Plan** | Slice-based plan with per-slice TDD fields, requiring user approval; output `plan.md` |
+| **3 — Implement** | TDD-enforced slice execution: failing test → production code → receipt |
+| **4 — Test** | Receipt completeness, spec compliance, code quality, and verification evidence, with up to 3 implement→test retries |
+| **5 — Integrate** | Skippable loop that reads deep-suite plugin artifacts and proposes up to 3 next steps (skip with `--skip-integrate`) |
 
-### Quality Gate (3) — auto-runs in `$deep-work:deep-test`, standalone available
-
-| Skill | Role in `$deep-work:deep-test` | Standalone |
-|-------|-------------------------------|------------|
-| `$deep-work:drift-check` | Required Gate — plan alignment | `$deep-work:drift-check [plan-file]` |
-| `$deep-work:solid-review` | Advisory Gate — SOLID principles | `$deep-work:solid-review [target]` |
-| `$deep-work:deep-insight` | Insight Tier — metrics/complexity | `$deep-work:deep-insight [target]` |
-
-### Internal (7) — auto-runs, manual supported
-
-These skills are called by the orchestrator or `$deep-work:deep-status`. Manual invocation remains a first-class path, especially `$deep-work:deep-finish` after tests pass and `$deep-work:deep-integrate` after Phase 4.
-
-| Skill | Called by |
-|-------|-----------|
-| `$deep-work:deep-brainstorm` | orchestrator Phase 0 (`Skill` dispatch) |
-| `$deep-work:deep-integrate` | orchestrator Phase 5 (`Skill` dispatch); manual after test pass |
-| `$deep-work:deep-finish` | orchestrator Step 3-6 (`Read`); manual after test pass |
-| `$deep-work:deep-report` | `$deep-work:deep-status --report` (`Read`) |
-| `$deep-work:deep-receipt` | `$deep-work:deep-status --receipts` (`Read`) |
-| `$deep-work:deep-history` | `$deep-work:deep-status --history` (`Read`) |
-| `$deep-work:deep-assumptions` | `$deep-work:deep-status --assumptions` (`Read`) |
-
-### Escape Hatch (1)
-
-| Skill | Surfaced by |
-|-------|-------------|
-| `$deep-work:deep-slice` | `phase-guard` TDD block message (`spike`, `reset`) |
-
-### Utility (2) — standalone, feature migration pending
-
-These skills are the sole path for certain behaviors. They will be removed once their functionality is migrated (see `$deep-work:deep-work --resume=<session-id>` and `$deep-work:deep-status --cleanup` roadmap).
-
-| Skill | Unique capability |
-|-------|-------------------|
-| `$deep-work:deep-cleanup` | `git worktree list` scan, stale/active classification, fork/registry cleanup |
-| `$deep-work:deep-resume` | Active session selection, worktree context restore, phase-specific resume dispatch |
+Each of the five main phases ends with an explicit Exit Gate (proceed / revise / pause). Code-file edits are physically blocked during Brainstorm, Research, Plan, and Test (including file-writing Bash commands like `echo >`, `sed -i`, `cp`); file changes and receipt data are collected automatically during Implement.
 
 ## Output Files
 
-All session artifacts are stored in `.deep-work/<task-folder>/`:
+All session artifacts live in `.deep-work/<task-folder>/`:
 
 | File | Created | Description |
-|------|---------|-------------|
-| `research.md` | Phase 1 complete | Codebase analysis results (Executive Summary first) |
-| `plan.md` | Phase 2 complete | Detailed implementation plan (Plan Summary first, per-slice contract + acceptance_threshold fields) |
-| `plan.v{N}.md` | Plan rewrite | Previous plan version backup |
-| `test-results.md` | Phase 4 complete | Verification results (cumulative per attempt) |
-| `report.md` | Session complete | Full session report (includes phase durations) |
-| `quality-gates.md` | Phase 4 complete | Quality Gate results detail (required/advisory) |
-| `drift-report.md` | Phase 4 complete | Plan alignment verification results |
-| `solid-review.md` | Phase 4 complete | SOLID design review scorecard and suggestions |
-| `insight-report.md` | Phase 4 complete | Code metrics, complexity, dependency analysis |
-| `file-changes.log` | Phase 3 ongoing | Auto-tracked file modifications with slice mapping (PostToolUse hook) |
-| `plan-diff.md` | Plan rewrite | Structural change comparison between plan versions |
-| `brainstorm.md` | Phase 0 complete | Design spec: problem definition, approach comparison, success criteria |
-| `receipts/SLICE-NNN.json` | Phase 3 ongoing | Per-slice evidence: TDD output, git diff, spec check, review, model used |
-| `session-receipt.json` | Session finish | Cross-slice session summary — derived cache from slice receipts |
-| `debug-log/RC-NNN.md` | Phase 3 (debug) | Root cause analysis notes from systematic debugging |
-| `harness-history/harness-sessions.jsonl` | Session end | Per-session assumption engine data — per-slice evidence, model, confidence signals |
-
-## Session State
-
-Stored as YAML frontmatter in `.claude/deep-work.local.md`:
-
-| Field | Description |
-|-------|-------------|
-| `current_phase` | Current phase (idle / brainstorm / research / plan / implement / test) |
-| `work_dir` | Task folder path |
-| `task_description` | Task description |
-| `team_mode` | Work mode (solo / team) |
-| `project_type` | Project type (existing / zero-base) |
-| `git_branch` | Created Git branch name |
-| `test_retry_count` | Test retry count |
-| `test_passed` | Final test pass status |
-| `*_started_at`, `*_completed_at` | Per-phase start/completion timestamps |
-| `model_routing` | Per-phase model configuration (research/plan/implement/test) |
-| `last_research_commit` | Git commit hash at the time of last research |
-| `quality_gates_passed` | Whether all Quality Gates passed |
-| `preset` | Active preset name |
-| `plan_approved_at` | Timestamp when plan was approved (used by Drift Detection) |
-| `tdd_mode` | TDD enforcement mode (strict / relaxed / coaching / spike) |
-| `active_slice` | Currently active slice ID (e.g., SLICE-001) |
-| `tdd_state` | Current TDD state (PENDING / RED / RED_VERIFIED / GREEN_ELIGIBLE / GREEN / REFACTOR / SPIKE) |
-| `tdd_override` | Slice-level TDD override — set to active slice ID when user bypasses TDD via AskUserQuestion |
-| `debug_mode` | Whether systematic debugging is active |
-| `brainstorm_started_at`, `brainstorm_completed_at` | Phase 0 timestamps |
-| `worktree_enabled` | Whether worktree isolation is active |
-| `worktree_path` | Absolute path to the worktree directory |
-| `worktree_branch` | Branch name inside the worktree |
-| `worktree_base_branch` | Original branch before worktree creation |
-| `worktree_base_commit` | Commit hash at the time of worktree creation |
-| `evaluator_model` | Default evaluator model for subagents — `"sonnet"` |
-| `plan_review_retries` | Auto-loop retry count for plan review — `0` |
-| `plan_review_max_retries` | Max retries for plan auto-loop — `3` |
-| `auto_loop_enabled` | Whether auto-loop evaluation is active — `true` |
-| `skipped_phases` | Phases skipped via `--skip-to-implement` — `[]` |
-| `assumption_adjustments` | Active adjustments from Assumption Engine — `[]` |
-| `fitness_baseline` | Phase 1 fitness violation snapshot for Phase 4 delta comparison |
-| `unresolved_required_issues` | Phase 1 required failures propagated to Phase 4 |
-| `health_report` | Latest Health Check results — drift + fitness |
-
-## Workflow Details
-
-### Phase 1: Research
-
-**Cross-Plugin Context (v6.2):** References external plugin data at the start of Research:
-- `.deep-dashboard/harnessability-report.json` — includes low-scoring dimensions (< 5.0) in context (skipped if > 7 days stale)
-- `.deep-evolve/evolve-insights.json` — includes meta-archive based insights as advisory context
-
-Systematically analyzes the codebase across 6 areas:
-
-1. **Architecture & Structure** — Project structure, architecture patterns, module boundaries
-2. **Code Patterns & Conventions** — Naming conventions, error handling, testing patterns
-3. **Data Layer** — ORM/DB schema, migrations, caching strategies
-4. **API & Integration** — API structure, authentication/authorization, external service integration
-5. **Shared Infrastructure** — Common utilities, configuration management, build system
-6. **Dependencies & Risks** — Dependency conflicts, compatibility, security risks
-
-**v3.0 features:**
-- **Executive Summary first** — Pyramid principle: conclusion → evidence → details
-- **Greenfield mode** — Tech stack selection, scaffolding design for new projects
-- **Partial re-run** — Re-analyze specific areas with `/deep-research --scope=api,data`
-- **Research caching** — Use previous session's research as baseline, re-analyze only changed areas
-- **Team mode progress** — Agent completion status: `[2/3] pattern-analyst done ✅`
-
-**v3.1 features:**
-- **Incremental research** — Re-analyze only changed areas based on git diff with `/deep-research --incremental` (60-80% time savings)
-- **Model routing** — Delegate Research Phase to a sonnet model Agent for token savings
-
-**v5.5 features:**
-- **Cross-Model Review** — codex/gemini independently review research findings with dedicated rubric
-- **Consolidated Judgment** — Claude synthesizes all review results; user confirms in bulk before proceeding
-
-**v5.9 features:**
-- **Health Check** — Automatic drift detection (dead-export, stale-config, dependency-vuln, coverage-trend) + fitness.json validation at Phase 1 start
-- **fitness.json auto-generation** — Ecosystem-aware architecture rule proposal with user approval
-- **dep-cruiser install suggestion** — Explains the tool and offers installation for dependency rules
-
-### Phase 2: Plan
-
-Creates a concrete implementation plan based on research results:
-
-- Plan Summary (approach, scope of changes, risks, key decisions) presented first
-- List of files to change with specific modifications for each
-- Code sketches, execution order, trade-off analysis, rollback strategy
-- Task checklist
-
-**v3.0 features:**
-- **Interactive plan review** — Chat "change item 3" → plan.md auto-updates
-- **Plan templates** — 6 types including API endpoint, UI component, DB migration
-- **Plan version history** — Backed up as `plan.v{N}.md` on rewrite, Change Log added
-- **Mode switch suggestions** — Team/Solo switch recommended based on plan analysis
-- **Typing "approve" automatically starts implementation.**
-
-**v3.1 features:**
-- **Plan Diff visualization** — Automatically compares task/file/architecture/risk changes in `plan-diff.md` when a plan is rewritten
-
-**v5.5 features:**
-- **Claude Self-Review** — Automatic quality check before structural review — placeholders, consistency, research alignment
-- **Consolidated Judgment** — Cross-review results synthesized with Claude's assessment; user confirms before plan modification
-
-**v5.5.1 features:**
-- **Team research cross-verification** — When `team_mode: team`, plan phase loads partial research files (`research-architecture.md`, `research-patterns.md`, `research-dependencies.md`) as supplementary references for cross-checking against synthesized `research.md`
-
-**v5.5.2 features:**
-- **Extended bash file-write detection** — 20+ new patterns: perl in-place, node -e `fs.writeFileSync`, python -c, ruby -e, awk, swift, git destructive ops, curl/wget output, ln, tar/unzip/cpio, rsync
-- **File-write-first detection order** — FILE_WRITE patterns now checked before SAFE_COMMAND patterns, preventing safe patterns from masking file writes
-- **Extended test file patterns** — Dart, Elixir, Lua, Vue, `fixtures/`, `__mocks__/`, `spec/` directories
-- **Extended TDD exempt patterns** — `.toml`, `.ini`, `.cfg`, `.lock`, `.editorconfig`, image files (`.svg`, `.png`, `.jpg`, `.gif`)
-- **TDD state validation** — Unknown TDD states blocked with actionable error message
-- **Backtick/subshell handling** — `splitCommands` correctly handles backtick quoting and `$()` depth tracking
-- **Error logging** — Hook errors logged to `.claude/deep-work-guard-errors.log` instead of suppressed
-
-### Phase 3: Implement (Evidence-Driven)
-
-Slice-based TDD-enforced execution:
-
-- Per-slice TDD cycle: RED (failing test) → GREEN (minimal code) → REFACTOR
-- **TDD State Machine** hook enforcement — production code edits blocked until failing test output exists
-- Each slice produces a **receipt JSON** (test output, git diff, spec checklist)
-- Unexpected test failures trigger **debug mode** (`/deep-debug`)
-- **Spike mode**: Exploratory coding, auto git stash + TDD restart on exit
-- **Coaching mode**: Educational TDD guidance instead of hard blocks
-- **TDD Override**: When TDD blocks a production edit, Claude asks the user whether to write a test first or skip TDD for this slice (merge-eligible with warning in receipt)
-- Block messages include escape hatch guidance (`/deep-slice spike`, `/deep-slice reset`)
-- **Mandatory TDD state updates** — B-1 (RED_VERIFIED) and B-2 (GREEN) state file updates are explicitly marked as mandatory with phase guard blocking warnings
-- **Automatically enters Test phase after implementation completes**
-
-**v3.0 features:**
-- **Checkpoints (resume support)** — Skips completed tasks when restarted after interruption
-- **Team mode progress** — Real-time per-agent completion status
-
-### Phase 4: Test
-
-Automatically verifies implementation results:
-
-- Auto-detects test/lint/type-check commands from project configuration files
-- Runs sequentially and records results (`test-results.md`)
-- **All pass**: Session complete → report auto-generated
-- **On failure**: Returns to implement phase → fix → re-test (up to 3 times)
-- Breaks out of the loop after max retries, requesting manual intervention
-
-```
-implement → test → (pass) → idle + report
-                 → (fail) → implement → test → ...
-```
-
-**v3.1 features:**
-- **Quality Gate system** — Define gates in plan.md (required ✅ / advisory ⚠️), outputs `quality-gates.md`
-- **Model routing** — Delegate Test Phase to a haiku model Agent for minimum cost
-
-**v3.2 features:**
-- **3-Tier Quality Gate system** — Required (blocking) / Advisory (warning) / Insight (informational)
-- **Plan Alignment (Drift Detection)** — Built-in Required gate that automatically verifies implementation matches the approved plan. Detects unimplemented items, out-of-scope changes, and design decision drift. Outputs `drift-report.md`.
-- **SOLID Design Review** — Advisory gate for evaluating code against SRP, OCP, LSP, ISP, DIP. Per-file scorecard, top-5 refactoring suggestions. Outputs `solid-review.md`.
-
-**v3.3 features:**
-- **Insight Tier Quality Gate** — `/deep-insight` command and built-in Insight gate. Measures file metrics, complexity indicators, dependency graph, and change summary. Outputs `insight-report.md`. Never blocks workflow.
-- **PostToolUse File Tracking** — Automatically logs file modifications during Implement phase to `file-changes.log`. Feeds into `/deep-report` and `/deep-insight`.
-- **Stop Hook** — Outputs a reminder message when CLI session ends with an active deep-work session.
-
-**v5.9 features:**
-- **Fitness Delta Gate** (Advisory) — Compares Phase 1 fitness baseline vs current violations. New violations get flagged but don't block.
-- **Health Required Gate** (Required) — Propagates Phase 1 required failures (critical vulnerabilities, required_missing tools) to Phase 4. User must acknowledge to proceed.
-- **Phase 4 Baseline Refresh** — Automatically updates health-baseline.json after quality gates pass, creating the comparison baseline for the next session.
-
-**v3.3.3 features:**
-- **Multi-Preset Profile System** — Create named presets (`dev`, `quick`, `review`) for different work styles. Interactive selection when multiple presets exist. Auto-migration from v1 single profile to v2 multi-preset format.
-
-### Phase 5: Integrate (v6.3.0, skippable)
-
-After Test passes, Deep Work can optionally run a **recommendation loop** that reads artifacts from installed deep-suite plugins (`deep-review`, `deep-docs`, `deep-wiki`, `deep-dashboard`, `deep-evolve`) and asks an AI to rank up to 3 next steps with rationale. The user picks one, runs it, returns, and the loop continues (max 5 rounds) until they choose `finish` — at which point `/deep-finish` takes over.
-
-Skip with `--skip-integrate`, or invoke manually with `/deep-integrate` at any time after Phase 4.
-
-### Session Report
-
-Automatically generated report after session completion:
-
-- **Session Overview** — Task name, mode, project type, Git branch
-- **Phase Duration** — Time spent per phase
-- **Research/Plan Summary** — Key analysis results, approach
-- **Implementation Results** — Per-task execution results
-- **Verification Results** — Test/lint/type-check results
-- **Test Retry History** — Results history per attempt
-
-### Model Routing
-
-Assigns the optimal model per phase, reducing token costs by 30-40%.
-
-**v4.1: Auto-routing by slice complexity** — In implement phase, the model is automatically selected based on each slice's size:
-
-| Slice Size | Default Model | Rationale |
-|-----------|--------------|-----------|
-| S (Small) | haiku | Simple config, 1-2 files, boilerplate |
-| M (Medium) | sonnet | Standard feature, 3-5 files |
-| L (Large) | sonnet | Complex feature, 5+ files |
-| XL (Extra-Large) | opus | Architecture change, 10+ files |
-
-Override per-slice: `/deep-slice model SLICE-NNN opus`. Customize the routing table in your preset's `routing_table` field.
-
-**Per-phase defaults:**
-
-| Phase | Default Model | Method | Rationale |
-|-------|--------------|--------|-----------|
-| Research | sonnet | Agent delegation | Sufficient for exploration/analysis |
-| Plan | Main session | Direct execution | Requires interactive feedback |
-| Implement | **auto** | Size-based selection | Cost-optimized per slice |
-| Test | haiku | Agent delegation | Only runs tests |
-
-### Worktree Isolation
-
-Sessions now run in an isolated git worktree by default. This prevents accidental changes to the main branch during development.
-
-- `/deep-work` creates a worktree at `.worktrees/dw/<slug>/` with a dedicated branch
-- All work happens inside the worktree — main branch stays clean
-- `/deep-finish` offers 4 completion options: merge, PR, keep branch, or discard
-- `/deep-cleanup` removes stale worktrees (7+ days old, no active session) — **standalone utility**
-- `/deep-resume` restores worktree context and dispatches into the correct phase — **standalone utility**; `/deep-work` init also auto-detects stale sessions
-- Opt-out with `--no-branch` flag or `git_branch: false` in preset
-
-### Session Lifecycle
-
-Complete session lifecycle management:
-
-```
-/deep-work (start) → worktree created → phases run → /deep-finish (end)
-                                                        ├── merge
-                                                        ├── PR
-                                                        ├── keep
-                                                        └── discard
-```
-
-### Receipt Validation
-
-- Receipt schema v1.0 with `schema_version`, `model_used`, `git_before`/`git_after`, `estimated_cost`
-- `hooks/scripts/receipt-migration.js` auto-converts pre-v4.1 receipts
-- `hooks/scripts/validate-receipt.sh` validates receipt chain integrity
-- `templates/deep-work-ci.yml` — GitHub Actions workflow for CI/CD receipt validation
-- `/deep-receipt export --format=ci` for CI-friendly bundle export
-
-### Session History
-
-`/deep-history` shows cross-session trends:
-- Past session list with model usage, TDD compliance, completion rate
-- Aggregate statistics and trend indicators
-- Model cost tracking (`estimated_cost` per slice and session)
-
-### Quality Gates
-
-Define Quality Gates in plan.md and they will be automatically executed during the Test Phase:
-
-```markdown
-## Quality Gates
-
-| Gate | Command | Required | Threshold |
-|------|---------|----------|-----------|
-| Type Check | `npx tsc --noEmit` | ✅ | — |
-| Coverage | `npm test -- --coverage` | ⚠️ | ≥80% |
-```
-
-- **✅ Required**: Returns to implement on failure
-- **⚠️ Advisory**: Warning logged only, does not block
-- **ℹ️ Insight**: Results recorded for information only
-- Falls back to existing auto-detection when not defined
-
-## Internationalization
-
-All commands automatically detect the user's language and output messages accordingly. Supported through Claude's native multilingual capability — no configuration needed.
-
-- **Korean**: Default reference templates
-- **English**: Automatically translated
-- **Other languages**: Japanese, Chinese, and any language Claude supports
-
-The plugin detects language from user messages or the Claude Code `language` setting.
+|---|---|---|
+| `research.md` | Phase 1 | Codebase analysis (Executive Summary first) |
+| `plan.md` | Phase 2 | Implementation plan (per-slice contract + acceptance fields) |
+| `plan.v{N}.md` / `plan-diff.md` | Plan rewrite | Previous plan backup / structural change comparison |
+| `brainstorm.md` | Phase 0 | Problem definition, approach comparison, success criteria |
+| `receipts/SLICE-NNN.json` | Phase 3 | Per-slice evidence: TDD output, git diff, spec check, review, model |
+| `file-changes.log` | Phase 3 | Auto-tracked file modifications with slice mapping |
+| `test-results.md` | Phase 4 | Verification results (cumulative per attempt) |
+| `quality-gates.md` / `drift-report.md` / `solid-review.md` / `insight-report.md` | Phase 4 | Quality gate, plan-alignment, SOLID, and metrics reports |
+| `report.md` | Session complete | Full session report incl. phase durations |
+| `session-receipt.json` | Session finish | Cross-slice session summary (M3 envelope) |
+| `debug-log/RC-NNN.md` | Phase 3 (debug) | Root-cause analysis notes |
+| `harness-history/harness-sessions.jsonl` | Session end | Per-session assumption-engine data |
+
+Session state is stored as YAML frontmatter in `.claude/deep-work.local.md` (current phase, work dir, TDD state, model routing, worktree info, quality gates, health report, and more).
 
 ## Hooks
 
 Hooks manage the session lifecycle and computational enforcement.
 
-> **Windows**: Hook scripts require `bash` in PATH (Git for Windows or WSL).
-
-| Hook | Script | Trigger | Purpose |
-|------|--------|---------|---------|
-| SessionStart | `update-check.sh` | startup/resume/clear/compact | Git-based version update check |
-| PreToolUse | `phase-guard.sh` | Write/Edit/MultiEdit/Bash | Phase-based edit blocking + **P0 Worktree Path Guard** (hard-blocks writes outside worktree) |
-| PostToolUse | `file-tracker.sh` | Write/Edit/MultiEdit/Bash | Tracks file modifications during implement phase, updates receipts |
-| PostToolUse | `sensor-trigger.js` | Write/Edit/MultiEdit/Bash | Triggers computational sensor pipeline (lint, typecheck, review-check) |
-| PostToolUse | `phase-transition.sh` | Write/Edit/MultiEdit | **P1 Phase Transition Injector** — injects worktree/team/cross_model conditions on phase change |
-| Stop | `session-end.sh` | CLI session end | Reminds about active sessions, shows worktree info, cleans phase cache |
-
-### Phase Guard
-
-| Phase | Code Changes | Doc Changes | File Tracking |
-|-------|-------------|-------------|---------------|
-| Brainstorm | ❌ Blocked | ✅ Allowed | — |
-| Research | ❌ Blocked | ✅ Allowed | — |
-| Plan | ❌ Blocked | ✅ Allowed | — |
-| Implement | ✅ Allowed | ✅ Allowed | ✅ Tracked |
-| Test | ❌ Blocked | ✅ Allowed | — |
-| Idle | ✅ Allowed | ✅ Allowed | — |
-
-## Profile System
-
-On first run, setup questions are asked and saved as the `default` preset. On subsequent runs, the preset is auto-applied — you only provide the task description.
-
-**Multi-preset support:** Create named presets for different work styles. When multiple presets exist, you choose one at session start.
-
-```bash
-# Use a specific preset
-/deep-work --profile=quick "Fix the login bug"
-
-# Manage presets (create, edit)
-/deep-work --setup
-
-# Override preset values for one session
-/deep-work --team "Large refactoring task"
-```
-
-| Flag | Effect |
-|------|--------|
-| `--profile=X` | Use preset X directly |
-| `--setup` | Manage presets (create/edit) |
-| `--team` | Override to Team mode |
-| `--zero-base` | Override to greenfield |
-| `--skip-research` | Start from Plan phase |
-| `--skip-to-implement` | Skip to implement phase (inline slice required) |
-| `--no-branch` | Skip git branch creation |
-
-## Session Options
-
-Options selected when running `/deep-work` (or saved in a preset):
-
-| Option | Choices | Description |
-|--------|---------|-------------|
-| Work mode | Solo / Team | Whether to run agents in parallel |
-| Project type | Existing / Greenfield | Whether this is a new project |
-| Starting phase | Research / Plan | Skip Research if you know the code well |
-| Git branch | Create / Skip | Auto-create a session branch |
-| Model routing | Default / Custom | Per-phase model assignment |
-
-## Team/Solo Mode (v6.4.1)
-
-### Semantics
-- `--team` → concurrency = N (parallel subagents for Research/Implement)
-- `--solo` (default) → concurrency = 1 (single subagent)
-
-### Where work runs
-All real work runs in **Claude Code subagents** by default. Main session is an orchestrator only.
-
-### Escape hatches (Implement only)
-| Situation | Behavior |
-|-----------|----------|
-| `tdd_mode=spike` | Auto-inline |
-| `--skip-plan` + 1 trivial slice | Auto-inline |
-| `--exec=inline` | Force inline |
-| `--exec=delegate` | Force delegate |
-| verify-receipt failure → "수동 수정" | Inline takeover |
-
-### Agent Team (optional)
-If `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` is set, team Implement prompts you to choose between classic Agent Team and parallel subagent dispatch.
-
-## Complexity Guide
-
-| Complexity | Recommended Workflow | Criteria |
-|------------|---------------------|----------|
-| High | Research → Plan → Implement → Test | 5+ files, architecture changes, unfamiliar codebase |
-| Medium | Plan → Implement → Test (skip Research) | 2-4 files, extending a familiar area |
-| Low | No workflow needed | Single file edit, config changes |
-
-## Multi-Model Verification
-
-deep-work v4.2 adds adversarial multi-model review to catch design flaws before implementation.
-
-### How it works
-1. **Structural Review** — Every phase document (brainstorm, research, plan) is reviewed by a Claude haiku subagent on phase-specific dimensions
-2. **Adversarial Review** (plan only) — codex and/or gemini-cli independently review your plan. Conflicts are shown transparently for you to resolve
-3. **Review Gate** — Low structural scores or critical consensus issues block auto-implement
-
-### Setup
-Cross-model review requires [codex](https://github.com/openai/codex) and/or [gemini-cli](https://github.com/google/gemini-cli) to be installed. deep-work auto-detects them at session init.
-
-```bash
-# Install codex (optional)
-npm install -g @openai/codex
-
-# Install gemini-cli (optional)
-npm install -g @google/gemini-cli
-```
-
-If neither tool is installed, deep-work works normally with structural review only.
-
-### Flags
-- `--skip-review` — Skip all reviews (useful for spike/experimental work)
-
-### Commands
-- `/deep-phase-review` — Manually trigger review on current phase document
-- `/deep-phase-review --adversarial` — Run only adversarial cross-model review
-
-## Auto-Loop Evaluation & Contract Negotiation
-
-deep-work v5.1 adds self-correcting evaluation loops and contract-driven slice negotiation.
-
-### Auto-Loop Evaluation
-- **Plan review auto-loop** — After plan creation, a subagent evaluator automatically reviews the plan. If the review score is below threshold, the plan is revised and re-reviewed (up to `plan_review_max_retries` times) without user intervention.
-- **Test phase auto-retry** — When tests fail, the implement→test cycle re-executes automatically with evaluator feedback, reducing manual back-and-forth.
-- Toggle with `auto_loop_enabled` in session state (default: `true`).
-
-### Contract Negotiation
-Each slice in `plan.md` can now include `contract` and `acceptance_threshold` fields:
-- **`contract`** — Defines the expected inputs, outputs, and invariants for a slice
-- **`acceptance_threshold`** — Numeric threshold (0.0–1.0) that the evaluator must meet for the slice to pass
-
-The evaluator checks each slice against its contract during the test phase. Slices below threshold are flagged for revision.
-
-### Assumption Engine Auto-Apply
-At session start, the Assumption Engine automatically applies adjustments based on historical evidence. Previously manual `/deep-assumptions` adjustments are now proactively suggested and applied when confidence is high enough.
-
-### Adaptive Evaluator Model
-- Default evaluator model: **sonnet** (configurable via `evaluator_model` in session state)
-- The engine can auto-adjust the evaluator model based on task complexity and historical accuracy signals.
-
-### Phase Skip Flexibility
-- **`--skip-to-implement`** flag on `/deep-work` — Skips brainstorm, research, and plan phases, jumping directly to implement. Requires an inline slice definition in the task description.
-- Skipped phases are recorded in `skipped_phases` for traceability in reports and receipts.
-
-## Auto-Flow Orchestration
-
-deep-work v5.2 consolidates the entire workflow into a single `/deep-work` command. Instead of manually invoking each phase, the auto-flow orchestrates the full pipeline automatically.
-
-### How it works
-1. `/deep-work "task description"` starts the session and begins the auto-flow
-2. Brainstorm → Research → Plan executes automatically
-3. **Plan approval is the only required user interaction** — review the plan, give feedback, and type "approve"
-4. After approval, Implement → Test → Report runs automatically
-5. `/deep-test` now auto-runs drift-check, SOLID review, and insight analysis as built-in gates
-6. `/deep-status` is the unified dashboard for all session information
-
-### What changed
-- **SKILL.md reduced**: 461 lines → 280 lines (clearer, less redundant)
-- **13 commands reclassified (v6.2.1)**: Quality Gate (3) / Internal (6) / Escape hatch (1) / Utility (2) / Special utility (1 moved). No commands removed; manual invocation remains supported.
-- **`/deep-status` expanded**: Routes `--report` / `--receipts` / `--history` / `--assumptions` flags to the same implementations as the standalone commands. Both manual paths work.
-- **`/deep-test` expanded**: Auto-runs drift-check, SOLID review, and insight analysis
-
-### Migration from v5.1
-No action needed. Your existing presets and session state are fully compatible. Previously "deprecated" commands are reclassified in v6.2.1 as Quality Gate / Internal / Escape hatch / Utility — they continue to work and remain first-class where auto-flow hands control back to you (e.g., `/deep-finish` after tests pass).
-
-## Health Engine + Architecture Fitness
-
-Phase 1 Research now includes an automatic **Health Check** that detects codebase drift and validates architecture fitness rules.
-
-### Drift Sensors (Phase 1, automatic)
-
-| Sensor | What it detects | Scope |
-|--------|----------------|-------|
-| dead-export | Unused exports never imported elsewhere | JS/TS |
-| stale-config | Broken paths in tsconfig, package.json, .eslintrc | JS/TS |
-| dependency-vuln | Known high/critical vulnerabilities via `npm audit` | JS/TS (Required gate) |
-| coverage-trend | Coverage degradation vs. previous session baseline | Universal |
-
-Drift sensors run in parallel (Promise.allSettled) with per-sensor timeouts. Results are injected into the research context so the agent considers codebase health during design.
-
-### Architecture Fitness Functions (fitness.json)
-
-Declare computational architecture rules in `.deep-review/fitness.json`:
-
-```json
-{
-  "version": 1,
-  "rules": [
-    { "id": "no-circular-deps", "type": "dependency", "check": "circular", "severity": "required" },
-    { "id": "max-file-lines", "type": "file-metric", "check": "line-count", "max": 500, "include": "src/**/*.{ts,js}", "severity": "advisory" },
-    { "id": "no-console-in-prod", "type": "forbidden-pattern", "pattern": "console\\.(log|debug)", "include": "src/**/*.{ts,js}", "exclude": "**/*.test.*", "severity": "advisory" }
-  ]
-}
-```
-
-- **Auto-generation**: If fitness.json doesn't exist, Phase 1 analyzes the project and proposes rules (ecosystem-aware — dependency rules only for JS/TS)
-- **Rule types**: `dependency` (dep-cruiser), `file-metric`, `forbidden-pattern`, `structure` (no `custom` in v1)
-- **Phase 4 gates**: Fitness Delta (Advisory) detects new violations; Health Required (Required) propagates unresolved critical issues
-- **Baseline management**: commit/branch-scoped with automatic invalidation on branch switch or rebase
-
-### deep-review Integration
-
-When deep-review is installed:
-- fitness.json rules are injected into the review agent's prompt for architecture-aware review
-- Health report from the receipt is used as additional review context (with scan_commit-based staleness check)
-
-## Topology Templates
-
-Phase 1 Research now auto-detects the service topology and loads a matching template that provides topology-specific guides, sensor configuration, and fitness defaults.
-
-### Topology Detection
-
-`topology-detector.js` runs on top of the existing ecosystem detection. It evaluates 6 built-in topologies in priority order and returns the first match:
-
-| Topology | Detected by |
-|----------|-------------|
-| `nextjs-app` | `next` dependency in package.json |
-| `react-spa` | `react` + no `next`/`express` |
-| `express-api` | `express` dependency |
-| `python-web` | `fastapi` / `django` / `flask` in requirements |
-| `python-lib` | Python project with no web framework |
-| `generic` | Fallback for all other projects |
-
-Detection results are stored in session state and used throughout the workflow.
-
-### Template Structure
-
-Each topology template (`templates/topologies/<name>.json`) contains:
-
-```json
-{
-  "topology": "nextjs-app",
-  "guides": ["...topology-specific implementation guidance..."],
-  "sensors": { "dead-export": true, "stale-config": true },
-  "fitness_defaults": [
-    { "id": "no-circular-deps", "type": "dependency", "severity": "required" }
-  ],
-  "harnessability_hints": ["...notes for the review agent..."]
-}
-```
-
-- **`guides`** — injected into Phase 1 research context and Phase 3 implementation prompts
-- **`sensors`** — topology-aware sensor enable/disable hints
-- **`fitness_defaults`** — merged into auto-generated `fitness.json` when no existing rules conflict
-- **`harnessability_hints`** — hints passed to deep-review for topology-aware code review
-
-### Custom Topology Override
-
-Place a file at `.deep-work/custom/<name>.json` using the same schema. The template loader performs a **deep merge** (custom values win), so you can override any field without rewriting the entire template.
-
-```bash
-# Example: override fitness_defaults for your nextjs-app project
-.deep-work/custom/nextjs-app.json
-```
-
-### Phase Integration
-
-- **Phase 1/3**: topology guides are injected into research and implementation context
-- **Fitness generator**: `fitness_defaults` from the matched template seed the auto-generated `fitness.json` (topology-appropriate rules only)
-- **deep-review**: `harnessability_hints` are forwarded to the review agent prompt
-
-## Self-Correction Loop
-
-A new `review-check` sensor runs automatically after lint and typecheck, providing two layers of correction before Phase 4.
-
-### review-check Sensor
-
-`sensors/review-check.js` operates in two independent layers:
-
-| Layer | Trigger | What it checks |
-|-------|---------|----------------|
-| **Always-on** | Every session | Topology guides compliance — ensures implementation follows topology-specific patterns |
-| **Fitness** | When `fitness.json` exists | Fitness rule violations introduced by the current implementation |
-
-The sensor is added to the standard pipeline:
-
-```
-lint → typecheck → review-check
-```
-
-### Per-Sensor Correction Limit
-
-Each sensor (including `review-check`) has an independent 3-round correction limit. If a sensor still fails after 3 rounds of self-correction, the session escalates to manual intervention rather than looping indefinitely.
-
-```
-round 1: sensor fails → self-correct
-round 2: sensor fails → self-correct
-round 3: sensor fails → self-correct
-round 4: sensor fails → escalate (manual intervention required)
-```
-
-The limits are independent per sensor — a `review-check` failure does not consume lint or typecheck correction rounds.
-
-### Disabling review-check
-
-Add to `.deep-work/config.json`:
-
-```json
-{
-  "review_check": false
-}
-```
-
-This disables both the always-on and fitness layers entirely. Individual layers cannot be disabled separately in v1.
-
-### v1 Scope
-
-- Computational checks only (pattern matching, fitness rule evaluation)
-- Full-project fitness checks (not incremental diff-only)
-- Receipt schema extended with `review_check` field recording layer results and correction rounds used
-
-## Quality Measurement
-
-Every session produces a **Session Quality Score** (0-100) based on five outcome metrics:
-
-| Metric | Weight | What it measures |
-|--------|--------|-----------------|
-| Test Pass Rate | 25% | How often tests pass on the first try |
-| Rework Cycles | 20% | How many implement→test loops were needed |
-| Plan Fidelity | 25% | How closely the implementation matches the approved plan |
-| Sensor Clean Rate | 15% | Lint/typecheck sensor pass rate (not_applicable excluded) |
-| Mutation Score | 15% | Mutation testing effectiveness (not_applicable excluded) |
-
-Health Check results are **not** included in the quality score — they reflect codebase state, not session work quality. They are reported separately in the receipt.
-
-Additional diagnostic metrics (Code Efficiency, Phase Balance) are tracked for informational purposes.
-
-### Quality Trend
-Use `/deep-status --history` to see your quality score trend across sessions. The trend helps identify whether your workflow is improving over time.
-
-### Quality Badge
-Use `/deep-status --badge` to generate a shield badge reflecting your recent quality trend (last 5 sessions). Badge levels: Excellent (90+), Good (75-89), Improving (60-74), Developing (<60).
-
-## Self-Evolving Rules
-
-The **Assumption Engine** tracks whether each enforcement rule (phase guard, TDD, research requirement, etc.) actually improves your outcomes. At each session start, it captures an **assumption snapshot** — the enforcement level of every rule. At session end, the quality score is recorded alongside the snapshot.
-
-Over time, the engine compares quality scores between sessions where a rule was active vs. inactive. If the evidence shows a rule isn't helping (or is hurting), it suggests relaxing or removing it. If a rule consistently correlates with higher quality, it suggests strengthening enforcement.
-
-This creates a feedback loop: rules that prove their value survive; rules that don't get adjusted. Your workflow evolves based on evidence, not dogma.
-
-## Installation
-
-### Prerequisites
-
-- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) CLI installed and configured
-
-### Via Deep Suite marketplace (recommended)
-
-```bash
-# 1. Add the marketplace
-/plugin marketplace add Sungmin-Cho/claude-deep-suite
-
-# 2. Install the plugin
-/plugin install deep-work@Sungmin-Cho-claude-deep-suite
-```
-
-### Standalone
-
-```bash
-# 1. Add this repo as a marketplace
-/plugin marketplace add Sungmin-Cho/claude-deep-work
-
-# 2. Install
-/plugin install deep-work@Sungmin-Cho-claude-deep-work
-```
-
-## Plugin Integration
-
-deep-work integrates with other Claude Deep Suite plugins when they are installed:
-
-### deep-review
-- **Sprint Contract** (Phase 2): After plan approval, automatically generates `.deep-review/contracts/` from slice criteria
-- **Slice Review** (Phase 3): Suggests `/deep-review --contract SLICE-NNN` after each slice reaches GREEN
-- **Full Review** (Phase 4): Suggests `/deep-review` for comprehensive review before quality gates
-- **Fitness-Aware Review**: deep-review reads `.deep-review/fitness.json` to evaluate architecture intent, and `health_report` from the receipt for drift context
-
-### deep-wiki
-- **Knowledge Capture** (Phase 4): After session completion, suggests `/wiki-ingest report.md` to archive research and design decisions
-
-All integrations are optional — they only activate when the respective plugin is detected, and always require user confirmation before execution.
+| Hook | Trigger | Purpose |
+|---|---|---|
+| SessionStart (`update-check.sh`) | startup/resume | Git-based version update check |
+| PreToolUse (`phase-guard.sh`) | Write/Edit/MultiEdit/Bash | Phase-based edit blocking + P0 Worktree Path Guard + non-implement dangerous-command denylist |
+| PostToolUse (`file-tracker.sh`) | Write/Edit/MultiEdit/Bash | Tracks file modifications during Implement, updates receipts |
+| PostToolUse (`sensor-trigger.js`) | Write/Edit/MultiEdit/Bash | Triggers the computational sensor pipeline (lint, typecheck, review-check) |
+| PostToolUse (`phase-transition.sh`) | Write/Edit/MultiEdit | P1 Phase Transition Injector — injects worktree/team/cross-model context on phase change |
+| Stop (`session-end.sh`) | CLI session end | Active-session reminder, worktree info, phase-cache cleanup |
+
+The Phase Guard denylist also blocks dangerous non-implement Bash (e.g. `curl | sh`, `rm -rf` on protected paths, `npm publish`, destructive `kubectl`/SQL, `dd`/`mkfs`), each with a per-family `CLAUDE_ALLOW_*` override env var.
+
+## Key features
+
+- **TDD enforcement** — a hook-enforced state machine (PENDING → RED → RED_VERIFIED → GREEN_ELIGIBLE → GREEN → REFACTOR) blocks production-code edits until a failing test exists. Modes: `strict`, `relaxed`, `coaching`, `spike`, plus a slice-scoped TDD override.
+- **Worktree isolation** — sessions run in an isolated git worktree by default (`.worktrees/dw/<slug>/`); `/deep-finish` offers merge / PR / keep / discard. Opt out with `--no-branch`.
+- **Model routing** — per-phase and per-slice model assignment (S→haiku, M/L→sonnet, XL→opus) cuts token cost; override per slice or in the preset routing table.
+- **Receipts as M3 envelopes** — `session-receipt.json` and slice receipts ship as cross-plugin envelopes with identity-triplet guards and chained provenance, validated by `validate-receipt.sh` and a CI template.
+- **Health Engine + architecture fitness** — Phase 1 runs parallel drift sensors (dead-export, stale-config, dependency-vuln, coverage-trend) and validates declarative rules in `.deep-review/fitness.json`; Phase 4 adds Fitness Delta (advisory) and Health Required (required) gates.
+- **Quality measurement** — every session produces a Session Quality Score (test pass rate, rework cycles, plan fidelity, sensor clean rate, mutation score), trended across sessions.
+- **Self-evolving rules** — the Assumption Engine treats each enforcement rule as a falsifiable hypothesis and suggests relaxing or strengthening it based on session-quality evidence.
+- **Multi-model review** — phase documents are structurally reviewed, and plans get adversarial cross-model review from [codex](https://github.com/openai/codex) and/or [gemini-cli](https://github.com/google/gemini-cli) when installed (skip with `--skip-review`).
+- **Profiles & flags** — named presets (`--profile=X`, `--setup`) and per-session overrides (`--team`, `--zero-base`, `--skip-research`, `--skip-to-implement`, `--tdd=MODE`).
+- **Internationalization** — all messages follow the user's language automatically (Korean reference templates, translated on the fly).
+
+## Plugin integration
+
+deep-work integrates with sibling plugins when they are installed, always with user confirmation before any action:
+
+- **deep-review** — generates `.deep-review/contracts/` from approved slices, suggests slice and full reviews, and shares `fitness.json` + `health_report` for architecture-aware review.
+- **deep-wiki** — suggests `/wiki-ingest report.md` after a session to archive research and design decisions.
+- **deep-memory** — recalls a cross-project brief in Phase 1 and recommends `/deep-memory-harvest` in Phase 5 (opt-in, read-only).
+
+## Links
+
+- [CHANGELOG](CHANGELOG.md) — release history
+- [claude-deep-suite](https://github.com/Sungmin-Cho/claude-deep-suite) — the marketplace and sibling plugins
+- [CONTRIBUTING](CONTRIBUTING.md) · [SECURITY](SECURITY.md)
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are delivered through the latest release of deep-work and a
+refreshed marketplace pin in the
+[claude-deep-suite](https://github.com/Sungmin-Cho/claude-deep-suite) repository.
+Check the current version with `jq -r .version .claude-plugin/plugin.json`.
+
+## Reporting a vulnerability
+
+Please report security issues **privately** via
+[GitHub Security Advisories](https://github.com/Sungmin-Cho/claude-deep-work/security/advisories/new)
+rather than opening a public issue.
+
+We aim to acknowledge reports within a few days and will coordinate a fix and a
+disclosure timeline with you.
+
+## Scope
+
+deep-work runs hooks inside the Claude Code / Codex plugin runtime that **execute
+shell commands** — `phase-guard.sh` (Phase Guard / Worktree Guard), `file-tracker.sh`,
+`phase-transition.sh`, `sensor-trigger.js`, and `session-end.sh`. Before enabling
+the plugin, review `hooks/hooks.json` and the scripts under `hooks/scripts/`.
+
+The Phase Guard enforces a dangerous-command denylist (e.g. `curl | sh`,
+`rm -rf` on protected paths, `npm publish`, destructive `kubectl`/SQL,
+`dd`/`mkfs`); each family can be overridden with a per-family `CLAUDE_ALLOW_*`
+env var. See also the suite-wide denylist guidance in
+[`guides/hook-patterns.md`](https://github.com/Sungmin-Cho/claude-deep-suite/blob/main/guides/hook-patterns.md).
+
+When reporting, please indicate the plugin version and runtime (Claude Code or
+Codex) affected.


### PR DESCRIPTION
Documentation overhaul to match the deep-suite documentation standard (`docs/DOCS_RULE.md`).

- **CHANGELOG** — condensed to concise Keep a Changelog entries; stripped `### Verification` sections, test counts, review-loop noise, and internal paths. Every version + date preserved.
- **README** — evergreen + badge row + standard section order (release notes live in the CHANGELOG).
- **CLAUDE.md / AGENTS.md** — drift-resistant (version read via `jq`), DOCS_RULE reference.
- Added CONTRIBUTING.md + SECURITY.md (+ LICENSE / CHANGELOG.ko.md where missing).

Docs-only — no source / test / manifest changes; plugin verification stayed green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)