### PR TITLE
fix(phase-guard): tool_name/tool_input stdin JSON fallback + v6.9.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deep-work",
-  "version": "6.9.2",
+  "version": "6.9.3",
   "description": "Evidence-Driven Development Protocol — 24 command-equivalent skill surfaces plus a skill-native deep-work entry alias (cross-platform: Claude Code skills + Codex / Copilot CLI / Gemini CLI / SDK), 3-layer architecture with Skill-based phase dispatch, computational enforcement (worktree guard + phase transition injection), TDD enforcement, and receipt validation",
   "author": {
     "name": "sungmin"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deep-work",
-  "version": "6.9.2",
+  "version": "6.9.3",
   "description": "Evidence-Driven Development Protocol with skill-based phase dispatch, computational enforcement, TDD discipline, and receipt validation",
   "author": {
     "name": "sungmin"

--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -7,6 +7,17 @@ Deep Work 플러그인의 모든 주요 변경 사항을 이 파일에 기록합
 형식은 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)를 따르며,
 이 프로젝트는 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)을 준수합니다.
 
+## [6.9.3] — 2026-07-10 (phase-guard stdin `tool_name`/`tool_input` fallback)
+
+### Fixed
+
+- `phase-guard.sh` — PreToolUse 훅이 도구 이름을 `CLAUDE_TOOL_USE_TOOL_NAME` / `CLAUDE_TOOL_NAME` 환경변수에서**만** 읽었습니다. 현재 Claude Code 하네스(및 cmux 등 일부 실행 환경)는 이 env를 설정하지 않고 `tool_name` / `tool_input`을 훅 stdin JSON의 최상위 키로 전달하므로 `TOOL_NAME`이 빈 문자열이 되고, 추출된 파일 경로도 비어 `checkTddEnforcement`가 모든 호출을 production 파일 수정으로 fail-closed 분류했습니다: implement/strict TDD(PENDING)에서 무해한 Bash 조회·테스트 파일 편집·exempt 파일(`.md`/`.env`) 편집까지 전부 차단(차단 메시지의 `파일: `이 빈 경로)되고, 비-implement phase에서도 Bash 조회가 차단됐습니다. 이제 env가 없을 때만(env 우선) stdin payload에서 `tool_name`을 fallback 파싱하고 중첩 `tool_input`을 unwrap합니다 — env가 설정된 하네스는 flat 계약을 그대로 유지하며, 가드가 평가하는 payload가 툴이 실제 실행하는 입력과 어긋나지 않습니다(4-way 리뷰 라운드 1 🔴 지적 — 게이트 없는 unwrap은 가드-실행 비대칭을 열었을 것). 메인 경로와 Phase 5 read-only 경로를 모두 커버하며, node 부재 시 기존 동작으로 degrade합니다. (참조: `docs/handoff/2026-07-10-phase-guard-toolname-stdin-fallback.md`)
+
+### Added
+
+- `hooks/scripts/phase-guard-stdin-fallback.test.js` — e2e 9케이스: stdin-only 계약 고정(Bash 조회 허용 / 테스트 파일 Write 허용 / production Write **차단 유지** / exempt `.md` Edit 허용), stdin-only payload에서의 Phase 5 read-only 경계(work_dir 밖 Write·Bash redirect 차단, 안 Write 허용), env-set 하네스 무회귀 계약(flat payload 불변; env-set + wrapper payload는 unwrap하지 *않고* fail-closed).
+- `hooks/scripts/test-helpers/run-phase-guard.js` — `HOST_LEAK_VARS`에 `CLAUDE_TOOL_USE_TOOL_NAME` / `CLAUDE_TOOL_NAME` 추가 — 호스트 셸/CI에서 leak된 tool-name 값이 훅 테스트의 "env 미설정" 전제를 깨지 못하게 봉인.
+
 ## [6.9.2] — 2026-07-07 (silent-failure 수정 + 결정론적 receipt 게이트)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ All notable changes to the Deep Work plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.9.3] — 2026-07-10 (phase-guard stdin `tool_name`/`tool_input` fallback)
