### PR TITLE
fix(hooks): stdin wrapper 계약 공유 헬퍼 + file-tracker/phase-transition 지원 (D-2) — v6.9.4

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deep-work",
-  "version": "6.9.3",
+  "version": "6.9.4",
   "description": "Evidence-Driven Development Protocol — 24 command-equivalent skill surfaces plus a skill-native deep-work entry alias (cross-platform: Claude Code skills + Codex / Copilot CLI / Gemini CLI / SDK), 3-layer architecture with Skill-based phase dispatch, computational enforcement (worktree guard + phase transition injection), TDD enforcement, and receipt validation",
   "author": {
     "name": "sungmin"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deep-work",
-  "version": "6.9.3",
+  "version": "6.9.4",
   "description": "Evidence-Driven Development Protocol with skill-based phase dispatch, computational enforcement, TDD discipline, and receipt validation",
   "author": {
     "name": "sungmin"

--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -7,6 +7,21 @@ Deep Work 플러그인의 모든 주요 변경 사항을 이 파일에 기록합
 형식은 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)를 따르며,
 이 프로젝트는 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)을 준수합니다.
 
+## [6.9.4] — 2026-07-10 (hooks stdin wrapper 계약 — 공유 헬퍼)
+
+### Fixed
+
+- `file-tracker.sh` / `phase-transition.sh` — 6.9.3이 `phase-guard.sh`에 대해 고친 stdin wrapper 계약을 두 PostToolUse 훅은 지원하지 않았습니다(deep-review 라운드 2 DEFER **D-2**). `tool_name` / `tool_input`을 stdin JSON 최상위 키로 전달하는 env-미설정 하네스에서 `file-tracker.sh`는 `TOOL_NAME`을 env에서만 읽어(빈 값 → 파일 추적/receipt 수집이 조용히 스킵) **wrapper** JSON을 그대로 캐시했고, 그 결과 `phase-transition.sh`의 `file_path` 추출이 비어 phase 전환 checklist 주입이 소리 없이 누락됐습니다. 이제 `file-tracker.sh`가 캐시 write **이전에** 공유 헬퍼로 두 값을 해석하므로 캐시에는 항상 flat `tool_input`이 담기고, `phase-transition.sh`는 env/캐시 입력 경로로 wrapper 형태가 직접 들어오는 경우까지 방어적으로 unwrap합니다(flat 입력·env-set tool-name 하네스에서는 no-op).
+
+### Changed
+
+- `hooks/scripts/utils.sh` — 공유 헬퍼 `resolve_hook_tool_context` 신설: env 우선(`CLAUDE_TOOL_USE_TOOL_NAME` / `CLAUDE_TOOL_NAME`) → stdin wrapper fallback + 중첩 `tool_input` unwrap을 6.9.3의 인라인 로직에서 추출해 세 훅이 하나의 구현을 공유합니다. 시맨틱 불변: env-set 하네스의 payload는 절대 교체하지 않고(가드-실행 대칭, R1-1), malformed JSON은 fail-open 유지(allowlist + fail-closed 전환은 stdin 계약 1차 승격 시로 유예, DEFER D-1). 기존 2회 node spawn을 **1회**로 통합해 두 값을 동시 추출합니다(`U+001F` unit separator 구분자 — `JSON.stringify`가 제어 문자를 이스케이프하므로 payload 내용과 충돌 불가). `phase-guard.sh`의 메인·Phase 5 경로가 이 헬퍼를 호출합니다.
+
+### Added
+
+- `hooks/scripts/hooks-stdin-contract.test.js` — 10케이스: 공유 헬퍼 단위 계약(wrapper unwrap, env 우선 무교체, flat/malformed fail-open, 비객체 `tool_input`, US 구분자 충돌 안전성), `file-tracker.sh` 캐시 unwrap + env-set flat 무회귀, PreToolUse→PostToolUse env-미설정 e2e 체인(`file-tracker` 캐시 → `phase-transition` checklist 주입) 및 wrapper-via-env defense-in-depth 경로.
+- `hooks/scripts/test-helpers/run-phase-guard.js` — `HOST_LEAK_VARS`에 `CLAUDE_TOOL_USE_INPUT` / `CLAUDE_TOOL_INPUT` 추가(`phase-transition.sh`의 env 우선 입력 소스 — 호스트 leak이 테스트 중 file-tracker 캐시 경로를 가리는 것을 봉인).
+
 ## [6.9.3] — 2026-07-10 (phase-guard stdin `tool_name`/`tool_input` fallback)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ All notable changes to the Deep Work plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.9.4] — 2026-07-10 (hooks stdin wrapper contract — shared helper)
