### PR TITLE
fix: make Codex hooks portable on Windows

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -8,11 +8,13 @@
           {
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/session-start-adapter.js\" update-check",
+            "commandWindows": "node \"${CLAUDE_PLUGIN_ROOT}\\hooks\\scripts\\session-start-adapter.js\" update-check; exit $LASTEXITCODE",
             "timeout": 8
           },
           {
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/session-start-adapter.js\" sensor-detect",
+            "commandWindows": "node \"${CLAUDE_PLUGIN_ROOT}\\hooks\\scripts\\session-start-adapter.js\" sensor-detect; exit $LASTEXITCODE",
             "timeout": 8
           }
         ]
@@ -24,7 +26,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/phase-guard.sh\"",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/hook-shell-adapter.js\" phase-guard",
+            "commandWindows": "node \"${CLAUDE_PLUGIN_ROOT}\\hooks\\scripts\\hook-shell-adapter.js\" phase-guard; exit $LASTEXITCODE",
             "timeout": 5
           }
         ]
@@ -36,22 +39,14 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/file-tracker.sh\"",
-            "timeout": 3
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/hook-shell-adapter.js\" post-tool",
+            "commandWindows": "node \"${CLAUDE_PLUGIN_ROOT}\\hooks\\scripts\\hook-shell-adapter.js\" post-tool; exit $LASTEXITCODE",
+            "timeout": 6
           },
           {
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/sensor-trigger.js\"",
-            "timeout": 3
-          }
-        ]
-      },
-      {
-        "matcher": "Write|Edit|MultiEdit",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/phase-transition.sh\"",
+            "commandWindows": "node \"${CLAUDE_PLUGIN_ROOT}\\hooks\\scripts\\sensor-trigger.js\"; exit $LASTEXITCODE",
             "timeout": 3
           }
         ]
@@ -63,7 +58,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/session-end.sh\"",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/hook-shell-adapter.js\" session-end",
+            "commandWindows": "node \"${CLAUDE_PLUGIN_ROOT}\\hooks\\scripts\\hook-shell-adapter.js\" session-end; exit $LASTEXITCODE",
             "timeout": 5
           }
         ]

--- a/hooks/scripts/hook-runtime-portability.test.js
+++ b/hooks/scripts/hook-runtime-portability.test.js
@@ -6,6 +6,7 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 const { spawnSync } = require('node:child_process');
+const { scrubHostEnv } = require('./test-helpers/run-phase-guard.js');
 
 const PLUGIN_ROOT = path.resolve(__dirname, '../..');
 const HOOKS_PATH = path.join(PLUGIN_ROOT, 'hooks', 'hooks.json');
@@ -16,6 +17,31 @@ function commandHandlers(document) {
     .flatMap((registration) => registration.hooks)
     .filter((handler) => handler.type === 'command');
 }