+
+### Fixed
+
+- `phase-guard.sh` — the PreToolUse hook read the tool name **only** from the `CLAUDE_TOOL_USE_TOOL_NAME` / `CLAUDE_TOOL_NAME` env vars. Current Claude Code harnesses (and runners such as cmux) do not set those vars and instead deliver `tool_name` / `tool_input` as top-level keys of the hook's stdin JSON payload — so `TOOL_NAME` came up empty, the extracted file path was empty, and `checkTddEnforcement` fail-closed classified every call as a production-file edit: in implement/strict TDD (PENDING) even harmless Bash queries, test-file edits, and exempt-file (`.md`/`.env`) edits were blocked (block message showed `파일: ` with an empty path), and non-implement phases blocked Bash queries too. The hook now falls back to parsing `tool_name` from the stdin payload and unwrapping the nested `tool_input` — strictly gated to when the env vars are absent (env-first): env-set harnesses keep the flat contract untouched, and the guard never swaps its evaluated payload away from what the tool actually executes (4-way review round-1 🔴 finding — an ungated unwrap would have opened a guard-vs-execution asymmetry). Both the main path and the Phase 5 read-only path are covered; with node absent the fallback degrades to the previous behavior. (Ref: `docs/handoff/2026-07-10-phase-guard-toolname-stdin-fallback.md`)
+
+### Added
+
+- `hooks/scripts/phase-guard-stdin-fallback.test.js` — 9 e2e cases pinning the stdin-only contract (Bash query allow / test-file Write allow / production Write **still blocked** / exempt `.md` Edit allow), the Phase 5 read-only boundary under stdin-only payloads (outside-work_dir Write and Bash redirect blocked, inside-work_dir Write allowed), and the no-regression contract for env-set harnesses (flat payload unchanged; env-set + wrapper payload is *not* unwrapped — fail-closed).
+- `hooks/scripts/test-helpers/run-phase-guard.js` — `CLAUDE_TOOL_USE_TOOL_NAME` / `CLAUDE_TOOL_NAME` added to `HOST_LEAK_VARS`, so a tool-name value leaking from the host shell / CI can no longer break the "env unset" premise of hook tests.
+
 ## [6.9.2] — 2026-07-07 (silent-failure fixes + deterministic receipt gate)
 
 ### Fixed