+
+### Fixed
+
+- `file-tracker.sh` / `phase-transition.sh` — the two PostToolUse hooks did not support the stdin wrapper contract that 6.9.3 fixed for `phase-guard.sh` (deep-review round-2 DEFER **D-2**). In an env-unset harness that delivers `tool_name` / `tool_input` as top-level stdin JSON keys, `file-tracker.sh` read `TOOL_NAME` from env only (empty → file tracking / receipt collection silently skipped) and cached the **wrapper** JSON verbatim — so `phase-transition.sh`'s `file_path` extraction came up empty and the phase-transition checklist injection was silently dropped. `file-tracker.sh` now resolves both values through the shared helper **before** the cache write, so the cache always carries the flat `tool_input`; `phase-transition.sh` additionally unwraps defensively in case a wrapper-shaped payload arrives via its env/cache input path (a no-op for flat inputs and for env-set tool-name harnesses).
+
+### Changed
+
+- `hooks/scripts/utils.sh` — new shared `resolve_hook_tool_context` helper: env-first (`CLAUDE_TOOL_USE_TOOL_NAME` / `CLAUDE_TOOL_NAME`) → stdin wrapper fallback + nested `tool_input` unwrap, extracted from the 6.9.3 inline logic so all three hooks share one implementation. Semantics are unchanged: env-set harnesses never get their payload swapped (guard-vs-execution symmetry, R1-1), malformed JSON stays fail-open (allowlist + fail-closed is deferred to the stdin-contract promotion, DEFER D-1). The helper extracts both values in a **single** node spawn (`U+001F` unit separator — `JSON.stringify` escapes control characters, so payload content cannot collide) instead of the previous two spawns; `phase-guard.sh`'s main and Phase 5 paths now call it.
+
+### Added
+
+- `hooks/scripts/hooks-stdin-contract.test.js` — 10 cases: shared-helper unit contract (wrapper unwrap, env-first no-swap, flat/malformed fail-open, non-object `tool_input`, unit-separator collision safety), `file-tracker.sh` cache-unwrap + env-set flat regression, and the PreToolUse→PostToolUse env-unset e2e chain (`file-tracker` cache → `phase-transition` checklist injection) plus the wrapper-via-env defense-in-depth path.
+- `hooks/scripts/test-helpers/run-phase-guard.js` — `CLAUDE_TOOL_USE_INPUT` / `CLAUDE_TOOL_INPUT` added to `HOST_LEAK_VARS` (they are `phase-transition.sh`'s env-first input source; a host leak would shadow the file-tracker cache path under test).
+
 ## [6.9.3] — 2026-07-10 (phase-guard stdin `tool_name`/`tool_input` fallback)
 
 ### Fixed

--- a/hooks/scripts/file-tracker.sh
+++ b/hooks/scripts/file-tracker.sh
@@ -21,7 +21,15 @@ STATE_FILE_NORM="$(normalize_path "$STATE_FILE")"
 # never got a fresh cache entry — breaking the injector on most phase
 # changes. Move stdin read to the top and cache atomically.
 TOOL_INPUT="$(cat)"
-TOOL_NAME="${CLAUDE_TOOL_USE_TOOL_NAME:-${CLAUDE_TOOL_NAME:-}}"
+# tool_name/tool_input 해석 — env 우선 → stdin wrapper fallback (utils.sh 공유
+# 헬퍼, v6.9.4 — deep-review D-2). env 미설정 하네스가 stdin에 wrapper JSON
+# ({"tool_name":..., "tool_input":{...}})을 실어 보내는 경우에도 tool_name을
+# 복원하고 payload를 unwrap한다. unwrap이 아래 캐시 write보다 먼저 실행되므로
+# phase-transition.sh가 읽는 캐시에는 항상 flat tool_input이 담긴다
+# (wrapper 계약의 전이적 지원).
+resolve_hook_tool_context "$TOOL_INPUT"
+TOOL_NAME="$HOOK_TOOL_NAME"
+TOOL_INPUT="$HOOK_TOOL_INPUT"
 
 # Does THIS tool call write a deep-work state file? (phase-transition.sh needs
 # the cache to detect the initial phase even before a session pointer resolves

--- a/hooks/scripts/hooks-stdin-contract.test.js
+++ b/hooks/scripts/hooks-stdin-contract.test.js
@@ -1,0 +1,223 @@
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('node:child_process');
+const { scrubHostEnv } = require('./test-helpers/run-phase-guard');
+
+// v6.9.4 (deep-review D-2): env 우선 → stdin wrapper fallback 로직을 utils.sh
+// 공유 헬퍼(resolve_hook_tool_context)로 추출하고 file-tracker.sh /
+// phase-transition.sh가 wrapper 계약을 지원하는지 검증한다.
+//
+// 계약 (docs/handoff/2026-07-10-phase-guard-toolname-stdin-fallback.md):
+//   - env(CLAUDE_TOOL_USE_TOOL_NAME/CLAUDE_TOOL_NAME) 설정 시 payload 무교체 (R1-1)
+//   - env 미설정 시에만 stdin payload의 tool_name을 읽고 중첩 tool_input을 unwrap
+//   - malformed JSON은 fail-open (이름 빈 문자열 + 입력 원본 유지 — D-1에서
+//     stdin 계약 1차 승격 시 fail-closed로 전환 예정)
+
+const UTILS = path.resolve(__dirname, 'utils.sh');
+const FILE_TRACKER = path.resolve(__dirname, 'file-tracker.sh');
+const PHASE_TRANSITION = path.resolve(__dirname, 'phase-transition.sh');
+
+// utils.sh를 source한 뒤 헬퍼를 호출하고 결과 전역 2개를 US(0x1f) 구분자로 출력.
+function runHelper(rawInput, extraEnv = {}) {
+  const result = spawnSync(
+    'bash',
+    ['-c', 'source "$1"; resolve_hook_tool_context "$2"; printf "%s\\x1f%s" "$HOOK_TOOL_NAME" "$HOOK_TOOL_INPUT"', '_', UTILS, rawInput],
+    { encoding: 'utf8', env: scrubHostEnv(extraEnv), timeout: 8000 }
+  );
+  assert.equal(result.status, 0, `helper spawn failed: ${result.stderr}`);
+  const sep = result.stdout.indexOf('\x1f');
+  assert.ok(sep !== -1, `missing separator in helper output: ${result.stdout}`);
+  return { name: result.stdout.slice(0, sep), input: result.stdout.slice(sep + 1) };
+}
+
+describe('utils.sh resolve_hook_tool_context (shared helper)', () => {
+  it('env 미설정 + wrapper: tool_name 복원 + tool_input unwrap', () => {
+    const wrapper = JSON.stringify({
+      tool_name: 'Write',
+      tool_input: { file_path: 'a/b.ts', content: 'x' },
+    });
+    const r = runHelper(wrapper);
+    assert.equal(r.name, 'Write');
+    assert.deepEqual(JSON.parse(r.input), { file_path: 'a/b.ts', content: 'x' });
+  });
+
+  it('env 설정: wrapper 형태여도 payload 무교체 (R1-1 회귀 방지)', () => {
+    const wrapper = JSON.stringify({
+      tool_name: 'Write',
+      tool_input: { file_path: 'a/b.ts' },
+    });
+    const r = runHelper(wrapper, { CLAUDE_TOOL_USE_TOOL_NAME: 'Edit' });
+    assert.equal(r.name, 'Edit', 'env가 payload의 tool_name을 이겨야 한다');
+    assert.equal(r.input, wrapper, 'env 설정 시 절대 unwrap하지 않는다');
+  });
+
+  it('env 미설정 + flat payload: 이름 빈 문자열, 입력 원본 유지', () => {
+    const flat = JSON.stringify({ file_path: 'a/b.ts', content: 'x' });
+    const r = runHelper(flat);
+    assert.equal(r.name, '');
+    assert.equal(r.input, flat);
+  });
+
+  it('env 미설정 + malformed JSON: fail-open (이름 빈 문자열 + 입력 원본)', () => {
+    const r = runHelper('{not json');
+    assert.equal(r.name, '');
+    assert.equal(r.input, '{not json');
+  });
+
+  it('env 미설정 + wrapper(tool_input이 객체가 아님): 이름만 복원, 입력 원본 유지', () => {
+    const wrapper = JSON.stringify({ tool_name: 'Bash', tool_input: 'true' });
+    const r = runHelper(wrapper);
+    assert.equal(r.name, 'Bash');
+    assert.equal(r.input, wrapper);
+  });
+
+  it('payload에 제어 문자가 있어도 US 구분자와 충돌하지 않는다', () => {
+    const wrapper = JSON.stringify({
+      tool_name: 'Write',
+      tool_input: { file_path: 'a.ts', content: 'x\x1fy' },
+    });
+    const r = runHelper(wrapper);
+    assert.equal(r.name, 'Write');
+    assert.equal(JSON.parse(r.input).content, 'x\x1fy');
+  });
+});
+
+// ─── file-tracker.sh / phase-transition.sh 통합 ─────────────────────────
+
+function writeStateFile(tmpDir, sid, fields) {
+  const yaml = Object.entries(fields).map(([k, v]) => `${k}: ${v}`).join('\n');
+  const filePath = path.join(tmpDir, '.claude', `deep-work.${sid}.md`);
+  fs.writeFileSync(filePath, `---\n${yaml}\n---\n`);
+  return filePath;
+}
+
+function writePointerFile(tmpDir, sid) {
+  fs.writeFileSync(path.join(tmpDir, '.claude', 'deep-work-current-session'), sid);
+}
+
+function runHook(script, { cwd, input = '', env = {} }) {
+  return spawnSync('bash', [script], {
+    input,
+    cwd,
+    env: scrubHostEnv(env),
+    encoding: 'utf8',
+    timeout: 10000,
+  });
+}
+
+function readCache(tmpDir) {
+  const files = fs
+    .readdirSync(path.join(tmpDir, '.claude'))
+    .filter((f) => f.startsWith('.hook-tool-input.') && !f.includes('.tmp.'));
+  assert.equal(files.length, 1, `expected exactly one cache file, got: ${files}`);
+  return fs.readFileSync(path.join(tmpDir, '.claude', files[0]), 'utf8');
+}
+
+describe('file-tracker.sh: env 미설정 wrapper 계약', () => {
+  let tmpDir;
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-stdin-'));
+    fs.mkdirSync(path.join(tmpDir, '.claude'), { recursive: true });
+  });
+  afterEach(() => { if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true }); });
+
+  it('wrapper stdin → 캐시에는 unwrap된 flat tool_input이 담긴다', () => {
+    const sid = 's-ft1';
+    const stateFile = writeStateFile(tmpDir, sid, { current_phase: 'plan', team_mode: 'solo' });
+    writePointerFile(tmpDir, sid);
+
+    const result = runHook(FILE_TRACKER, {
+      cwd: tmpDir,
+      input: JSON.stringify({
+        tool_name: 'Write',
+        tool_input: { file_path: stateFile, content: 'x' },
+      }),
+    });
+    assert.equal(result.status, 0, `file-tracker failed: ${result.stderr}`);
+
+    const cached = JSON.parse(readCache(tmpDir));
+    assert.equal(cached.file_path, stateFile, '캐시는 flat tool_input이어야 한다');
+    assert.ok(!('tool_input' in cached), '캐시에 wrapper 키가 남으면 안 된다');
+  });
+
+  it('env 설정 + flat stdin(기존 하네스): 캐시 원본 유지 (회귀 없음)', () => {
+    const sid = 's-ft2';
+    const stateFile = writeStateFile(tmpDir, sid, { current_phase: 'plan', team_mode: 'solo' });
+    writePointerFile(tmpDir, sid);
+
+    const flat = JSON.stringify({ file_path: stateFile, content: 'x' });
+    const result = runHook(FILE_TRACKER, {
+      cwd: tmpDir,
+      input: flat,
+      env: { CLAUDE_TOOL_USE_TOOL_NAME: 'Write' },
+    });
+    assert.equal(result.status, 0, `file-tracker failed: ${result.stderr}`);
+    assert.equal(readCache(tmpDir), flat);
+  });
+});
+
+describe('e2e: PreToolUse→PostToolUse env-unset 체인 (D-2 통합 계약)', () => {
+  let tmpDir;
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'chain-stdin-'));
+    fs.mkdirSync(path.join(tmpDir, '.claude'), { recursive: true });
+  });
+  afterEach(() => { if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true }); });
+
+  it('wrapper stdin: file-tracker 캐시 → phase-transition 주입까지 동작한다', () => {
+    const sid = 's-chain1';
+    const stateFile = writeStateFile(tmpDir, sid, {
+      current_phase: 'plan',
+      worktree_enabled: 'true',
+      worktree_path: '"/tmp/wt/chain"',
+      team_mode: 'team',
+    });
+    writePointerFile(tmpDir, sid);
+
+    // PostToolUse hook 배열 순서 재현: file-tracker가 stdin(wrapper)을 소비·캐시하고,
+    // phase-transition은 빈 stdin + env 미설정으로 캐시에서 입력을 읽는다.
+    const ft = runHook(FILE_TRACKER, {
+      cwd: tmpDir,
+      input: JSON.stringify({
+        tool_name: 'Write',
+        tool_input: { file_path: stateFile, content: 'x' },
+      }),
+    });
+    assert.equal(ft.status, 0, `file-tracker failed: ${ft.stderr}`);
+
+    const pt = runHook(PHASE_TRANSITION, { cwd: tmpDir, input: '' });
+    assert.equal(pt.status, 0, `phase-transition failed: ${pt.stderr}`);
+    assert.ok(pt.stdout.includes('Phase Transition'),
+      `wrapper 하네스에서 phase 전환 주입이 누락되면 안 된다:\n${pt.stdout}`);
+    assert.ok(pt.stdout.includes('worktree_path'), pt.stdout);
+    assert.ok(pt.stdout.includes('team_mode: team'), pt.stdout);
+  });
+
+  it('defense-in-depth: env로 wrapper가 직접 오는 경우도 phase-transition이 unwrap한다', () => {
+    const sid = 's-chain2';
+    const stateFile = writeStateFile(tmpDir, sid, {
+      current_phase: 'implement',
+      tdd_mode: 'strict',
+      team_mode: 'solo',
+    });
+    writePointerFile(tmpDir, sid);
+
+    // tool-name env 미설정 + CLAUDE_TOOL_INPUT이 wrapper 형태인 비정형 하네스.
+    const pt = runHook(PHASE_TRANSITION, {
+      cwd: tmpDir,
+      input: '',
+      env: {
+        CLAUDE_TOOL_INPUT: JSON.stringify({
+          tool_name: 'Write',
+          tool_input: { file_path: stateFile, content: 'x' },
+        }),
+      },
+    });
+    assert.equal(pt.status, 0, `phase-transition failed: ${pt.stderr}`);
+    assert.ok(pt.stdout.includes('Phase Transition'), pt.stdout);
+    assert.ok(pt.stdout.includes('tdd_mode: strict'), pt.stdout);
+  });
+});

