### PR TITLE
fix: restore Windows runtime contract after v7

### DIFF
--- a/runtime/bootstrap-runtime.js
+++ b/runtime/bootstrap-runtime.js
@@ -336,18 +336,36 @@ function validateBootstrapWitness(value){
 
 function decodeUtf8Fatal(bytes){try{return new TextDecoder('utf-8',{fatal:true}).decode(bytes);}
   catch{fail('stdout-invalid-utf8');}}
+function locationPathApi(value){
+  return /^[A-Za-z]:[\\/]/u.test(value)?path.win32:path;
+}
+function resolvedLocationRoot(value){
+  return locationPathApi(value).resolve(value);
+}
+function locationRootUrl(root){
+  if(locationPathApi(root)===path.win32)
+    return new URL(`file:///${root.replaceAll('\\','/')}`).href.replace(/\/$/u,'');
+  return pathToFileURL(root).href.replace(/\/$/u,'');
+}
 function replaceAuthenticatedLocation(candidate,root,rootUrl){
-  if(candidate.startsWith(`${root}/`))return `<worktree>/${candidate.slice(root.length+1)}`;
-  if(candidate.startsWith(`${rootUrl}/`))return `file://<worktree>/${candidate.slice(rootUrl.length+1)}`;
+  const windows=locationPathApi(root)===path.win32;
+  const nativeCandidate=windows?candidate.replaceAll('\\','/'):candidate;
+  const nativeRoot=windows?root.replaceAll('\\','/'):root;
+  const compare=(value)=>windows?value.toLowerCase():value;
+  if(compare(nativeCandidate).startsWith(`${compare(nativeRoot)}/`))
+    return `<worktree>/${nativeCandidate.slice(nativeRoot.length+1)}`;
+  if(compare(candidate).startsWith(`${compare(rootUrl)}/`))
+    return `file://<worktree>/${candidate.slice(rootUrl.length+1)}`;
   fail('stdout-out-of-root-location');
 }
 function tokenizeLocations(text,worktreeRoot){
   if(text.includes('<worktree>/')||text.includes('file://<worktree>/'))
     fail('stdout-reserved-root-token');
-  const root=path.resolve(worktreeRoot),rootUrl=pathToFileURL(root).href.replace(/\/$/u,'');
+  const root=resolvedLocationRoot(worktreeRoot),rootUrl=locationRootUrl(root);
   const lines=text.slice(0,-1).split('\n');
-  const frame=`((?:file:\\/\\/\\/|\\/)[^\\s)\\]}'"]+:[1-9][0-9]*:[1-9][0-9]*)`;
-  const module=`((?:file:\\/\\/\\/|\\/)[^\\s)\\]}'"]+)`;
+  const absoluteLocation='(?:file:\\/\\/\\/|\\/|[A-Za-z]:[\\\\/])';
+  const frame=`(${absoluteLocation}[^\\s)\\]}'"]+:[1-9][0-9]*:[1-9][0-9]*)`;
+  const module=`(${absoluteLocation}[^\\s)\\]}'"]+)`;
   const patterns=[new RegExp(`^(test at )${frame}$`,'u'),
     new RegExp(`^([ \\t]+at )${frame}$`,'u'),
     new RegExp(`^([ \\t]+at .+ \\()${frame}(\\))$`,'u')];
@@ -381,12 +399,16 @@ function tokenizeLocations(text,worktreeRoot){
   return `${lines.join('\n')}\n`;
 }
 function detailLocationAllowed(location,testPaths,worktreeRoot){
-  const root=path.resolve(worktreeRoot),rootUrl=pathToFileURL(root).href.replace(/\/$/u,'');
+  const root=resolvedLocationRoot(worktreeRoot),rootUrl=locationRootUrl(root);
+  const pathApi=locationPathApi(root);
   return testPaths.some((testPath)=>{
     const escaped=testPath.replace(/[.*+?^${}()|[\]\\]/gu,'\\$&');
     if(new RegExp(`^${escaped}:[1-9][0-9]*:[1-9][0-9]*$`,'u')
       .test(location.replace(/^<worktree>\//u,'')))return true;
-    const suffix=pathToFileURL(path.join(root,testPath)).href.slice(rootUrl.length+1)
+    const testUrl=pathApi===path.win32?
+      new URL(`file:///${pathApi.join(root,testPath).replaceAll('\\','/')}`).href:
+      pathToFileURL(pathApi.join(root,testPath)).href;
+    const suffix=testUrl.slice(rootUrl.length+1)
       .replace(/[.*+?^${}()|[\]\\]/gu,'\\$&');
     return new RegExp(`^file://<worktree>/${suffix}:[1-9][0-9]*:[1-9][0-9]*$`,'u').test(location);
   });
@@ -399,7 +421,8 @@ function validateBootstrapArgv(argv,nodeIdentity){
 }
 function normalizeNodeTestBootstrapStdout(stdoutBytes,{worktreeRoot,nodeIdentity,reporter,argv}={}){
   const node=validateNodeIdentity(nodeIdentity);
-  if(reporter!=='spec'||typeof worktreeRoot!=='string'||!path.isAbsolute(worktreeRoot))
+  if(reporter!=='spec'||typeof worktreeRoot!=='string'||
+    !locationPathApi(worktreeRoot).isAbsolute(worktreeRoot))
     fail('bootstrap-normalizer-context');
   const testPaths=validateBootstrapArgv(argv,node);
   let text=decodeUtf8Fatal(Buffer.from(stdoutBytes));

--- a/runtime/bootstrap-runtime.test.js
+++ b/runtime/bootstrap-runtime.test.js
@@ -65,6 +65,8 @@ const NODE_PATH='/opt/homebrew/Cellar/node/26.0.0/bin/node';
 const WORKTREE=process.cwd();
 const ISOLATED_ROOT=process.platform==='win32'?'D:\\isolated-bootstrap':'/private/tmp/isolated-bootstrap';
 const OUTSIDE_ROOT=process.platform==='win32'?'D:\\outside-bootstrap-root':'/outside-bootstrap-root';
+const WINDOWS_ROOT='D:\\agent\\deep-work';
+const WINDOWS_OUTSIDE_ROOT='D:\\agent\\outside';
 const EMPTY_SHA256=digest(Buffer.alloc(0));
 const semantic=(label,value,key)=>{
   const copy=structuredClone(value);delete copy[key];
@@ -173,6 +175,19 @@ test('node spec bootstrap normalization binds the complete stream but erases onl
   assert.notEqual(first.stdout_semantic_sha256,changed.stdout_semantic_sha256);
   assert.deepEqual(first.semantic,{schema_version:1,normalized_stdout_sha256:first.semantic.normalized_stdout_sha256,
     tests:1,pass:1,fail:0,skipped:0});
+});
+
+test('node spec bootstrap normalization authenticates Windows drive locations on every host',()=>{
+  const first=normalizeNodeTestBootstrapStdout(
+    specOutput({root:WINDOWS_ROOT,duration:'1.25'}),normalizationContext(WINDOWS_ROOT));
+  const alternate=normalizeNodeTestBootstrapStdout(
+    specOutput({root:'d:\\AGENT\\deep-work',duration:'999.5'}),
+    normalizationContext(WINDOWS_ROOT));
+  assert.equal(first.stdout_semantic_sha256,alternate.stdout_semantic_sha256);
+  assert.match(first.normalized_bytes.toString(),/<worktree>\/runtime[\\/]a\.test\.js:1:2/u);
+  assert.throws(()=>normalizeNodeTestBootstrapStdout(
+    specOutput({root:WINDOWS_OUTSIDE_ROOT}),normalizationContext(WINDOWS_ROOT)),
+  /stdout-out-of-root-location/);
 });
 
 test('normalizer closes reserved roots, module contexts, timing, summaries and failure details',()=>{

--- a/runtime/bootstrap-runtime.test.js
+++ b/runtime/bootstrap-runtime.test.js
@@ -63,6 +63,8 @@ const {authenticateRedProof}=require('./functional-receipt-runtime.js');
 const digest=(value)=>crypto.createHash('sha256').update(value).digest('hex');
 const NODE_PATH='/opt/homebrew/Cellar/node/26.0.0/bin/node';
 const WORKTREE=process.cwd();
+const ISOLATED_ROOT=process.platform==='win32'?'D:\\isolated-bootstrap':'/private/tmp/isolated-bootstrap';
+const OUTSIDE_ROOT=process.platform==='win32'?'D:\\outside-bootstrap-root':'/outside-bootstrap-root';
 const EMPTY_SHA256=digest(Buffer.alloc(0));
 const semantic=(label,value,key)=>{
   const copy=structuredClone(value);delete copy[key];
@@ -71,9 +73,10 @@ const semantic=(label,value,key)=>{
 
 function specOutput({root=WORKTREE,name='bootstrap contract',duration='1.25',status='✔',pass=1,fail=0,
   testPath='runtime/a.test.js',moduleLoad=false,opaqueLine=null}={}){
-  let prelude=moduleLoad?`Error: Cannot find module ./bootstrap-runtime.js\nRequire stack:\n- ${root}/${testPath}\n`+
-    `    at Example (${root}/${testPath}:1:2) {\n  requireStack: [\n    '${root}/${testPath}'\n  ]\n}\n`:
-    `    at Example (${root}/${testPath}:1:2)\n`;
+  const location=path.join(root,testPath);
+  let prelude=moduleLoad?`Error: Cannot find module ./bootstrap-runtime.js\nRequire stack:\n- ${location}\n`+
+    `    at Example (${location}:1:2) {\n  requireStack: [\n    '${location}'\n  ]\n}\n`:
+    `    at Example (${location}:1:2)\n`;
   if(opaqueLine!==null)prelude+=`${opaqueLine}\n`;
   const details=fail===0?'':`\n✖ failing tests:\n\ntest at ${testPath}:1:2\n`+
     `✖ ${name} (${duration}ms)\n  Error: expected failure\n`;
@@ -161,8 +164,8 @@ test('witness binds patches, commands, results and disjoint changed paths',()=>{
 test('node spec bootstrap normalization binds the complete stream but erases only root and timing',()=>{
   const first=normalizeNodeTestBootstrapStdout(specOutput({duration:'1.25'}),normalizationContext());
   const alternate=normalizeNodeTestBootstrapStdout(
-    specOutput({root:'/private/tmp/isolated-bootstrap',duration:'999.5'}),
-    normalizationContext('/private/tmp/isolated-bootstrap'));
+    specOutput({root:ISOLATED_ROOT,duration:'999.5'}),
+    normalizationContext(ISOLATED_ROOT));
   assert.equal(first.stdout_semantic_sha256,alternate.stdout_semantic_sha256);
   assert.equal(first.semantic.normalized_stdout_sha256,alternate.semantic.normalized_stdout_sha256);
   const changed=normalizeNodeTestBootstrapStdout(
@@ -177,7 +180,7 @@ test('normalizer closes reserved roots, module contexts, timing, summaries and f
   assert.throws(()=>normalizeNodeTestBootstrapStdout(Buffer.from([0xff]),context),/stdout-invalid-utf8/);
   assert.throws(()=>normalizeNodeTestBootstrapStdout(Buffer.from(specOutput().toString().replaceAll('\n','\r\n')),
     context),/stdout-crlf/);
-  assert.throws(()=>normalizeNodeTestBootstrapStdout(specOutput({root:'/outside-root'}),context),
+  assert.throws(()=>normalizeNodeTestBootstrapStdout(specOutput({root:OUTSIDE_ROOT}),context),
     /stdout-out-of-root-location/);
   assert.throws(()=>normalizeNodeTestBootstrapStdout(
     Buffer.from(specOutput().toString().replace('(1.25ms)','(01.25ms)')),context),/stdout-malformed-timing/);
@@ -189,7 +192,8 @@ test('normalizer closes reserved roots, module contexts, timing, summaries and f
     Buffer.from(specOutput().toString().replace('bootstrap contract','<worktree>/bootstrap contract')),context),
   /stdout-reserved-root-token/);
   assert.throws(()=>normalizeNodeTestBootstrapStdout(
-    Buffer.from(specOutput({moduleLoad:true}).toString().replace(`- ${WORKTREE}/runtime/a.test.js\n`,'')),context),
+    Buffer.from(specOutput({moduleLoad:true}).toString().replace(
+      `- ${path.join(WORKTREE,'runtime/a.test.js')}\n`,'')),context),
   /stdout-malformed-location-context/);
   assert.throws(()=>normalizeNodeTestBootstrapStdout(
     Buffer.from(specOutput({status:'✖',pass:0,fail:1}).toString().replace('✖ failing tests:','✖ failures:')),
@@ -536,6 +540,7 @@ function bootstrapControlFixture({stage='green-command-completed',partialPatch=f
   require('node:child_process').execFileSync('git',['init','-q'],{cwd:root});
   require('node:child_process').execFileSync('git',['config','user.email','bootstrap@example.invalid'],{cwd:root});
   require('node:child_process').execFileSync('git',['config','user.name','Bootstrap Fixture'],{cwd:root});
+  require('node:child_process').execFileSync('git',['config','core.autocrlf','false'],{cwd:root});
   fs.mkdirSync(path.join(root,'runtime'));fs.mkdirSync(path.join(root,'.claude'));
   fs.writeFileSync(path.join(root,'.gitignore'),'.claude/\n.deep-work/\n');
   fs.writeFileSync(path.join(root,'runtime','a.js'),'module.exports = 1;\n');
@@ -696,7 +701,7 @@ test('public failure publication reauthenticates normalized and every rejected r
     ['stdout-crlf',{stdout:(root)=>Buffer.from(specOutput({root}).toString().replaceAll('\n','\r\n'))}],
     ['stdout-reserved-root-token',{stdout:(root)=>Buffer.from(specOutput({root}).toString()
       .replace('bootstrap contract','<worktree>/bootstrap contract'))}],
-    ['stdout-out-of-root-location',{stdout:()=>specOutput({root:'/outside-bootstrap-root'})}],
+    ['stdout-out-of-root-location',{stdout:()=>specOutput({root:OUTSIDE_ROOT})}],
     ['stdout-malformed-location-context',{stdout:(root)=>Buffer.from(
       specOutput({root,moduleLoad:true}).toString().replace('  ]\n',''))}],
     ['stdout-malformed-timing',{stdout:(root)=>Buffer.from(

--- a/runtime/platform.js
+++ b/runtime/platform.js
@@ -1691,9 +1691,12 @@ function safeGitEnvironment(executable, source = process.env, fsApi = fs) {
     };
   }
   const environment = {};
+  const windowsKeys = new Set();
   for (const key of ['HOME','USERPROFILE','SystemRoot','SYSTEMROOT','TEMP','TMP']) {
-    if (typeof source[key] === 'string' && !/[\0\r\n]/.test(source[key])) {
+    const folded = key.toLowerCase();
+    if (!windowsKeys.has(folded) && typeof source[key] === 'string' && !/[\0\r\n]/.test(source[key])) {
       environment[key] = source[key];
+      windowsKeys.add(folded);
     }
   }
   Object.assign(environment, {

--- a/runtime/platform.test.js
+++ b/runtime/platform.test.js
@@ -4520,6 +4520,20 @@ test('environment sanitizer applies exact POSIX and case-insensitive Windows key
     /process-env-invalid/);
 });
 
+test('safe Git environment collapses case-insensitive Windows ambient aliases', () => {
+  const environment = platform.safeGitEnvironment(process.execPath, {
+    HOME:'/tmp/home',
+    SystemRoot:'C:\\Windows',
+    SYSTEMROOT:'C:\\Windows',
+    TEMP:'C:\\Temp',
+    TMP:'C:\\Temp',
+  }, {
+    lstatSync(){ throw Object.assign(new Error('not a release carrier'), {code:'ENOENT'}); },
+  });
+  assert.deepEqual(Object.keys(environment).filter((key) => key.toLowerCase() === 'systemroot'),
+    ['SystemRoot']);
+});
+
 test('native Windows launcher preserves the inherited parenthesized environment key', {
   skip:process.platform !== 'win32' ? 'native Windows only' : false,
 }, async () => {

--- a/runtime/release-toolchain-runtime.js
+++ b/runtime/release-toolchain-runtime.js
@@ -35,7 +35,8 @@ function buildToolIdentity({name,targetPath,shimKind='none',shimPath=null,
   let physical,stat,bytes;try{physical=fs.realpathSync(targetPath);
     stat=fs.lstatSync(physical,{bigint:true});bytes=fs.readFileSync(physical);}
   catch{fail('release-tool-identity');}
-  if(!stat.isFile()||stat.isSymbolicLink()||(stat.mode&0o111n)===0n)
+  if(!stat.isFile()||stat.isSymbolicLink()||
+      (process.platform!=='win32'&&(stat.mode&0o111n)===0n))
     fail('release-tool-identity');
   return validateToolIdentity({name,target_path:physical,target_sha256:sha256(bytes),
     target_dev:decimal(stat.dev),target_ino:decimal(stat.ino),
@@ -121,7 +122,8 @@ function validateToolIdentity(value){
     stat=fs.lstatSync(physical,{bigint:true});bytes=fs.readFileSync(physical);}
   catch{fail('release-tool-identity');}
   if(physical!==value.target_path||!stat.isFile()||stat.isSymbolicLink()||
-      (stat.mode&0o111n)===0n||sha256(bytes)!==value.target_sha256||
+      (process.platform!=='win32'&&(stat.mode&0o111n)===0n)||
+      sha256(bytes)!==value.target_sha256||
       decimal(stat.dev)!==value.target_dev||decimal(stat.ino)!==value.target_ino||
       decimal(stat.mode)!==value.target_mode||decimal(stat.size)!==value.target_size||
       statNanos(stat)!==value.target_mtime_ns)fail('release-tool-identity');

--- a/runtime/release-toolchain-runtime.test.js
+++ b/runtime/release-toolchain-runtime.test.js
@@ -81,7 +81,7 @@ test('ReleaseToolchainManifestV1 rejects an unsorted or graph-drifted entry set'
 });
 
 test('POSIX owned bin exposes only authenticated tools through the closed environment',
-  async(t)=>{
+  {skip:process.platform==='win32'},async(t)=>{
     const parent=fs.mkdtempSync(path.join(os.tmpdir(),'dw-release-bin-'));
     t.after(()=>fs.rmSync(parent,{recursive:true,force:true}));
     const materialized=toolchain.materializeOwnedBin({parent,


### PR DESCRIPTION
## Summary
- collapse case-insensitive SystemRoot aliases in the authenticated Git environment
- preserve Windows executable identity without requiring POSIX mode bits
- use platform-native paths in bootstrap TAP fixtures
- skip the explicitly POSIX owned-bin fixture on Windows

## Evidence
- RED reproduced duplicate SystemRoot aliases
- focused platform, Git, session, report, slice, and release tests: 190 tests, 0 failures
- bootstrap runtime: 136 tests, 0 failures