### PR TITLE
fix: use string form for repository field in plugin.json

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -5,10 +5,7 @@
   "author": {
     "name": "sungmin"
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/Sungmin-Cho/claude-deep-work.git"
-  },
+  "repository": "https://github.com/Sungmin-Cho/claude-deep-work.git",
   "license": "MIT",
   "keywords": [
     "workflow",


### PR DESCRIPTION
## Problem

`/plugin marketplace update` failed with:

```
Failed to update: Plugin temp_git_..._unuq3w has an invalid manifest file at
.../.claude-plugin/plugin.json.
Validation errors: repository: Invalid input: expected string, received object
```

The Claude Code plugin validator clones `main` into a temp dir and validates
`.claude-plugin/plugin.json`. The `repository` field was an npm-style
`{type, url}` object, but the validator now requires a plain string.

## Fix

- `.claude-plugin/plugin.json`: `repository` object → string.
- `.codex-plugin/plugin.json`: already a string — unchanged.
- `package.json`: keeps the npm object form (valid npm manifest, not read by the
  plugin loader).

No version bump — this is a manifest-shape hotfix, not a feature release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)