### PR TITLE
chore(release): v6.13.1 — Windows-portable Codex hooks

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deep-work",
-  "version": "6.13.0",
+  "version": "6.13.1",
   "description": "Evidence-Driven Development Protocol — 24 command-equivalent skill surfaces plus a skill-native deep-work entry alias (cross-platform: Claude Code skills + Codex / Copilot CLI / Gemini CLI / SDK), 3-layer architecture with Skill-based phase dispatch, computational enforcement (worktree guard + phase transition injection), TDD enforcement, and receipt validation",
   "author": {
     "name": "sungmin"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deep-work",
-  "version": "6.13.0",
+  "version": "6.13.1",
   "description": "Evidence-Driven Development Protocol with skill-based phase dispatch, computational enforcement, TDD discipline, and receipt validation",
   "author": {
     "name": "sungmin"

--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -7,6 +7,17 @@ Deep Work 플러그인의 모든 주요 변경 사항을 이 파일에 기록합
 형식은 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)를 따르며,
 이 프로젝트는 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)을 준수합니다.
 
+## [6.13.1] — 2026-07-23 (Windows 호환 Codex hook)
+
+### Fixed
+
+- Windows에서 Codex hook 실행이 이제 `hooks/scripts/hook-shell-adapter.js`(Node adapter)를 거칩니다. 이 adapter는 기존 `.sh` 스크립트(`phase-guard.sh`, `file-tracker.sh`, `phase-transition.sh`, `session-end.sh`) 실행을 위해 Git for Windows Bash를 선택하고, `commandWindows` 항목(`; exit $LASTEXITCODE`)으로 PowerShell 종료 코드를 보존하며, PostToolUse tool-input 흐름을 끝까지 온전하게 유지합니다.
+- `hooks/hooks.json`의 모든 hook 항목(`session-start-adapter.js`, `hook-shell-adapter.js`, `sensor-trigger.js`)에 `commandWindows` variant가 추가되어, Windows가 더 이상 순수 POSIX `bash` 호출에 의존하지 않습니다.
+
+### Added
+
+- `hooks/scripts/hook-runtime-portability.test.js` — 신규 adapter의 Windows Git-Bash 경로 해석, 종료 코드 보존, PostToolUse 입력 통과 동작을 고정합니다.
+
 ## [6.13.0] — 2026-07-22 (Spec Contract & Evidence Policy)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ All notable changes to the Deep Work plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.13.1] — 2026-07-23 (Windows-portable Codex hooks)
+
+### Fixed
+
+- Codex hook execution on Windows now routes through `hooks/scripts/hook-shell-adapter.js`, a Node adapter that selects Git for Windows Bash for the underlying `.sh` scripts (`phase-guard.sh`, `file-tracker.sh`, `phase-transition.sh`, `session-end.sh`), preserves PowerShell exit codes via an explicit `commandWindows` entry (`; exit $LASTEXITCODE`), and keeps the PostToolUse tool-input flow intact end to end.
+- `hooks/hooks.json` gains `commandWindows` variants for every hook entry (`session-start-adapter.js`, `hook-shell-adapter.js`, `sensor-trigger.js`) so Windows no longer depends on a bare POSIX `bash` invocation.
+
+### Added
+
+- `hooks/scripts/hook-runtime-portability.test.js` — pins the Windows Git-Bash resolution, exit-code preservation, and PostToolUse input passthrough behavior of the new adapter.
+
 ## [6.13.0] — 2026-07-22 (Spec Contract & Evidence Policy)
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-deep-work/deep-work",
-  "version": "6.13.0",
+  "version": "6.13.1",
   "engines": {
     "node": ">=22"
   },

--- a/tests/integration/v6.4.0-smoke.test.js
+++ b/tests/integration/v6.4.0-smoke.test.js
@@ -211,12 +211,12 @@ describe('v6.4.0 integration — Health Engine command contracts', () => {
 });
 
 describe('release metadata', () => {
-  it('active release metadata is bumped to 6.13.0 with 6.9.0 feature docs intact', () => {
-    // 6.13.0 is a feature release (spec contract and evidence policy): the
-    // three manifests track the current version, while the README "What's New" and
+  it('active release metadata is bumped to 6.13.1 with 6.9.0 feature docs intact', () => {
+    // 6.13.1 is a patch release (Windows-portable Codex hooks): the three
+    // manifests track the current version, while the README "What's New" and
     // the deep-memory CHANGELOG attributions stay pinned to the prior feature
-    // release (6.9.0), which this release does not rewrite.
-    const version = '6.13.0';        // current release — manifests
+    // release (6.9.0), which this patch does not rewrite.
+    const version = '6.13.1';        // current release — manifests
     const featureVersion = '6.9.0';  // last feature release — README highlight + deep-memory notes
     const root = path.join(__dirname, '..', '..');
     const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
@@ -231,13 +231,13 @@ describe('release metadata', () => {
     assert.equal(claudePlugin.version, version);
     assert.equal(codexPlugin.version, version);
 
-    // Current release (6.13.0) — spec contract and evidence policy.
+    // Current release (6.13.1) — Windows-portable Codex hooks.
     const changelogCurrent = releaseSection(changelog, version);
     const changelogKoCurrent = releaseSection(changelogKo, version);
-    assert.ok(changelogCurrent.includes('runtime/contract-runtime.js')&&changelogCurrent.includes('runtime/evidence-runtime.js'),
-      'CHANGELOG.md 6.13.0 section must cite contract and evidence runtimes');
-    assert.ok(changelogKoCurrent.includes('runtime/contract-runtime.js')&&changelogKoCurrent.includes('runtime/evidence-runtime.js'),
-      'CHANGELOG.ko.md 6.13.0 section must cite contract and evidence runtimes');
+    assert.ok(changelogCurrent.includes('hooks/scripts/hook-runtime-portability.test.js'),
+      'CHANGELOG.md 6.13.1 section must cite the hook portability regression test');
+    assert.ok(changelogKoCurrent.includes('hooks/scripts/hook-runtime-portability.test.js'),
+      'CHANGELOG.ko.md 6.13.1 section must cite the hook portability regression test');
     // The prior release (6.10.0) section stays intact with its own model-catalog
     // citation; the 6.12.0 promotion must not clobber or absorb it.
     assert.ok(releaseSection(changelog, '6.10.0').includes('runtime/model-catalog.js'),


### PR DESCRIPTION
## Summary

- The Windows/Codex hook-portability fix (#52 / `ae1c42b`, "make Codex hooks portable on Windows") landed on `main` without a version bump.
- Claude Code's plugin-update check is version-only (SemVer), not SHA-aware: an install already at `6.13.0` reports "already at the latest version" and never re-fetches, even after the marketplace re-pins to the new commit — so the Windows fix silently never reaches already-installed users.
- Bump `plugin.json` / `.codex-plugin/plugin.json` / `package.json` to `6.13.1` (patch — bug fix, no feature), add CHANGELOG entries (EN + KO) citing `hooks/scripts/hook-runtime-portability.test.js`, and sync the `release metadata` smoke test to the new current version (pattern matches the prior 6.9.1 Windows patch release).

## Validation

- `node --test tests/integration/v6.4.0-smoke.test.js` — 8/8 pass
- `npm run test:all` — 1477/1493 pass, 0 fail, 16 skip

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>