--- a/hooks/scripts/phase-guard.sh
+++ b/hooks/scripts/phase-guard.sh
@@ -101,22 +101,12 @@ fi
 # Literal unresolved `$VAR` 또는 백틱 치환은 reject — SKILL은 expanded path를 사용 (RC3-3).
 if [[ -n "$PHASE5_MODE" ]]; then
   _P5_INPUT="$(cat)"
-  _P5_TOOL="${CLAUDE_TOOL_USE_TOOL_NAME:-${CLAUDE_TOOL_NAME:-}}"
-  # 메인 경로와 동일한 stdin JSON fallback (env 우선). unwrap도 게이트 안에서만 —
-  # env가 설정된 하네스(flat 계약)에서는 payload를 교체하지 않는다 (가드-실행 입력 일치).
-  if [[ -z "$_P5_TOOL" ]]; then
-    _P5_TOOL="$(printf '%s' "$_P5_INPUT" | node -e "
-      process.stdin.setEncoding('utf8');let d='';
-      process.stdin.on('data',c=>d+=c);
-      process.stdin.on('end',()=>{try{process.stdout.write(String(JSON.parse(d).tool_name||''))}catch(e){}});
-    " 2>/dev/null || echo "")"
-    _P5_INNER="$(printf '%s' "$_P5_INPUT" | node -e "
-      process.stdin.setEncoding('utf8');let d='';
-      process.stdin.on('data',c=>d+=c);
-      process.stdin.on('end',()=>{try{const o=JSON.parse(d);if(o&&o.tool_input&&typeof o.tool_input==='object')process.stdout.write(JSON.stringify(o.tool_input));}catch(e){}});
-    " 2>/dev/null || echo "")"
-    [[ -n "$_P5_INNER" ]] && _P5_INPUT="$_P5_INNER"
-  fi
+  # 메인 경로와 동일한 env 우선 → stdin wrapper fallback — 공유 헬퍼
+  # utils.sh:resolve_hook_tool_context (v6.9.4, deep-review D-2). env가 설정된
+  # 하네스(flat 계약)에서는 payload를 교체하지 않는다 (가드-실행 입력 일치).
+  resolve_hook_tool_context "$_P5_INPUT"
+  _P5_TOOL="$HOOK_TOOL_NAME"
+  _P5_INPUT="$HOOK_TOOL_INPUT"
 
   _PROJECT_ROOT_NORM="$(normalize_path "$PROJECT_ROOT")"
   # snapshot 우선 (RC3-1). snapshot 없으면 work_dir로 backward-compat.