+
+test('every registered hook exposes shell-free POSIX and Windows commands', () => {
+  const document = JSON.parse(fs.readFileSync(HOOKS_PATH, 'utf8'));
+  const handlers = commandHandlers(document);
+
+  assert.ok(handlers.length > 0);
+  for (const handler of handlers) {
+    assert.equal(typeof handler.command, 'string');
+    assert.equal(typeof handler.commandWindows, 'string');
+    for (const command of [handler.command, handler.commandWindows]) {
+      assert.match(command, /^node "/);
+      assert.doesNotMatch(command, /\b(?:bash|wsl)(?:\.exe)?\b/i);
+      assert.doesNotMatch(command, /\.sh(?:"|\s|$)/i);
+    }
+    assert.match(handler.command, /\$\{CLAUDE_PLUGIN_ROOT\}\//);
+    assert.match(handler.commandWindows, /\$\{CLAUDE_PLUGIN_ROOT\}\\/);
+    assert.match(handler.commandWindows, /; exit \$LASTEXITCODE$/);
+  }
+
+  assert.equal(document.hooks.PostToolUse.length, 1);
+  assert.match(
+    document.hooks.PostToolUse[0].hooks[0].command,
+    /hook-shell-adapter\.js" post-tool$/,
+  );
+});
 
 test('every hook command survives a plugin root containing spaces', {
   skip: process.platform === 'win32' ? 'POSIX command path regression' : false,
@@ -31,6 +57,7 @@ test('every hook command survives a plugin root containing spaces', {
     'hooks/scripts/session-end.sh',
   ];
   const nodeScripts = [
+    'hooks/scripts/hook-shell-adapter.js',
     'hooks/scripts/session-start-adapter.js',
     'hooks/scripts/sensor-trigger.js',
     'sensors/detect.js',
@@ -43,7 +70,10 @@ test('every hook command survives a plugin root containing spaces', {
   for (const relativePath of nodeScripts) {
     const target = path.join(fixtureRoot, relativePath);
     fs.mkdirSync(path.dirname(target), { recursive: true });
-    fs.writeFileSync(target, "'use strict';\nprocess.exitCode = 0;\n");
+    const source = relativePath.endsWith('hook-shell-adapter.js')
+      ? fs.readFileSync(path.join(PLUGIN_ROOT, relativePath), 'utf8')
+      : "'use strict';\nprocess.exitCode = 0;\n";
+    fs.writeFileSync(target, source);
   }
 
   const document = JSON.parse(fs.readFileSync(HOOKS_PATH, 'utf8'));
@@ -54,6 +84,213 @@ test('every hook command survives a plugin root containing spaces', {
       `${command}\nstdout: ${result.stdout}\nstderr: ${result.stderr}`);
   }
 });
+
+test('Windows shell adapter converts drive-letter, UNC, and spaced paths for Git Bash', () => {
+  const { toGitBashPath } = require('./hook-shell-adapter.js');
+
+  assert.equal(
+    toGitBashPath('C:\\Users\\Codex User\\.codex\\plugins\\deep-work\\hooks\\scripts\\phase-guard.sh'),
+    '/c/Users/Codex User/.codex/plugins/deep-work/hooks/scripts/phase-guard.sh',
+  );
+  assert.equal(
+    toGitBashPath('\\\\server\\share name\\deep-work\\hooks\\scripts\\session-end.sh'),
+    '//server/share name/deep-work/hooks/scripts/session-end.sh',
+  );
+});
+
+test('Windows shell adapter selects Git for Windows without probing PATH bash', () => {
+  const { resolveBashExecutable } = require('./hook-shell-adapter.js');
+  const calls = [];
+  const gitBash = 'C:\\Program Files\\Git\\bin\\bash.exe';
+  const result = resolveBashExecutable({
+    platform: 'win32',
+    env: {},
+    exists: (candidate) => candidate === gitBash,
+    run: (executable, args) => {
+      calls.push([executable, args]);
+      assert.equal(executable, 'git');
+      assert.deepEqual(args, ['--exec-path']);
+      return {
+        status: 0,
+        stdout: 'C:\\Program Files\\Git\\mingw64\\libexec\\git-core\r\n',
+        stderr: '',
+      };
+    },
+  });
+
+  assert.equal(result, gitBash);
+  assert.deepEqual(calls, [['git', ['--exec-path']]]);
+  assert.equal(calls.some(([executable]) => /bash/i.test(executable)), false);
+});
+
+test('Windows shell adapter fails immediately with a specific unsupported-runtime error', () => {
+  const { runHookScript } = require('./hook-shell-adapter.js');
+  const result = runHookScript('session-end', {
+    platform: 'win32',
+    pluginRoot: 'C:\\Users\\Codex User\\.codex\\plugins\\deep-work\\6.13.0',
+    env: {},
+    exists: () => false,
+    run: (executable, args) => {
+      assert.equal(executable, 'git');
+      assert.deepEqual(args, ['--exec-path']);
+      return { status: 1, stdout: '', stderr: '' };
+    },
+    capture: true,
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Git for Windows Bash was not found/);
+  assert.match(result.stderr, /session-end/);
+  assert.doesNotMatch(result.stderr, /timed out/i);
+});
+
+test('Windows StopHook uses the resolved Git Bash and preserves the script exit code', () => {
+  const { runHookScript } = require('./hook-shell-adapter.js');
+  const gitBash = 'C:\\Program Files\\Git\\bin\\bash.exe';
+  const calls = [];
+  const result = runHookScript('session-end', {
+    platform: 'win32',
+    pluginRoot: 'C:\\Users\\Codex User\\.codex\\plugins\\deep work\\6.13.0',
+    cwd: 'C:\\Users\\Codex User\\repo with spaces',
+    env: {},
+    exists: (candidate) => candidate === gitBash,
+    run: (executable, args, options) => {
+      if (executable === 'git') {
+        return {
+          status: 0,
+          stdout: 'C:\\Program Files\\Git\\mingw64\\libexec\\git-core\r\n',
+          stderr: '',
+        };
+      }
+      calls.push({ executable, args, options });
+      return { status: 7, stdout: '', stderr: 'stop failed\n' };
+    },
+    capture: true,
+  });
+
+  assert.equal(result.status, 7);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].executable, gitBash);
+  assert.deepEqual(calls[0].args, [
+    '/c/Users/Codex User/.codex/plugins/deep work/6.13.0/hooks/scripts/session-end.sh',
+  ]);
+  assert.equal(calls[0].options.cwd, 'C:\\Users\\Codex User\\repo with spaces');
+  assert.equal(calls[0].options.shell, false);
+});
+
+test('PostToolUse adapter forwards one input to file tracking and phase transition', () => {
+  const { runPostToolHooks } = require('./hook-shell-adapter.js');
+  const input = JSON.stringify({
+    tool_name: 'Write',
+    tool_input: { file_path: '/repo/.claude/deep-work.local.md', content: 'x' },
+  });
+  const calls = [];
+  const result = runPostToolHooks({
+    bashExecutable: '/opt/git/bin/bash',
+    capture: true,
+    cwd: '/repo',
+    env: {},
+    input,
+    pluginRoot: '/plugin root',
+    run: (executable, args, options) => {
+      calls.push({ executable, args, options });
+      if (args[0].endsWith('/file-tracker.sh')) {
+        return { status: 0, stdout: '', stderr: '' };
+      }
+      if (args[0].endsWith('/phase-transition.sh')) {
+        return { status: 0, stdout: 'Phase Transition', stderr: '' };
+      }
+      throw new Error(`unexpected command: ${executable} ${args.join(' ')}`);
+    },
+  });
+
+  assert.equal(result.status, 0);
+  assert.equal(result.stdout, 'Phase Transition');
+  assert.equal(calls.length, 2);
+  assert.equal(calls[0].options.input, input);
+  assert.equal(calls[1].options.env.CLAUDE_TOOL_INPUT, input);
+  assert.equal(calls[0].options.cwd, calls[1].options.cwd);
+});
+
+test('native adapter executes PreToolUse, PostToolUse, and StopHook end to end', (t) => {
+  const {
+    runHookScript,
+    runPostToolHooks,
+  } = require('./hook-shell-adapter.js');
+  const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'deep-work-hook-runtime-'));
+  t.after(() => fs.rmSync(fixtureRoot, { recursive: true, force: true }));
+
+  const sessionId = 's-portable';
+  const claudeDir = path.join(fixtureRoot, '.claude');
+  const stateFile = path.join(claudeDir, `deep-work.${sessionId}.md`);
+  fs.mkdirSync(claudeDir, { recursive: true });
+  fs.writeFileSync(path.join(claudeDir, 'deep-work-current-session'), sessionId);
+  fs.writeFileSync(stateFile, [
+    '---',
+    'current_phase: plan',
+    'work_dir: ""',
+    'worktree_enabled: true',
+    `worktree_path: "${fixtureRoot}"`,
+    'team_mode: team',
+    'task_description: "Windows hook portability fixture"',
+    '---',
+    '',
+  ].join('\n'));
+
+  const env = scrubHostEnv({ DEEP_WORK_SESSION_ID: sessionId });
+  const pre = runHookScript('phase-guard', {
+    capture: true,
+    cwd: fixtureRoot,
+    env,
+    input: JSON.stringify({
+      tool_name: 'Bash',
+      tool_input: { command: 'pwd' },
+    }),
+  });
+  assert.equal(pre.status, 0, pre.stderr);
+
+  const post = runPostToolHooks({
+    capture: true,
+    cwd: fixtureRoot,
+    env,
+    input: JSON.stringify({
+      tool_name: 'Write',
+      tool_input: { file_path: stateFile, content: 'fixture' },
+    }),
+  });
+  assert.equal(post.status, 0, post.stderr);
+  assert.match(post.stdout, /Phase Transition/);
+  assert.match(post.stdout, /team_mode: team/);
+
+  const stop = runHookScript('session-end', {
+    capture: true,
+    cwd: fixtureRoot,
+    env,
+  });
+  assert.equal(stop.status, 0, stop.stderr);
+  assert.match(stop.stdout, /Deep Work/);
+
+  const sensorDetect = runSessionStartAdapterForTest('sensor-detect', {
+    cwd: fixtureRoot,
+    env,
+  });
+  assert.equal(sensorDetect.status, 0, sensorDetect.stderr);
+
+  const sensorTrigger = spawnSync(process.execPath, [
+    path.join(PLUGIN_ROOT, 'hooks', 'scripts', 'sensor-trigger.js'),
+  ], {
+    cwd: fixtureRoot,
+    encoding: 'utf8',
+    env,
+    shell: false,
+  });
+  assert.equal(sensorTrigger.status, 0, sensorTrigger.stderr);
+});
+
+function runSessionStartAdapterForTest(mode, options) {
+  const { runSessionStartAdapter } = require('./session-start-adapter.js');
+  return runSessionStartAdapter(mode, options);
+}
 
 test('SessionStart adapter emits the shared Claude and Codex additionalContext contract', () => {
   const { runSessionStartAdapter } = require('./session-start-adapter.js');

--- a/hooks/scripts/hook-shell-adapter.js
+++ b/hooks/scripts/hook-shell-adapter.js
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const PLUGIN_ROOT = path.resolve(__dirname, '../..');
+const HOOK_SCRIPTS = Object.freeze({
+  'update-check': 'update-check.sh',
+  'phase-guard': 'phase-guard.sh',
+  'file-tracker': 'file-tracker.sh',
+  'phase-transition': 'phase-transition.sh',
+  'session-end': 'session-end.sh',
+});
+
+function toGitBashPath(value) {
+  const input = String(value || '');
+  const drive = /^([A-Za-z]):[\\/](.*)$/.exec(input);
+  if (drive) {
+    return `/${drive[1].toLowerCase()}/${drive[2].replaceAll('\\', '/')}`;
+  }
+  if (/^\\\\/.test(input)) return `//${input.slice(2).replaceAll('\\', '/')}`;
+  return input.replaceAll('\\', '/');
+}
+
+function cleanProbeOutput(value) {
+  const output = String(value || '').trim();
+  if (output.startsWith('"') && output.endsWith('"')) return output.slice(1, -1);
+  return output;
+}
+
+function gitInstallCandidates(execPath) {
+  const cleaned = cleanProbeOutput(execPath);
+  if (!cleaned) return [];
+  const root = path.win32.resolve(cleaned, '..', '..', '..');
+  return [
+    path.win32.join(root, 'bin', 'bash.exe'),
+    path.win32.join(root, 'usr', 'bin', 'bash.exe'),
+  ];
+}
+
+function standardGitBashCandidates(env) {
+  const candidates = [];
+  for (const root of [env.ProgramFiles, env['ProgramFiles(x86)']]) {
+    if (root) candidates.push(path.win32.join(root, 'Git', 'bin', 'bash.exe'));
+  }
+  if (env.LOCALAPPDATA) {
+    candidates.push(path.win32.join(env.LOCALAPPDATA, 'Programs', 'Git', 'bin', 'bash.exe'));
+  }
+  return candidates;
+}
+
+function resolveBashExecutable(options = {}) {
+  const platform = options.platform || process.platform;
+  if (platform !== 'win32') return 'bash';
+
+  const env = options.env || process.env;
+  const exists = options.exists || fs.existsSync;
+  const run = options.run || spawnSync;
+  const candidates = [];
+
+  if (env.DEEP_WORK_GIT_BASH) candidates.push(env.DEEP_WORK_GIT_BASH);
+
+  const probe = run('git', ['--exec-path'], {
+    encoding: 'utf8',
+    env,
+    shell: false,
+    timeout: 1_000,
+    windowsHide: true,
+  });
+  if (probe && probe.status === 0) {
+    candidates.push(...gitInstallCandidates(probe.stdout));
+  }
+  candidates.push(...standardGitBashCandidates(env));
+
+  return candidates.find((candidate) => exists(candidate)) || null;
+}
+
+function failureStatus(hookName) {
+  return hookName === 'phase-guard' ? 2 : 1;
+}
+
+function runHookScript(hookName, options = {}) {
+  const scriptName = HOOK_SCRIPTS[hookName];
+  if (!scriptName) {
+    return {
+      status: 2,
+      stdout: '',
+      stderr: `deep-work hook adapter: unknown hook script "${hookName || '<missing>'}"\n`,
+    };
+  }
+
+  const platform = options.platform || process.platform;
+  const env = options.env || process.env;
+  const run = options.run || spawnSync;
+  const bash = Object.hasOwn(options, 'bashExecutable')
+    ? options.bashExecutable
+    : resolveBashExecutable({
+      platform,
+      env,
+      run,
+      exists: options.exists,
+    });
+  if (!bash) {
+    return {
+      status: failureStatus(hookName),
+      stdout: '',
+      stderr: 'deep-work hook adapter: Git for Windows Bash was not found '
+        + `(hook: ${hookName}). Install Git for Windows or set DEEP_WORK_GIT_BASH `
+        + 'to its bash.exe path.\n',
+    };
+  }
+
+  const pathApi = platform === 'win32' ? path.win32 : path;
+  const pluginRoot = options.pluginRoot || PLUGIN_ROOT;
+  const scriptPath = pathApi.resolve(pluginRoot, 'hooks', 'scripts', scriptName);
+  const scriptArg = platform === 'win32' ? toGitBashPath(scriptPath) : scriptPath;
+  const capture = options.capture === true;
+  const hasInput = Object.hasOwn(options, 'input');
+  const result = run(bash, [scriptArg], {
+    cwd: options.cwd || process.cwd(),
+    env,
+    encoding: 'utf8',
+    ...(hasInput ? { input: options.input } : {}),
+    shell: false,
+    stdio: capture ? [hasInput ? 'pipe' : 'ignore', 'pipe', 'pipe'] : 'inherit',
+    windowsHide: true,
+  }) || {};
+
+  if (Number.isInteger(result.status)) {
+    return {
+      status: result.status,
+      stdout: typeof result.stdout === 'string' ? result.stdout : '',
+      stderr: typeof result.stderr === 'string' ? result.stderr : '',
+    };
+  }
+
+  const detail = result.error && result.error.message
+    ? `: ${result.error.message}`
+    : (result.signal ? `: terminated by ${result.signal}` : '');
+  return {
+    status: failureStatus(hookName),
+    stdout: '',
+    stderr: `deep-work hook adapter: ${hookName} could not start${detail}\n`,
+  };
+}
+
+function runPostToolHooks(options = {}) {
+  const platform = options.platform || process.platform;
+  const env = options.env || process.env;
+  const run = options.run || spawnSync;
+  const bash = Object.hasOwn(options, 'bashExecutable')
+    ? options.bashExecutable
+    : resolveBashExecutable({
+      platform,
+      env,
+      run,
+      exists: options.exists,
+    });
+  if (!bash) {
+    return {
+      status: 1,
+      stdout: '',
+      stderr: 'deep-work hook adapter: Git for Windows Bash was not found '
+        + '(hook: post-tool). Install Git for Windows or set DEEP_WORK_GIT_BASH '
+        + 'to its bash.exe path.\n',
+    };
+  }
+
+  const input = String(options.input || '');
+  const shared = {
+    bashExecutable: bash,
+    capture: true,
+    cwd: options.cwd || process.cwd(),
+    exists: options.exists,
+    platform,
+    pluginRoot: options.pluginRoot || PLUGIN_ROOT,
+    run,
+  };
+  const tracker = runHookScript('file-tracker', {
+    ...shared,
+    env,
+    input,
+  });
+  const transition = runHookScript('phase-transition', {
+    ...shared,
+    env: {
+      ...env,
+      CLAUDE_TOOL_INPUT: input,
+    },
+  });
+
+  return {
+    status: tracker.status !== 0 ? tracker.status : transition.status,
+    stdout: `${tracker.stdout}${transition.stdout}`,
+    stderr: `${tracker.stderr}${transition.stderr}`,
+  };
+}
+
+function main() {
+  const hookName = process.argv[2];
+  const result = hookName === 'post-tool'
+    ? runPostToolHooks({ input: fs.readFileSync(0, 'utf8') })
+    : runHookScript(hookName);
+  if (result.stdout) process.stdout.write(result.stdout);
+  if (result.stderr) process.stderr.write(result.stderr);
+  process.exitCode = result.status;
+}
+
+if (require.main === module) main();
+
+module.exports = {
+  HOOK_SCRIPTS,
+  resolveBashExecutable,
+  runHookScript,
+  runPostToolHooks,
+  toGitBashPath,
+};

--- a/hooks/scripts/session-start-adapter.js
+++ b/hooks/scripts/session-start-adapter.js
@@ -2,14 +2,14 @@
 
 const path = require('node:path');
 const { spawnSync } = require('node:child_process');
+const { runHookScript } = require('./hook-shell-adapter.js');
 
 const PLUGIN_ROOT = path.resolve(__dirname, '../..');
 
 function probeSpec(mode, pluginRoot) {
   if (mode === 'update-check') {
     return {
-      executable: 'bash',
-      args: [path.join(pluginRoot, 'hooks', 'scripts', 'update-check.sh')],
+      hookScript: 'update-check',
     };
   }
   if (mode === 'sensor-detect') {
@@ -28,13 +28,24 @@ function runSessionStartAdapter(mode, options = {}) {
     return { status: 2, output: null, stderr: `unknown SessionStart probe: ${mode || '<missing>'}\n` };
   }
 
-  const result = run(spec.executable, spec.args, {
-    cwd: process.cwd(),
-    env: process.env,
-    encoding: 'utf8',
-    timeout: 7_000,
-    windowsHide: true,
-  });
+  const result = spec.hookScript
+    ? runHookScript(spec.hookScript, {
+      capture: true,
+      cwd: options.cwd || process.cwd(),
+      env: options.env || process.env,
+      exists: options.exists,
+      platform: options.platform,
+      pluginRoot: options.pluginRoot || PLUGIN_ROOT,
+      run,
+    })
+    : run(spec.executable, spec.args, {
+      cwd: options.cwd || process.cwd(),
+      env: options.env || process.env,
+      encoding: 'utf8',
+      shell: false,
+      timeout: 7_000,
+      windowsHide: true,
+    });
   const status = Number.isInteger(result.status) ? result.status : 1;
   const stderr = typeof result.stderr === 'string'
     ? result.stderr

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test:all": "node --test --test-concurrency=1 \"runtime/**/*.test.js\" \"hooks/**/*.test.js\" \"tests/**/*.test.js\" \"skills/**/*.test.js\" \"sensors/**/*.test.js\" \"templates/**/*.test.js\" \"scripts/**/*.test.js\"",
     "test:health": "node --test --test-concurrency=1 \"health/**/*.test.js\"",
     "test": "npm run test:all",
-    "test:runtime": "node --test runtime/*.test.js hooks/scripts/phase-guard-core.test.js hooks/scripts/verify-receipt-core.test.js"
+    "test:runtime": "node --test runtime/*.test.js hooks/scripts/hook-runtime-portability.test.js hooks/scripts/phase-guard-core.test.js hooks/scripts/verify-receipt-core.test.js"
   },
   "description": "Deep Work plugin for Claude Code and Codex (cross-platform via 24 command-equivalent skills plus deep-work entry alias) - Evidence-Driven Development Protocol with TDD enforcement, Health Engine (drift detection + fitness functions), worktree isolation, model auto-routing, receipt validation, 6-phase workflow with Phase 5 Integrate",
   "author": "sungmin",


### PR DESCRIPTION
## Summary

- route every registered hook through explicit Node entrypoints with Windows command variants
- resolve Git for Windows Bash without selecting the WSL `bash.exe` launcher
- preserve PowerShell native exit codes for PreToolUse, PostToolUse, SessionStart, and Stop
- keep `file-tracker` and `phase-transition` on one PostToolUse input path

## Root cause

Native Windows Codex expanded `CLAUDE_PLUGIN_ROOT` as a drive-letter path while the hook command resolved `bash` to the WSL launcher. WSL Bash could not open the Windows-form script path. The same direct or indirect PATH lookup affected PreToolUse, PostToolUse, SessionStart update checks, and StopHook.

## Impact

Windows hosts now locate Git for Windows Bash from the Git installation, convert drive-letter/UNC paths explicitly, and fail immediately with a specific unsupported-runtime message if the runtime is unavailable. PowerShell forwards the adapter exit code so phase-guard blocks remain enforceable.

## Validation

- `node --test hooks/scripts/hook-runtime-portability.test.js` — 10/10 pass
- `npm run test:runtime` — pass
- `npm test` — 1,477 pass, 0 fail, 16 skip
- hook JSON parse, Node syntax checks, and `git diff --check` — pass

Closes #51