--- a/hooks/scripts/phase-guard-stdin-fallback.test.js
+++ b/hooks/scripts/phase-guard-stdin-fallback.test.js
@@ -1,0 +1,139 @@
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { runPhaseGuard, parseGuardOutput } = require('./test-helpers/run-phase-guard');
+
+// e2e: harness가 tool_name/tool_input을 env(CLAUDE_TOOL_USE_TOOL_NAME) 대신
+// stdin JSON 최상위 키로 전달하는 경우의 fallback 파싱.
+//
+// 계약 (docs/handoff/2026-07-10-phase-guard-toolname-stdin-fallback.md):
+//   - env 미설정 시 stdin payload의 `tool_name`을 읽고, 중첩 `tool_input`을 unwrap
+//   - env가 설정된 기존 하네스(flat payload)는 동작 불변 (회귀 없음)
+//   - TDD 강제 로직 자체는 불변 — production 파일 차단(#3)이 그 증거
+//
+// runPhaseGuard의 toolName 옵션을 생략하면 env가 설정되지 않으므로
+// (scrubHostEnv가 호스트 leak도 제거), stdin-only 하네스 계약이 재현된다.
+
+function writeImplementState(tmpDir, sid) {
+  fs.writeFileSync(
+    path.join(tmpDir, '.claude', `deep-work.${sid}.md`),
+    '---\ncurrent_phase: implement\nwork_dir: .deep-work/wd\nactive_slice: SLICE-001\ntdd_mode: strict\ntdd_state: PENDING\n---\n'
+  );
+  fs.writeFileSync(path.join(tmpDir, '.claude', 'deep-work-current-session'), sid);
+}
+
+describe('e2e: stdin JSON tool_name/tool_input fallback (env unset)', () => {
+  let tmpDir;
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pg-stdin-'));
+    fs.mkdirSync(path.join(tmpDir, '.claude'), { recursive: true });
+  });
+  afterEach(() => { if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true }); });
+
+  it('#1 Bash 조회 명령은 허용된다 (implement/PENDING에서도)', () => {
+    const sid = 's-stdin1';
+    writeImplementState(tmpDir, sid);
+
+    const result = runPhaseGuard({
+      cwd: tmpDir,
+      env: { DEEP_WORK_SESSION_ID: sid },
+      toolInput: { tool_name: 'Bash', tool_input: { command: 'true' } },
+    });
+
+    assert.equal(result.status, 0, `expected allow (exit 0), got ${result.status}: ${result.stdout} ${result.stderr}`);
+    const parsed = parseGuardOutput(result.stdout);
+    assert.ok(!parsed || parsed.decision !== 'block', `unexpected block:\n${result.stdout}`);
+  });
+
+  it('#2 테스트 파일 Write는 허용된다', () => {
+    const sid = 's-stdin2';
+    writeImplementState(tmpDir, sid);
+
+    const result = runPhaseGuard({
+      cwd: tmpDir,
+      env: { DEEP_WORK_SESSION_ID: sid },
+      toolInput: { tool_name: 'Write', tool_input: { file_path: 'tests/unit/test_x.py', content: 'x' } },
+    });
+
+    assert.equal(result.status, 0, `expected allow (exit 0), got ${result.status}: ${result.stdout} ${result.stderr}`);
+  });
+
+  it('#3 production 파일 Write는 여전히 차단된다 (TDD 강제 로직 보존 증거)', () => {
+    const sid = 's-stdin3';
+    writeImplementState(tmpDir, sid);
+
+    const result = runPhaseGuard({
+      cwd: tmpDir,
+      env: { DEEP_WORK_SESSION_ID: sid },
+      toolInput: { tool_name: 'Write', tool_input: { file_path: 'src/pkg/mod.py', content: 'x' } },
+    });
+
+    assert.equal(result.status, 2, `expected block (exit 2), got ${result.status}: ${result.stdout} ${result.stderr}`);
+    const parsed = parseGuardOutput(result.stdout);
+    assert.ok(parsed, `block message not valid JSON:\n${result.stdout}`);
+    assert.equal(parsed.decision, 'block');
+    // 빈 file_path로 오분류된 차단이 아니라, 실제 파일 경로를 인지한 차단이어야 한다.
+    assert.ok(parsed.reason.includes('src/pkg/mod.py'), `reason should contain the file path, got:\n${parsed.reason}`);
+  });
+
+  it('#4 exempt(.md) 파일 Edit는 허용된다', () => {
+    const sid = 's-stdin4';
+    writeImplementState(tmpDir, sid);
+
+    const result = runPhaseGuard({
+      cwd: tmpDir,
+      env: { DEEP_WORK_SESSION_ID: sid },
+      toolInput: {
+        tool_name: 'Edit',
+        tool_input: { file_path: `.claude/deep-work.${sid}.md`, old_string: 'a', new_string: 'b' },
+      },
+    });
+
+    assert.equal(result.status, 0, `expected allow (exit 0), got ${result.status}: ${result.stdout} ${result.stderr}`);
+  });
+});
+
+describe('e2e: env가 설정된 기존 하네스는 회귀 없음', () => {
+  let tmpDir;
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pg-stdin-env-'));
+    fs.mkdirSync(path.join(tmpDir, '.claude'), { recursive: true });
+  });
+  afterEach(() => { if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true }); });
+
+  it('env 설정 + flat payload(구 형식): production Write 차단 유지', () => {
+    const sid = 's-env1';
+    writeImplementState(tmpDir, sid);
+
+    const result = runPhaseGuard({
+      cwd: tmpDir,
+      env: { DEEP_WORK_SESSION_ID: sid },
+      toolName: 'Write',
+      toolInput: { file_path: 'src/pkg/mod.py', content: 'x' },
+    });
+
+    assert.equal(result.status, 2, `expected block (exit 2), got ${result.status}: ${result.stdout} ${result.stderr}`);
+    const parsed = parseGuardOutput(result.stdout);
+    assert.equal(parsed && parsed.decision, 'block');
+    assert.ok(parsed.reason.includes('src/pkg/mod.py'), `reason should contain the file path, got:\n${parsed.reason}`);
+  });
+
+  it('env 설정 + wrapper payload(신 형식 하이브리드): tool_input이 unwrap되어 파일 경로를 인지한다', () => {
+    const sid = 's-env2';
+    writeImplementState(tmpDir, sid);
+
+    const result = runPhaseGuard({
+      cwd: tmpDir,
+      env: { DEEP_WORK_SESSION_ID: sid },
+      toolName: 'Write',
+      toolInput: { tool_name: 'Write', tool_input: { file_path: 'src/pkg/mod.py', content: 'x' } },
+    });
+
+    assert.equal(result.status, 2, `expected block (exit 2), got ${result.status}: ${result.stdout} ${result.stderr}`);
+    const parsed = parseGuardOutput(result.stdout);
+    assert.equal(parsed && parsed.decision, 'block');
+    assert.ok(parsed.reason.includes('src/pkg/mod.py'), `reason should contain the unwrapped file path, got:\n${parsed.reason}`);
+  });
+});

--- a/hooks/scripts/phase-guard-stdin-fallback.test.js
+++ b/hooks/scripts/phase-guard-stdin-fallback.test.js
@@ -95,6 +95,61 @@ describe('e2e: stdin JSON tool_name/tool_input fallback (env unset)', () => {
   });
 });
 