@@ -559,26 +549,13 @@ fi
 
 TOOL_INPUT="$(cat)"
 
-# Detect tool name from environment (set by hooks system)
-TOOL_NAME="${CLAUDE_TOOL_USE_TOOL_NAME:-${CLAUDE_TOOL_NAME:-}}"
-
-# 하네스가 tool_name/tool_input을 env가 아니라 stdin JSON 최상위 키로 전달하는
-# 경우의 fallback. env 우선 — TOOL_NAME이 빌 때만 payload에서 읽고 중첩 tool_input을
-# unwrap한다. unwrap도 이 게이트 안에서만 수행 — env가 설정된 하네스는 flat 계약이므로
-# 가드가 평가하는 입력과 툴이 실행하는 입력이 어긋나지 않도록 payload를 교체하지 않는다.
-if [[ -z "$TOOL_NAME" ]]; then
-  TOOL_NAME="$(printf '%s' "$TOOL_INPUT" | node -e "
-    process.stdin.setEncoding('utf8');let d='';
-    process.stdin.on('data',c=>d+=c);
-    process.stdin.on('end',()=>{try{process.stdout.write(String(JSON.parse(d).tool_name||''))}catch(e){}});
-  " 2>/dev/null || echo "")"
-  _INNER_INPUT="$(printf '%s' "$TOOL_INPUT" | node -e "
-    process.stdin.setEncoding('utf8');let d='';
-    process.stdin.on('data',c=>d+=c);
-    process.stdin.on('end',()=>{try{const o=JSON.parse(d);if(o&&o.tool_input&&typeof o.tool_input==='object')process.stdout.write(JSON.stringify(o.tool_input));}catch(e){}});
-  " 2>/dev/null || echo "")"
-  [[ -n "$_INNER_INPUT" ]] && TOOL_INPUT="$_INNER_INPUT"
-fi
+# tool_name/tool_input 해석 — env 우선 → stdin wrapper fallback.
+# v6.9.3의 인라인 로직을 공유 헬퍼 utils.sh:resolve_hook_tool_context로 추출
+# (v6.9.4, deep-review D-2). 시맨틱 불변: env 설정 시 payload 무교체(R1-1),
+# env 미설정 시에만 wrapper unwrap, malformed JSON은 fail-open.
+resolve_hook_tool_context "$TOOL_INPUT"
+TOOL_NAME="$HOOK_TOOL_NAME"
+TOOL_INPUT="$HOOK_TOOL_INPUT"
 
 # ─── File path extraction (all phases, for worktree guard + ownership) ──
 # NOTE: 파일 경로 추출은 CURRENT_SESSION_ID와 무관하게 실행해야 한다 (F-02).

