### PR TITLE
fix(readme): install by marketplace name (@claude-deep-suite), not owner-repo slug

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -27,7 +27,7 @@ deep-work는 [claude-deep-suite](https://github.com/Sungmin-Cho/claude-deep-suit
 
 ```bash
 /plugin marketplace add Sungmin-Cho/claude-deep-suite
-/plugin install deep-work@Sungmin-Cho-claude-deep-suite
+/plugin install deep-work@claude-deep-suite
 ```
 
 이 저장소에서 단독 설치:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Via the `claude-deep-suite` marketplace (recommended):
 
 ```bash
 /plugin marketplace add Sungmin-Cho/claude-deep-suite
-/plugin install deep-work@Sungmin-Cho-claude-deep-suite
+/plugin install deep-work@claude-deep-suite
 ```
 
 Standalone, from this repository:


### PR DESCRIPTION
## Problem

The README install command used the GitHub **owner-repo slug** as the marketplace
identifier:

```
/plugin install <plugin>@Sungmin-Cho-claude-deep-suite   # ❌ fails
```

But Claude Code installs plugins by the marketplace **`name`** field from
`marketplace.json` (which is `claude-deep-suite`), not the `owner/repo` slug used
to *add* the marketplace. So the documented command fails for every new user.

```
/plugin install <plugin>@claude-deep-suite               # ✅ correct
```

## Verification (three independent sources)

1. **Official docs** — the marketplaces guide example installs `plugin@<manifest-name>`; the `name` field is defined as the public install identifier.
2. **marketplace.json history** — the suite manifest `name` has always been `claude-deep-suite`.
3. **Local install records** — `~/.claude/plugins/installed_plugins.json` keys the installed plugins as `<plugin>@claude-deep-suite`.

Sibling repos deep-review / deep-docs / deep-dashboard / deep-memory already use
the correct form; this brings the remaining repos in line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