+describe('e2e: Phase 5 read-only 경계도 stdin-only 계약에서 유지된다', () => {
+  let tmpDir;
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pg-stdin-p5-'));
+    fs.mkdirSync(path.join(tmpDir, '.claude'), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, '.deep-work', 'session-x'), { recursive: true });
+    // Phase 5 mode: current_phase=idle + phase5_entered_at (+ completed_at 없음)
+    fs.writeFileSync(
+      path.join(tmpDir, '.claude', 'deep-work.local.md'),
+      '---\ncurrent_phase: idle\nwork_dir: .deep-work/session-x\nphase5_work_dir_snapshot: .deep-work/session-x\nphase5_entered_at: "2026-07-10T00:00:00Z"\n---\n'
+    );
+  });
+  afterEach(() => { if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true }); });
+
+  it('stdin-only wrapper: work_dir 밖 Write는 차단된다', () => {
+    const result = runPhaseGuard({
+      cwd: tmpDir,
+      env: { DEEP_WORK_ROOT: tmpDir },
+      toolInput: {
+        tool_name: 'Write',
+        tool_input: { file_path: path.join(tmpDir, 'src', 'app.ts'), content: 'x' },
+      },
+    });
+    assert.equal(result.status, 2, `expected block (exit 2), got ${result.status}: ${result.stdout} ${result.stderr}`);
+    assert.match(result.stdout, /Phase 5 .*쓰기 제한/);
+  });
+
+  it('stdin-only wrapper: work_dir 안 Write는 허용된다', () => {
+    const result = runPhaseGuard({
+      cwd: tmpDir,
+      env: { DEEP_WORK_ROOT: tmpDir },
+      toolInput: {
+        tool_name: 'Write',
+        tool_input: {
+          file_path: path.join(tmpDir, '.deep-work', 'session-x', 'integrate-loop.json'),
+          content: '{}',
+        },
+      },
+    });
+    assert.equal(result.status, 0, `expected allow (exit 0), got ${result.status}: ${result.stdout} ${result.stderr}`);
+  });
+
+  it('stdin-only wrapper: work_dir 밖 Bash write redirect는 차단된다', () => {
+    const result = runPhaseGuard({
+      cwd: tmpDir,
+      env: { DEEP_WORK_ROOT: tmpDir },
+      toolInput: {
+        tool_name: 'Bash',
+        tool_input: { command: `echo x > ${tmpDir}/foo.txt` },
+      },
+    });
+    assert.equal(result.status, 2, `expected block (exit 2), got ${result.status}: ${result.stdout} ${result.stderr}`);
+  });
+});
+
 describe('e2e: env가 설정된 기존 하네스는 회귀 없음', () => {
   let tmpDir;
   beforeEach(() => {
@@ -120,7 +175,11 @@ describe('e2e: env가 설정된 기존 하네스는 회귀 없음', () => {
     assert.ok(parsed.reason.includes('src/pkg/mod.py'), `reason should contain the file path, got:\n${parsed.reason}`);
   });
 
-  it('env 설정 + wrapper payload(신 형식 하이브리드): tool_input이 unwrap되어 파일 경로를 인지한다', () => {
+  it('env 설정 + wrapper payload(합성 시나리오): unwrap하지 않고 fail-closed 차단한다', () => {
+    // env가 설정된 하네스는 flat 계약이다. 인자에 중첩 tool_input 객체가 섞여도
+    // 가드는 payload를 교체하지 않는다 — unwrap하면 가드가 평가하는 입력과 툴이
+    // 실제 실행하는 입력(top-level)이 어긋나는 우회 표면이 된다 (R1-1).
+    // top-level에 file_path가 없으므로 빈 경로 → production fail-closed 차단.
     const sid = 's-env2';
     writeImplementState(tmpDir, sid);
 
@@ -128,12 +187,14 @@ describe('e2e: env가 설정된 기존 하네스는 회귀 없음', () => {
       cwd: tmpDir,
       env: { DEEP_WORK_SESSION_ID: sid },
       toolName: 'Write',
-      toolInput: { tool_name: 'Write', tool_input: { file_path: 'src/pkg/mod.py', content: 'x' } },
+      toolInput: { tool_name: 'Write', tool_input: { file_path: 'tests/unit/test_x.py', content: 'x' } },
     });
 
-    assert.equal(result.status, 2, `expected block (exit 2), got ${result.status}: ${result.stdout} ${result.stderr}`);
+    assert.equal(result.status, 2, `expected fail-closed block (exit 2), got ${result.status}: ${result.stdout} ${result.stderr}`);
     const parsed = parseGuardOutput(result.stdout);
     assert.equal(parsed && parsed.decision, 'block');
-    assert.ok(parsed.reason.includes('src/pkg/mod.py'), `reason should contain the unwrapped file path, got:\n${parsed.reason}`);
+    // 내부 tool_input의 test-file 경로가 평가에 사용되지 않았다는 증거 —
+    // unwrap됐다면 test 파일로 분류되어 allow(exit 0)됐을 것이다.
+    assert.ok(!parsed.reason.includes('tests/unit/test_x.py'), `nested path must NOT be evaluated, got:\n${parsed.reason}`);
   });
 });

--- a/hooks/scripts/phase-guard.sh
+++ b/hooks/scripts/phase-guard.sh
@@ -102,20 +102,21 @@ fi
 if [[ -n "$PHASE5_MODE" ]]; then
   _P5_INPUT="$(cat)"
   _P5_TOOL="${CLAUDE_TOOL_USE_TOOL_NAME:-${CLAUDE_TOOL_NAME:-}}"
-  # 메인 경로와 동일한 stdin JSON fallback (env 우선, 중첩 tool_input unwrap).
+  # 메인 경로와 동일한 stdin JSON fallback (env 우선). unwrap도 게이트 안에서만 —
+  # env가 설정된 하네스(flat 계약)에서는 payload를 교체하지 않는다 (가드-실행 입력 일치).
   if [[ -z "$_P5_TOOL" ]]; then
     _P5_TOOL="$(printf '%s' "$_P5_INPUT" | node -e "
       process.stdin.setEncoding('utf8');let d='';
       process.stdin.on('data',c=>d+=c);
       process.stdin.on('end',()=>{try{process.stdout.write(String(JSON.parse(d).tool_name||''))}catch(e){}});
     " 2>/dev/null || echo "")"
+    _P5_INNER="$(printf '%s' "$_P5_INPUT" | node -e "
+      process.stdin.setEncoding('utf8');let d='';
+      process.stdin.on('data',c=>d+=c);
+      process.stdin.on('end',()=>{try{const o=JSON.parse(d);if(o&&o.tool_input&&typeof o.tool_input==='object')process.stdout.write(JSON.stringify(o.tool_input));}catch(e){}});
+    " 2>/dev/null || echo "")"
+    [[ -n "$_P5_INNER" ]] && _P5_INPUT="$_P5_INNER"
   fi
-  _P5_INNER="$(printf '%s' "$_P5_INPUT" | node -e "
-    process.stdin.setEncoding('utf8');let d='';
-    process.stdin.on('data',c=>d+=c);
-    process.stdin.on('end',()=>{try{const o=JSON.parse(d);if(o&&o.tool_input&&typeof o.tool_input==='object')process.stdout.write(JSON.stringify(o.tool_input));}catch(e){}});
-  " 2>/dev/null || echo "")"
-  [[ -n "$_P5_INNER" ]] && _P5_INPUT="$_P5_INNER"
 
   _PROJECT_ROOT_NORM="$(normalize_path "$PROJECT_ROOT")"
   # snapshot 우선 (RC3-1). snapshot 없으면 work_dir로 backward-compat.
@@ -562,21 +563,22 @@ TOOL_INPUT="$(cat)"
 TOOL_NAME="${CLAUDE_TOOL_USE_TOOL_NAME:-${CLAUDE_TOOL_NAME:-}}"
 
 # 하네스가 tool_name/tool_input을 env가 아니라 stdin JSON 최상위 키로 전달하는
-# 경우의 fallback. env 우선 — TOOL_NAME이 빌 때만 payload에서 읽고, 중첩
-# tool_input은 형식 무관하게 unwrap한다(flat 구형식은 tool_input 키가 없어 no-op).
+# 경우의 fallback. env 우선 — TOOL_NAME이 빌 때만 payload에서 읽고 중첩 tool_input을
+# unwrap한다. unwrap도 이 게이트 안에서만 수행 — env가 설정된 하네스는 flat 계약이므로
+# 가드가 평가하는 입력과 툴이 실행하는 입력이 어긋나지 않도록 payload를 교체하지 않는다.
 if [[ -z "$TOOL_NAME" ]]; then
   TOOL_NAME="$(printf '%s' "$TOOL_INPUT" | node -e "
     process.stdin.setEncoding('utf8');let d='';
     process.stdin.on('data',c=>d+=c);
     process.stdin.on('end',()=>{try{process.stdout.write(String(JSON.parse(d).tool_name||''))}catch(e){}});
   " 2>/dev/null || echo "")"
+  _INNER_INPUT="$(printf '%s' "$TOOL_INPUT" | node -e "
+    process.stdin.setEncoding('utf8');let d='';
+    process.stdin.on('data',c=>d+=c);
+    process.stdin.on('end',()=>{try{const o=JSON.parse(d);if(o&&o.tool_input&&typeof o.tool_input==='object')process.stdout.write(JSON.stringify(o.tool_input));}catch(e){}});
+  " 2>/dev/null || echo "")"
+  [[ -n "$_INNER_INPUT" ]] && TOOL_INPUT="$_INNER_INPUT"
 fi
-_INNER_INPUT="$(printf '%s' "$TOOL_INPUT" | node -e "
-  process.stdin.setEncoding('utf8');let d='';
-  process.stdin.on('data',c=>d+=c);
-  process.stdin.on('end',()=>{try{const o=JSON.parse(d);if(o&&o.tool_input&&typeof o.tool_input==='object')process.stdout.write(JSON.stringify(o.tool_input));}catch(e){}});
-" 2>/dev/null || echo "")"
-[[ -n "$_INNER_INPUT" ]] && TOOL_INPUT="$_INNER_INPUT"
 
 # ─── File path extraction (all phases, for worktree guard + ownership) ──
 # NOTE: 파일 경로 추출은 CURRENT_SESSION_ID와 무관하게 실행해야 한다 (F-02).

--- a/hooks/scripts/phase-guard.sh
+++ b/hooks/scripts/phase-guard.sh
@@ -102,6 +102,20 @@ fi
 if [[ -n "$PHASE5_MODE" ]]; then
   _P5_INPUT="$(cat)"
   _P5_TOOL="${CLAUDE_TOOL_USE_TOOL_NAME:-${CLAUDE_TOOL_NAME:-}}"
+  # 메인 경로와 동일한 stdin JSON fallback (env 우선, 중첩 tool_input unwrap).
+  if [[ -z "$_P5_TOOL" ]]; then
+    _P5_TOOL="$(printf '%s' "$_P5_INPUT" | node -e "
+      process.stdin.setEncoding('utf8');let d='';
+      process.stdin.on('data',c=>d+=c);
+      process.stdin.on('end',()=>{try{process.stdout.write(String(JSON.parse(d).tool_name||''))}catch(e){}});
+    " 2>/dev/null || echo "")"
+  fi
+  _P5_INNER="$(printf '%s' "$_P5_INPUT" | node -e "
+    process.stdin.setEncoding('utf8');let d='';
+    process.stdin.on('data',c=>d+=c);
+    process.stdin.on('end',()=>{try{const o=JSON.parse(d);if(o&&o.tool_input&&typeof o.tool_input==='object')process.stdout.write(JSON.stringify(o.tool_input));}catch(e){}});
+  " 2>/dev/null || echo "")"
+  [[ -n "$_P5_INNER" ]] && _P5_INPUT="$_P5_INNER"
 
   _PROJECT_ROOT_NORM="$(normalize_path "$PROJECT_ROOT")"
   # snapshot 우선 (RC3-1). snapshot 없으면 work_dir로 backward-compat.
@@ -546,6 +560,23 @@ TOOL_INPUT="$(cat)"
 
 # Detect tool name from environment (set by hooks system)
 TOOL_NAME="${CLAUDE_TOOL_USE_TOOL_NAME:-${CLAUDE_TOOL_NAME:-}}"
+
+# 하네스가 tool_name/tool_input을 env가 아니라 stdin JSON 최상위 키로 전달하는
+# 경우의 fallback. env 우선 — TOOL_NAME이 빌 때만 payload에서 읽고, 중첩
+# tool_input은 형식 무관하게 unwrap한다(flat 구형식은 tool_input 키가 없어 no-op).
+if [[ -z "$TOOL_NAME" ]]; then
+  TOOL_NAME="$(printf '%s' "$TOOL_INPUT" | node -e "
+    process.stdin.setEncoding('utf8');let d='';
+    process.stdin.on('data',c=>d+=c);
+    process.stdin.on('end',()=>{try{process.stdout.write(String(JSON.parse(d).tool_name||''))}catch(e){}});
+  " 2>/dev/null || echo "")"
+fi
+_INNER_INPUT="$(printf '%s' "$TOOL_INPUT" | node -e "
+  process.stdin.setEncoding('utf8');let d='';
+  process.stdin.on('data',c=>d+=c);
+  process.stdin.on('end',()=>{try{const o=JSON.parse(d);if(o&&o.tool_input&&typeof o.tool_input==='object')process.stdout.write(JSON.stringify(o.tool_input));}catch(e){}});
+" 2>/dev/null || echo "")"
+[[ -n "$_INNER_INPUT" ]] && TOOL_INPUT="$_INNER_INPUT"
 
 # ─── File path extraction (all phases, for worktree guard + ownership) ──
 # NOTE: 파일 경로 추출은 CURRENT_SESSION_ID와 무관하게 실행해야 한다 (F-02).

--- a/hooks/scripts/test-helpers/run-phase-guard.js
+++ b/hooks/scripts/test-helpers/run-phase-guard.js
@@ -26,10 +26,19 @@ const path = require('node:path');
 
 const DEFAULT_PHASE_GUARD = path.resolve(__dirname, '..', 'phase-guard.sh');
 
-// Verified consumer list (grep hooks/scripts/ as of v6.6.2). Update this
-// list AND the comment block above when a new consumer of a host-leakable
-// env var is added or removed — a stale list silently weakens isolation.
-const HOST_LEAK_VARS = ['DEEP_WORK_SESSION_ID', 'DEEP_WORK_ROOT', 'CLAUDE_PROJECT_DIR'];
+// Verified consumer list (grep hooks/scripts/ as of v6.6.2; tool-name vars
+// added with the stdin-fallback suite — phase-guard.sh reads them at :548/:104
+// and the "env unset" contract of phase-guard-stdin-fallback.test.js breaks if
+// they leak from the host shell). Update this list AND the comment block above
+// when a new consumer of a host-leakable env var is added or removed — a stale
+// list silently weakens isolation.
+const HOST_LEAK_VARS = [
+  'DEEP_WORK_SESSION_ID',
+  'DEEP_WORK_ROOT',
+  'CLAUDE_PROJECT_DIR',
+  'CLAUDE_TOOL_USE_TOOL_NAME',
+  'CLAUDE_TOOL_NAME',
+];
 
 /**
  * Return a copy of process.env with the known host-leak vars removed,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-deep-work/deep-work",
-  "version": "6.9.2",
+  "version": "6.9.3",
   "scripts": {
     "test:core": "node --test tests/envelope-emit.test.js tests/envelope-chain.test.js tests/handoff-roundtrip.test.js tests/phase-guard-denylist.test.js tests/phase-guard-golden.test.js tests/skill-entry-alias.test.js tests/deep-memory-integration.test.js",
     "test:all": "node --test --test-concurrency=1 \"hooks/**/*.test.js\" \"tests/**/*.test.js\" \"skills/**/*.test.js\" \"sensors/**/*.test.js\" \"templates/**/*.test.js\" \"scripts/**/*.test.js\"",

--- a/tests/integration/v6.4.0-smoke.test.js
+++ b/tests/integration/v6.4.0-smoke.test.js
@@ -211,12 +211,12 @@ describe('v6.4.0 integration — Health Engine command contracts', () => {
 });
 
 describe('release metadata', () => {
-  it('active release metadata is bumped to 6.9.2 with 6.9.0 feature docs intact', () => {
-    // 6.9.2 is a patch release (silent-failure fixes + deterministic receipt gate): the three
+  it('active release metadata is bumped to 6.9.3 with 6.9.0 feature docs intact', () => {
+    // 6.9.3 is a patch release (phase-guard stdin tool_name/tool_input fallback): the three
     // manifests track the current version, while the README "What's New" and
     // the deep-memory CHANGELOG attributions stay pinned to the last feature
     // release (6.9.0), which the patch does not rewrite.
-    const version = '6.9.2';         // current release — manifests
+    const version = '6.9.3';         // current release — manifests
     const featureVersion = '6.9.0';  // last feature release — README highlight + deep-memory notes
     const root = path.join(__dirname, '..', '..');
     const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
@@ -231,23 +231,23 @@ describe('release metadata', () => {
     assert.equal(claudePlugin.version, version);
     assert.equal(codexPlugin.version, version);
 
-    // Current release (6.9.2) — silent-failure fixes + deterministic receipt gate.
+    // Current release (6.9.3) — phase-guard stdin tool_name/tool_input fallback.
     const changelogCurrent = releaseSection(changelog, version);
     const changelogKoCurrent = releaseSection(changelogKo, version);
-    assert.ok(changelogCurrent.includes('registry-rmw.test.js'),
-      'CHANGELOG.md 6.9.2 section must cite the registry RMW regression test');
-    assert.ok(changelogKoCurrent.includes('registry-rmw.test.js'),
-      'CHANGELOG.ko.md 6.9.2 section must cite the registry RMW regression test');
-    // The prior release (6.9.1) section stays intact with its own ghost-folder
-    // regression-test citation; the 6.9.2 promotion must not clobber or absorb it.
-    assert.ok(releaseSection(changelog, '6.9.1').includes('file-tracker-ghost-guard.test.js'),
-      'CHANGELOG.md 6.9.1 section must retain the ghost-folder regression test');
-    assert.ok(releaseSection(changelogKo, '6.9.1').includes('file-tracker-ghost-guard.test.js'),
-      'CHANGELOG.ko.md 6.9.1 section must retain the ghost-folder regression test');
-    assert.equal(changelogCurrent.includes('file-tracker-ghost-guard.test.js'), false,
-      'CHANGELOG.md 6.9.2 section must not absorb the 6.9.1 ghost-folder note');
-    assert.equal(changelogKoCurrent.includes('file-tracker-ghost-guard.test.js'), false,
-      'CHANGELOG.ko.md 6.9.2 section must not absorb the 6.9.1 ghost-folder note');
+    assert.ok(changelogCurrent.includes('phase-guard-stdin-fallback.test.js'),
+      'CHANGELOG.md 6.9.3 section must cite the stdin-fallback regression test');
+    assert.ok(changelogKoCurrent.includes('phase-guard-stdin-fallback.test.js'),
+      'CHANGELOG.ko.md 6.9.3 section must cite the stdin-fallback regression test');
+    // The prior release (6.9.2) section stays intact with its own registry-RMW
+    // regression-test citation; the 6.9.3 promotion must not clobber or absorb it.
+    assert.ok(releaseSection(changelog, '6.9.2').includes('registry-rmw.test.js'),
+      'CHANGELOG.md 6.9.2 section must retain the registry RMW regression test');
+    assert.ok(releaseSection(changelogKo, '6.9.2').includes('registry-rmw.test.js'),
+      'CHANGELOG.ko.md 6.9.2 section must retain the registry RMW regression test');
+    assert.equal(changelogCurrent.includes('registry-rmw.test.js'), false,
+      'CHANGELOG.md 6.9.3 section must not absorb the 6.9.2 registry-RMW note');
+    assert.equal(changelogKoCurrent.includes('registry-rmw.test.js'), false,
+      'CHANGELOG.ko.md 6.9.3 section must not absorb the 6.9.2 registry-RMW note');
 
     // Last feature release (6.9.0) — deep-memory integration docs remain intact.
     const changelogRelease = releaseSection(changelog, featureVersion);


### PR DESCRIPTION
## Summary
- `phase-guard.sh` PreToolUse 훅이 도구 이름을 env(`CLAUDE_TOOL_USE_TOOL_NAME`/`CLAUDE_TOOL_NAME`)에서만 읽어, env를 설정하지 않고 stdin JSON 최상위 키(`tool_name`/`tool_input`)로 전달하는 현재 Claude Code 하네스(cmux 등)에서 `TOOL_NAME`이 비었고 — 빈 filePath가 production으로 fail-closed 분류되어 implement phase에서 무해한 Bash 조회·테스트 파일 편집·exempt 파일 편집까지 전부 차단되던 버그를 수정합니다.
- **env 우선 → stdin fallback**: env가 비어 있을 때만 stdin payload에서 `tool_name`을 파싱하고 중첩 `tool_input`을 unwrap합니다. unwrap도 같은 게이트 안에서만 수행 — env-set 하네스(flat 계약)에서는 payload를 교체하지 않아 가드가 평가하는 입력과 툴이 실행하는 입력이 어긋나지 않습니다. 메인 경로 + Phase 5 read-only 경로 모두 적용, node 부재 시 기존 동작으로 degrade.
- e2e 회귀 테스트 9케이스 신설(stdin-only allow/block 4 + Phase 5 경계 3 + env-set 무회귀 2), `HOST_LEAK_VARS`에 tool-name env 2종 추가, v6.9.3 CHANGELOG(en/ko) + manifest bump.
- Ref: `docs/handoff/2026-07-10-phase-guard-toolname-stdin-fallback.md` (gitignored 로컬 handoff 문서)

## Review
- deep-loop run `01KX4V8SZTVBEDJRGAJ7WEAAXD` — 4-way cross-model 리뷰 2라운드 수렴:
  - R1 (Opus + Codex review + Codex adversarial + agy): REQUEST_CHANGES — 🔴 unwrap이 env-미설정 게이트 밖(가드-실행 입력 비대칭) 외 3건 → 전건 대응
  - R2: **APPROVE** (Opus·agy APPROVE, Codex review 결함 0건)
- DEFER(후속): file-tracker/phase-transition의 stdin wrapper 계약 미지원(PostToolUse 추적 갭), stdin 계약 1차 승격 시 malformed tool_name fail-closed 설계

## Test plan
- [x] `bash -n hooks/scripts/phase-guard.sh`
- [x] 신규 테스트 패치 전 RED(5/6 실패, 증상 재현) → 패치 후 GREEN
- [x] `npm test` — 891 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)