--- a/hooks/scripts/phase-transition.sh
+++ b/hooks/scripts/phase-transition.sh
@@ -28,6 +28,14 @@ if [[ -z "$TOOL_INPUT" ]]; then
 fi
 [[ -z "$TOOL_INPUT" ]] && exit 0
 
+# v6.9.4 (deep-review D-2): env 미설정(wrapper) 하네스 방어 — 받은 입력이
+# wrapper JSON 형태면 공유 헬퍼로 unwrap한다. 정상 경로에서는 no-op이다:
+# file-tracker.sh가 이미 unwrap해 캐시하므로 캐시 경로는 flat이고, flat 입력은
+# tool_input 키가 없어 그대로 통과하며, tool-name env가 설정된 flat 계약
+# 하네스에서는 헬퍼가 payload를 건드리지 않는다 (defense-in-depth).
+resolve_hook_tool_context "$TOOL_INPUT"
+TOOL_INPUT="$HOOK_TOOL_INPUT"
+
 # ─── 1. State 파일 대상인지 확인 ────────────────────────────
 FILE_PATH="$(extract_file_path_from_json "$TOOL_INPUT")"
 

--- a/hooks/scripts/test-helpers/run-phase-guard.js
+++ b/hooks/scripts/test-helpers/run-phase-guard.js
@@ -26,18 +26,23 @@ const path = require('node:path');
 
 const DEFAULT_PHASE_GUARD = path.resolve(__dirname, '..', 'phase-guard.sh');
 
-// Verified consumer list (grep hooks/scripts/ as of v6.6.2; tool-name vars
-// added with the stdin-fallback suite — phase-guard.sh reads them at :548/:104
-// and the "env unset" contract of phase-guard-stdin-fallback.test.js breaks if
-// they leak from the host shell). Update this list AND the comment block above
-// when a new consumer of a host-leakable env var is added or removed — a stale
-// list silently weakens isolation.
+// Verified consumer list (grep hooks/scripts/ as of v6.9.4). Tool-name vars
+// were added with the stdin-fallback suite — since v6.9.4 they are read by
+// utils.sh:resolve_hook_tool_context (shared by phase-guard.sh main/Phase5,
+// file-tracker.sh, phase-transition.sh), and the "env unset" contract of the
+// stdin-fallback/contract tests breaks if they leak from the host shell.
+// Tool-INPUT vars are phase-transition.sh's env-first input source — a host
+// leak there would shadow the file-tracker cache path under test. Update this
+// list AND the comment block above when a consumer of a host-leakable env var
+// is added or removed — a stale list silently weakens isolation.
 const HOST_LEAK_VARS = [
   'DEEP_WORK_SESSION_ID',
   'DEEP_WORK_ROOT',
   'CLAUDE_PROJECT_DIR',
   'CLAUDE_TOOL_USE_TOOL_NAME',
   'CLAUDE_TOOL_NAME',
+  'CLAUDE_TOOL_USE_INPUT',
+  'CLAUDE_TOOL_INPUT',
 ];
 
 /**

--- a/hooks/scripts/utils.sh
+++ b/hooks/scripts/utils.sh
@@ -180,6 +180,53 @@ json_escape() {
   ' 2>/dev/null
 }
 
+# resolve_hook_tool_context — hook의 tool_name/tool_input 해석 (env 우선 →
+# stdin wrapper fallback). 하네스는 tool_name을 env(flat 계약)로 주거나, env
+# 미설정 시 stdin payload 최상위 키({"tool_name":..., "tool_input":{...}})로
+# 감싸 전달할 수 있다 (docs/handoff/2026-07-10-phase-guard-toolname-stdin-fallback.md).
+#
+# env 우선 — CLAUDE_TOOL_USE_TOOL_NAME/CLAUDE_TOOL_NAME이 설정된 하네스에서는
+# payload를 절대 교체하지 않는다: unwrap하면 가드가 평가하는 입력과 툴이 실제
+# 실행하는 입력(top-level)이 어긋나는 우회 표면이 된다 (v6.9.3 리뷰 R1-1).
+# env 미설정일 때만 wrapper 키를 읽고 중첩 tool_input을 unwrap한다.
+#
+# node 1회 spawn으로 tool_name과 unwrap된 tool_input을 US(0x1f) 구분자로 동시
+# 추출한다 — JSON.stringify는 제어 문자를 \u001f로 이스케이프하므로 payload
+# 내용과 구분자가 충돌하지 않는다. malformed JSON이면 HOOK_TOOL_NAME은 빈
+# 문자열로 남고 입력은 원본 유지 (fail-open — stdin 계약을 1차로 승격할 때
+# allowlist + fail-closed로 전환 예정, deep-review D-1).
+#
+# 결과는 전역 HOOK_TOOL_NAME / HOOK_TOOL_INPUT에 설정된다.
+# Usage: resolve_hook_tool_context "$RAW_INPUT"
+#        TOOL_NAME="$HOOK_TOOL_NAME"; TOOL_INPUT="$HOOK_TOOL_INPUT"
+
+resolve_hook_tool_context() {
+  local raw="${1-}"
+  HOOK_TOOL_NAME="${CLAUDE_TOOL_USE_TOOL_NAME:-${CLAUDE_TOOL_NAME:-}}"
+  HOOK_TOOL_INPUT="$raw"
+  [[ -n "$HOOK_TOOL_NAME" ]] && return 0
+  local out
+  out="$(printf '%s' "$raw" | node -e '
+    process.stdin.setEncoding("utf8"); let d = "";
+    process.stdin.on("data", c => d += c);
+    process.stdin.on("end", () => {
+      try {
+        const o = JSON.parse(d);
+        const name = typeof o.tool_name === "string" ? o.tool_name : "";
+        const inner = (o && o.tool_input && typeof o.tool_input === "object")
+          ? JSON.stringify(o.tool_input) : "";
+        process.stdout.write(name + "\u001f" + inner);
+      } catch (_) { /* malformed — no output, caller keeps raw (fail-open) */ }
+    });
+  ' 2>/dev/null || printf '')"
+  # 구분자가 없으면 파싱 실패 — env-빈 이름 + 원본 입력 유지.
+  [[ "$out" != *$'\x1f'* ]] && return 0
+  HOOK_TOOL_NAME="${out%%$'\x1f'*}"
+  local inner="${out#*$'\x1f'}"
+  [[ -n "$inner" ]] && HOOK_TOOL_INPUT="$inner"
+  return 0
+}
+
 # ─── Lock primitives ─────────────────────────────────────────
 # mkdir-based advisory spinlock. Fail-closed on timeout (no force-removal —
 # that was the v6.2.3 bug that corrupted the registry under contention).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-deep-work/deep-work",
-  "version": "6.9.3",
+  "version": "6.9.4",
   "scripts": {
     "test:core": "node --test tests/envelope-emit.test.js tests/envelope-chain.test.js tests/handoff-roundtrip.test.js tests/phase-guard-denylist.test.js tests/phase-guard-golden.test.js tests/skill-entry-alias.test.js tests/deep-memory-integration.test.js",
     "test:all": "node --test --test-concurrency=1 \"hooks/**/*.test.js\" \"tests/**/*.test.js\" \"skills/**/*.test.js\" \"sensors/**/*.test.js\" \"templates/**/*.test.js\" \"scripts/**/*.test.js\"",

--- a/tests/integration/v6.4.0-smoke.test.js
+++ b/tests/integration/v6.4.0-smoke.test.js
@@ -211,12 +211,12 @@ describe('v6.4.0 integration — Health Engine command contracts', () => {
 });
 
 describe('release metadata', () => {
-  it('active release metadata is bumped to 6.9.3 with 6.9.0 feature docs intact', () => {
-    // 6.9.3 is a patch release (phase-guard stdin tool_name/tool_input fallback): the three
+  it('active release metadata is bumped to 6.9.4 with 6.9.0 feature docs intact', () => {
+    // 6.9.4 is a patch release (hooks stdin wrapper contract — shared helper): the three
     // manifests track the current version, while the README "What's New" and
     // the deep-memory CHANGELOG attributions stay pinned to the last feature
     // release (6.9.0), which the patch does not rewrite.
-    const version = '6.9.3';         // current release — manifests
+    const version = '6.9.4';         // current release — manifests
     const featureVersion = '6.9.0';  // last feature release — README highlight + deep-memory notes
     const root = path.join(__dirname, '..', '..');
     const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
@@ -231,23 +231,23 @@ describe('release metadata', () => {
     assert.equal(claudePlugin.version, version);
     assert.equal(codexPlugin.version, version);
 
-    // Current release (6.9.3) — phase-guard stdin tool_name/tool_input fallback.
+    // Current release (6.9.4) — hooks stdin wrapper contract, shared helper.
     const changelogCurrent = releaseSection(changelog, version);
     const changelogKoCurrent = releaseSection(changelogKo, version);
-    assert.ok(changelogCurrent.includes('phase-guard-stdin-fallback.test.js'),
-      'CHANGELOG.md 6.9.3 section must cite the stdin-fallback regression test');
-    assert.ok(changelogKoCurrent.includes('phase-guard-stdin-fallback.test.js'),
-      'CHANGELOG.ko.md 6.9.3 section must cite the stdin-fallback regression test');
-    // The prior release (6.9.2) section stays intact with its own registry-RMW
-    // regression-test citation; the 6.9.3 promotion must not clobber or absorb it.
-    assert.ok(releaseSection(changelog, '6.9.2').includes('registry-rmw.test.js'),
-      'CHANGELOG.md 6.9.2 section must retain the registry RMW regression test');
-    assert.ok(releaseSection(changelogKo, '6.9.2').includes('registry-rmw.test.js'),
-      'CHANGELOG.ko.md 6.9.2 section must retain the registry RMW regression test');
-    assert.equal(changelogCurrent.includes('registry-rmw.test.js'), false,
-      'CHANGELOG.md 6.9.3 section must not absorb the 6.9.2 registry-RMW note');
-    assert.equal(changelogKoCurrent.includes('registry-rmw.test.js'), false,
-      'CHANGELOG.ko.md 6.9.3 section must not absorb the 6.9.2 registry-RMW note');
+    assert.ok(changelogCurrent.includes('hooks-stdin-contract.test.js'),
+      'CHANGELOG.md 6.9.4 section must cite the stdin-contract regression test');
+    assert.ok(changelogKoCurrent.includes('hooks-stdin-contract.test.js'),
+      'CHANGELOG.ko.md 6.9.4 section must cite the stdin-contract regression test');
+    // The prior release (6.9.3) section stays intact with its own stdin-fallback
+    // regression-test citation; the 6.9.4 promotion must not clobber or absorb it.
+    assert.ok(releaseSection(changelog, '6.9.3').includes('phase-guard-stdin-fallback.test.js'),
+      'CHANGELOG.md 6.9.3 section must retain the stdin-fallback regression test');
+    assert.ok(releaseSection(changelogKo, '6.9.3').includes('phase-guard-stdin-fallback.test.js'),
+      'CHANGELOG.ko.md 6.9.3 section must retain the stdin-fallback regression test');
+    assert.equal(changelogCurrent.includes('phase-guard-stdin-fallback.test.js'), false,
+      'CHANGELOG.md 6.9.4 section must not absorb the 6.9.3 stdin-fallback note');
+    assert.equal(changelogKoCurrent.includes('phase-guard-stdin-fallback.test.js'), false,
+      'CHANGELOG.ko.md 6.9.4 section must not absorb the 6.9.3 stdin-fallback note');
 
     // Last feature release (6.9.0) — deep-memory integration docs remain intact.
     const changelogRelease = releaseSection(changelog, featureVersion);


### PR DESCRIPTION
## Summary

- `utils.sh`: 공유 헬퍼 `resolve_hook_tool_context` 신설 — env 우선 → stdin wrapper fallback + 중첩 `tool_input` unwrap을 v6.9.3 phase-guard 인라인 로직에서 추출 (node 2회 spawn → 1회 통합, U+001F 구분자)
- `phase-guard.sh` (main + Phase5): 공유 헬퍼 호출로 치환 — 시맨틱 불변 (R1-1 no-swap 게이트, malformed fail-open 유지)
- `file-tracker.sh`: 캐시 write **이전에** unwrap — env 미설정 하네스에서 TOOL_NAME 복원 + 캐시에 flat `tool_input` 보장 (**deep-review v6.9.3 DEFER D-2 해소** — phase-transition 전이 지원)
- `phase-transition.sh`: wrapper-via-env/캐시 방어적 unwrap (flat 입력 no-op)
- 신규 `hooks-stdin-contract.test.js` 10케이스 (헬퍼 단위 계약 + file-tracker 캐시 + PreToolUse→PostToolUse env-unset e2e 체인)
- v6.9.4 릴리스: CHANGELOG(en/ko) + manifest 3종 bump + release-metadata smoke 갱신

## Review

- deep-review 4-way cross-model (Opus · Codex review · Codex adversarial · agy) 라운드 1 **APPROVE** — 잔여 🔴/🟡 0/0, ℹ️ 2 (U+001F 주석 스코프, node spawn 미세 지연 — non-blocking)

## Test plan

- [x] `npm test` → 901/901 pass (신규 10케이스 포함)
- [x] 기존 phase-guard stdin-fallback 9케이스 계약 유지 (Opus가 19/19 직접 재검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)