### PR TITLE
fix(security): guard maintainer-only paths named in shipped documents

### DIFF
--- a/.bootstrap-prep/s-6236e5bc/stranded-generation-28-r9-review/generation-33-candidates/build-generation-33-candidates.mjs
+++ b/.bootstrap-prep/s-6236e5bc/stranded-generation-28-r9-review/generation-33-candidates/build-generation-33-candidates.mjs
@@ -1,0 +1,777 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import {spawnSync} from 'node:child_process';
+import {fileURLToPath} from 'node:url';
+
+const SCRIPT_PATH=fileURLToPath(import.meta.url);
+const CANDIDATE_ROOT=path.dirname(SCRIPT_PATH);
+const STRANDED_ROOT=path.dirname(CANDIDATE_ROOT);
+const PREPARATION_ROOT=path.dirname(STRANDED_ROOT);
+const SCRATCH_ROOT=path.resolve(PREPARATION_ROOT,'../..');
+const TARGET_ROOT='/Users/sungmin/Dev/claude-plugins/deep-work/.claude/worktrees/v6-14-tdd-replan';
+const MAIN_ROOT='/Users/sungmin/Dev/claude-plugins/deep-work';
+const SESSION='s-6236e5bc';
+const TARGET_SESSION_ROOT=path.join(TARGET_ROOT,'.deep-work',SESSION);
+const REVIEWS_ROOT=path.join(TARGET_SESSION_ROOT,'reviews');
+const PLAN_PATH=path.join(TARGET_SESSION_ROOT,'plan.md');
+const PLAN_APPROVAL_PATH=path.join(TARGET_SESSION_ROOT,'plan-approval-native-goal-e35.json');
+const SPEC_PATH=path.join(TARGET_SESSION_ROOT,'spec.md');
+const SPEC_APPROVAL_PATH=path.join(TARGET_SESSION_ROOT,'spec-approval-native-goal-e35.json');
+const SOURCE_ROOT=path.join(STRANDED_ROOT,'generation-30-candidates');
+const SOURCE_PREP=path.join(SOURCE_ROOT,'prep-tool-green.mjs');
+const SOURCE_EXECUTOR=path.join(SOURCE_ROOT,'executor-green.mjs');
+const SOURCE_CANDIDATE_MANIFEST=path.join(SOURCE_ROOT,'program-candidate-manifest.json');
+const SOURCE_PROJECTION_RED=path.join(SOURCE_ROOT,'runtime-projection-red-result.json');
+const SOURCE_SELECTOR_RED=path.join(SOURCE_ROOT,'historical-selector-isolation-red-result.json');
+const SOURCE_SELECTOR_GREEN=path.join(SOURCE_ROOT,'historical-selector-isolation-green-result.json');
+const SOURCE_ARGV_MANIFEST=path.join(STRANDED_ROOT,'generation-30-command-argv-manifest.json');
+const SOURCE_ARGV_APPROVAL=path.join(STRANDED_ROOT,'generation-30-argv-approval.json');
+const GENERATION30_FAILURE_PATH=path.join(STRANDED_ROOT,'generation-30-first-self-test-failure.json');
+const GENERATION31_FAILURE_PATH=path.join(STRANDED_ROOT,'generation-31-builder-failure.json');
+const FAILURE_PATH=path.join(STRANDED_ROOT,'generation-32-builder-failure.json');
+const GENERATION32_CANDIDATE_ROOT=path.join(STRANDED_ROOT,'generation-32-candidates');
+const GENERATION32_BUILDER_PATH=path.join(
+  GENERATION32_CANDIDATE_ROOT,'build-generation-32-candidates.mjs');
+const GENERATION32_RED_PREP=path.join(GENERATION32_CANDIDATE_ROOT,'prep-tool-red.mjs');
+const ARGV_MANIFEST_PATH=path.join(STRANDED_ROOT,'generation-33-command-argv-manifest.json');
+const ARGV_APPROVAL_PATH=path.join(STRANDED_ROOT,'generation-33-argv-approval.json');
+const LIVE_PREP=path.join(PREPARATION_ROOT,'prep-tool-r2.mjs');
+const LIVE_EXECUTOR=path.join(PREPARATION_ROOT,'executor.mjs');
+const GENERATION_ROOT=path.join(PREPARATION_ROOT,'generation-33');
+const FIRST_SELF_TEST=path.join(PREPARATION_ROOT,'prep-tool-r33-gate0-command-self-test.json');
+const POST_SELF_TEST=path.join(PREPARATION_ROOT,'prep-tool-r33-post-authoring-self-test.json');
+
+const AUTH=Object.freeze({
+  plan_sha256:'bfb62d4eee3ced99b59a55350f93d71ddcd4777da2af248ef8137357c0091d9f',
+  plan_approval_raw_sha256:'664623686d2324037bc150b6443f62d1e06d700cef07faeda93477bfe7cc4d20',
+  spec_sha256:'526ca481efd9c1f0586ceb499fd524cc0fe05f1eb558b59e991112cd04dadf76',
+  spec_approval_raw_sha256:'65f371775b9571db764868ac10d2762eee54e98e99cef64873cfc97a61e05c14',
+  source_prep_sha256:'b75a51ae5f5de1ab7b1eb76ba76a051ef67bbf571e8da3627640549e49f6cb94',
+  source_executor_sha256:'79fb366c1f2554b63e2d0e6a3615ecd520c9d9f6706362c5c043b834f6db6c33',
+  source_candidate_manifest_raw_sha256:'dd3dcf82ff0f7168968c6421edeb5e845390a377b3fa80921ba2a41bb4f957ae',
+  source_candidate_manifest_sha256:'4fc466deef08d16f1789868abda653a0f1e27d2ba858f3b2378357f849700307',
+  source_argv_manifest_raw_sha256:'0c2983ab9938f7fe3d316436283ea51e4f9e7039b6c8076383ab24e7093c45a4',
+  source_argv_approval_raw_sha256:'76c4f53a2c564487e9d5fd1a69fc7c881ef9ca2b068be3e8f82682f3effd2021',
+  source_argv_approval_sha256:'80b0367ca2edd6da6a4f7c8edfe96048f97451c599d653cd40cae9fe2464a5ce',
+  source_projection_red_raw_sha256:'5be5a4c573a3b7edac0b0abd692c2fb3353368565b46a7dbd57de181db73bfaf',
+  source_selector_red_raw_sha256:'6d936071af6a08fa0ec69942b1ff5a1cd53a85d84989085df08225047714b8bf',
+  source_selector_green_raw_sha256:'7c1a07b4e741c6eddf3c80dea9d48c5b295176197449fdeb362d6495859da7b0',
+  production_oid:'092306db8665bcb1c5df8c5c4ac871e051b1c604',
+  test_oid:'4418614ec6c989980bf2fac9cc29be82d1ce1312',
+  runtime_sha256:'1512005dde49dca2a97ef9f7c9de37538a8c6ec61d690e08b64144acbde80e51',
+  platform_sha256:'1493c7515194f01bb99f3b307e7e31f8b57a48186a333643e5f1b9c652eba114',
+});
+const REVIEW_PATHS=Object.freeze(new Map([
+  ['structural',path.join(REVIEWS_ROOT,'native-goal-generation-33-argv-structural.json')],
+  ['semantic',path.join(REVIEWS_ROOT,'native-goal-generation-33-argv-semantic.json')],
+  ['executability',path.join(REVIEWS_ROOT,'native-goal-generation-33-argv-executability.json')],
+]));
+const CHILDREN=Object.freeze([
+  'build-generation-33-candidates.mjs','executor-green.mjs','executor-red-to-green.diff',
+  'executor-red.mjs','executor-source-to-red.diff','prep-tool-green.mjs',
+  'prep-tool-red-to-green.diff','prep-tool-red.mjs','prep-tool-source-to-red.diff',
+  'program-candidate-manifest.json','runtime-parity-green-result.json',
+  'runtime-parity-red-result.json',
+].sort(compareBytes));
+
+function fail(code,detail=''){const error=new Error(`${code}${detail?`:${detail}`:''}`);error.code=code;throw error;}
+function compareBytes(a,b){return Buffer.compare(Buffer.from(a),Buffer.from(b));}
+function canonicalJson(value){
+  if(value===null||typeof value!=='object')return JSON.stringify(value);
+  if(Array.isArray(value))return `[${value.map(canonicalJson).join(',')}]`;
+  return `{${Object.keys(value).sort(compareBytes)
+    .map((key)=>`${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(',')}}`;
+}
+function sha256(bytes){return crypto.createHash('sha256').update(bytes).digest('hex');}
+function semanticDigest(domain,value,omitted){
+  const copy=structuredClone(value);delete copy[omitted];
+  return sha256(Buffer.concat([Buffer.from(`${domain}\0`),Buffer.from(canonicalJson(copy))]));
+}
+function regularFile(file,{absent=false,max=64*1024*1024}={}){
+  try{
+    const stat=fs.lstatSync(file,{bigint:true});
+    if(!stat.isFile()||stat.isSymbolicLink()||stat.size>BigInt(max))fail('regular-file',file);
+    const bytes=fs.readFileSync(file);
+    if(BigInt(bytes.length)!==stat.size)fail('file-size',file);
+    return {bytes,sha256:sha256(bytes),size:bytes.length,stat};
+  }catch(error){
+    if(absent&&error?.code==='ENOENT')return null;
+    throw error;
+  }
+}
+function fsyncDirectory(directory){
+  const fd=fs.openSync(directory,fs.constants.O_RDONLY);
+  try{fs.fsyncSync(fd);}finally{fs.closeSync(fd);}
+}
+function writeExclusive(file,bytes){
+  const expected=Buffer.from(bytes);
+  try{
+    const fd=fs.openSync(file,fs.constants.O_CREAT|fs.constants.O_EXCL|fs.constants.O_WRONLY,0o600);
+    try{fs.writeFileSync(fd,expected);fs.fsyncSync(fd);}finally{fs.closeSync(fd);}
+    fsyncDirectory(path.dirname(file));
+  }catch(error){
+    if(error?.code!=='EEXIST')throw error;
+    if(Buffer.compare(regularFile(file).bytes,expected)!==0)fail('existing-byte-drift',file);
+  }
+  if(Buffer.compare(regularFile(file).bytes,expected)!==0)fail('reopen-byte-drift',file);
+}
+function parse(file,digest=null){
+  const retained=regularFile(file);
+  if(digest!==null&&retained.sha256!==digest)fail('raw-authority',file);
+  try{return {retained,value:JSON.parse(retained.bytes.toString('utf8'))};}
+  catch{fail('json-authority',file);}
+}
+function exactReplace(text,from,to,count=1){
+  const observed=text.split(from).length-1;
+  if(observed!==count)fail('replacement-count',`${from}:${observed}`);
+  return text.replaceAll(from,to);
+}
+function gitText(args){
+  const result=spawnSync('git',args,{cwd:SCRATCH_ROOT,encoding:'utf8'});
+  if(result.status!==0||result.signal!==null||result.stderr!=='')fail('git-authority',args.join(' '));
+  return result.stdout.trim();
+}
+function nodeIdentity(){
+  const real=fs.realpathSync(process.execPath),stat=fs.lstatSync(real,{bigint:true});
+  return {path:real,version:process.versions.node,sha256:sha256(fs.readFileSync(real)),
+    dev:String(stat.dev),ino:String(stat.ino),mode:String(stat.mode),size:String(stat.size),
+    mtime_ns:String(stat.mtimeNs)};
+}
+function fileRow(role,file,base=CANDIDATE_ROOT){
+  const retained=regularFile(file);
+  return {role,path:path.relative(base,file).split(path.sep).join('/'),
+    sha256:retained.sha256,size:retained.size};
+}
+function sealTree(root){
+  const rows=[];
+  function visit(current,relative){
+    const stat=fs.lstatSync(current,{bigint:true});
+    if(stat.isSymbolicLink())fail('seal-symlink',current);
+    if(stat.isDirectory()){
+      const names=fs.readdirSync(current).sort(compareBytes);
+      rows.push({path:relative,type:'directory',mode:String(stat.mode),
+        children:names.map((name)=>[name,fs.lstatSync(path.join(current,name)).isDirectory()?'directory':'file'])});
+      for(const name of names)visit(path.join(current,name),relative?`${relative}/${name}`:name);
+    }else if(stat.isFile()){
+      const bytes=fs.readFileSync(current);
+      rows.push({path:relative,type:'file',mode:String(stat.mode),size:bytes.length,sha256:sha256(bytes)});
+    }else fail('seal-type',current);
+  }
+  visit(root,'');
+  return sha256(Buffer.from(canonicalJson(rows)));
+}
+function assertAuthority({allowAdopted=false,expectedPrep=null,expectedExecutor=null}={}){
+  const exact=[
+    [PLAN_PATH,AUTH.plan_sha256],[PLAN_APPROVAL_PATH,AUTH.plan_approval_raw_sha256],
+    [SPEC_PATH,AUTH.spec_sha256],[SPEC_APPROVAL_PATH,AUTH.spec_approval_raw_sha256],
+    [SOURCE_PREP,AUTH.source_prep_sha256],[SOURCE_EXECUTOR,AUTH.source_executor_sha256],
+    [SOURCE_CANDIDATE_MANIFEST,AUTH.source_candidate_manifest_raw_sha256],
+    [SOURCE_ARGV_MANIFEST,AUTH.source_argv_manifest_raw_sha256],
+    [SOURCE_ARGV_APPROVAL,AUTH.source_argv_approval_raw_sha256],
+    [SOURCE_PROJECTION_RED,AUTH.source_projection_red_raw_sha256],
+    [SOURCE_SELECTOR_RED,AUTH.source_selector_red_raw_sha256],
+    [SOURCE_SELECTOR_GREEN,AUTH.source_selector_green_raw_sha256],
+    [GENERATION30_FAILURE_PATH,'652be9224de0b0c3aa8cbb0425579435361de42f16e4a318982c9e1092815262'],
+    [GENERATION31_FAILURE_PATH,'263dbabf3d68d54559da25450fb82d4f0cdeadd83904e80b7e3d5aeca40ea307'],
+    [GENERATION32_BUILDER_PATH,'58044989986019096737c553ea1d0cfd8fb333c2d36e55100e3a1d3271a4eff5'],
+    [path.join(SCRATCH_ROOT,'runtime','bootstrap-runtime.js'),AUTH.runtime_sha256],
+    [path.join(SCRATCH_ROOT,'runtime','platform.js'),AUTH.platform_sha256],
+  ];
+  for(const [file,digest] of exact)if(regularFile(file).sha256!==digest)fail('authority-drift',file);
+  retainedGeneration32Children();
+  if(gitText(['rev-parse','HEAD'])!==AUTH.production_oid||
+    gitText(['rev-parse','bootstrap-v614-test-r10'])!==AUTH.test_oid||
+    gitText(['rev-parse','bootstrap-v614-production-r10'])!==AUTH.production_oid)
+    fail('ref-authority');
+  const planApproval=parse(PLAN_APPROVAL_PATH).value;
+  if(planApproval.plan_sha256!==AUTH.plan_sha256||planApproval.replan_epoch!==35||
+    planApproval.active_generation!==33||planApproval.verdict!=='APPROVE'||
+    !Array.isArray(planApproval.reviews)||planApproval.reviews.length!==3)
+    fail('plan-approval-authority');
+  const sourceManifest=parse(SOURCE_CANDIDATE_MANIFEST).value;
+  if(sourceManifest.manifest_sha256!==AUTH.source_candidate_manifest_sha256)
+    fail('source-candidate-manifest');
+  const sourceArgv=parse(SOURCE_ARGV_MANIFEST).value;
+  const sourceApproval=parse(SOURCE_ARGV_APPROVAL).value;
+  if(sourceApproval.approval_sha256!==AUTH.source_argv_approval_sha256||
+    sourceApproval.candidate_manifest_sha256!==AUTH.source_candidate_manifest_sha256||
+    sourceApproval.argv_manifest_raw_sha256!==AUTH.source_argv_manifest_raw_sha256||
+    sourceApproval.verdict!=='APPROVE')fail('source-argv-approval');
+  for(const [file,digest] of [[SOURCE_PROJECTION_RED,AUTH.source_projection_red_raw_sha256],
+    [SOURCE_SELECTOR_RED,AUTH.source_selector_red_raw_sha256],
+    [SOURCE_SELECTOR_GREEN,AUTH.source_selector_green_raw_sha256]]){
+    const value=parse(file).value;
+    if(value.pre_seal_sha256!==value.post_seal_sha256||value.no_target_writes!==true)
+      fail('source-evidence-seal',file);
+    if(!sourceManifest.external_red_result_raw_sha256&&file===SOURCE_PROJECTION_RED)
+      fail('source-evidence-binding',file);
+    if(file===SOURCE_PROJECTION_RED&&sourceManifest.external_red_result_raw_sha256!==digest)
+      fail('source-evidence-binding',file);
+    if(file===SOURCE_SELECTOR_RED&&sourceManifest.selector_red_result_raw_sha256!==digest)
+      fail('source-evidence-binding',file);
+    if(file===SOURCE_SELECTOR_GREEN&&sourceManifest.selector_green_result_raw_sha256!==digest)
+      fail('source-evidence-binding',file);
+  }
+  const livePrep=regularFile(LIVE_PREP).sha256,liveExecutor=regularFile(LIVE_EXECUTOR).sha256;
+  if(!allowAdopted){
+    if(livePrep!==AUTH.source_prep_sha256||liveExecutor!==AUTH.source_executor_sha256)
+      fail('live-source-authority');
+  }else if(![AUTH.source_prep_sha256,expectedPrep].includes(livePrep)||
+    ![AUTH.source_executor_sha256,expectedExecutor].includes(liveExecutor)||
+    (livePrep===AUTH.source_prep_sha256&&liveExecutor===expectedExecutor))
+    fail('live-adoption-authority');
+  if(fs.existsSync(GENERATION_ROOT)||fs.existsSync(FIRST_SELF_TEST)||fs.existsSync(POST_SELF_TEST))
+    fail('generation33-output-preexists');
+  return {sourceManifest,sourceArgv};
+}
+function retainedGeneration30Failure(){
+  const parsed=parse(GENERATION30_FAILURE_PATH,'652be9224de0b0c3aa8cbb0425579435361de42f16e4a318982c9e1092815262');
+  if(parsed.value.artifact_kind!=='Generation30FirstSelfTestFailureV1'||
+    semanticDigest('generation-30-first-self-test-failure-v1',parsed.value,'failure_sha256')!==parsed.value.failure_sha256)
+    fail('generation30-failure-authority');
+  return {value:parsed.value,raw_sha256:parsed.retained.sha256};
+}
+function retainedGeneration31Failure(){
+  const parsed=parse(GENERATION31_FAILURE_PATH,'263dbabf3d68d54559da25450fb82d4f0cdeadd83904e80b7e3d5aeca40ea307');
+  if(parsed.value.artifact_kind!=='Generation31BuilderFailureV1'||
+    parsed.value.generation31_builder_raw_sha256!=='16bff77cdb28334577956d987a47bcd6d4f5334a9b832a21b0fc282cb3ed0c97'||
+    semanticDigest('generation-31-builder-failure-v1',parsed.value,'failure_sha256')!==
+      parsed.value.failure_sha256)
+    fail('generation31-failure-authority');
+  return {value:parsed.value,raw_sha256:parsed.retained.sha256};
+}
+function retainedGeneration32Children(){
+  const expected=new Map([
+    ['build-generation-32-candidates.mjs',['58044989986019096737c553ea1d0cfd8fb333c2d36e55100e3a1d3271a4eff5',40906]],
+    ['executor-green.mjs',['352217ba87108c0ee8fdb29c5dbce8333d0b13de79482da146ff24da1a8dc1ee',144303]],
+    ['executor-red-to-green.diff',['e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',0]],
+    ['executor-red.mjs',['352217ba87108c0ee8fdb29c5dbce8333d0b13de79482da146ff24da1a8dc1ee',144303]],
+    ['executor-source-to-red.diff',['8fbf06ecc7a64dce88707eff048058a4edefbe76507596f7864cad27f029ab4a',27949]],
+    ['prep-tool-green.mjs',['bc294ca464e9d814e93962cc6cecd584e07beecce72ef649fb1bb0273a1cd306',461533]],
+    ['prep-tool-red-to-green.diff',['d9d958bdc5a937ee4681b469e64d2a5b14537ea7886df3f1fdc49596a95fe6de',584]],
+    ['prep-tool-red.mjs',['f38f7903463fd520f5011e8267fa171e30bc1030cb75597d98737a8ab058a1b1',461483]],
+    ['prep-tool-source-to-red.diff',['6eb9d8cd5bd3466f9ccc4fbeb47deda0c39705f0688bc7f0d9c39bfd61109024',48458]],
+  ]);
+  const names=fs.readdirSync(GENERATION32_CANDIDATE_ROOT).sort(compareBytes);
+  if(canonicalJson(names)!==canonicalJson([...expected.keys()].sort(compareBytes)))
+    fail('generation32-child-set');
+  return names.map((name)=>{
+    const retained=regularFile(path.join(GENERATION32_CANDIDATE_ROOT,name));
+    const [digest,size]=expected.get(name);
+    if(retained.sha256!==digest||retained.size!==size)fail('generation32-child-authority',name);
+    return {path:name,sha256:digest,size};
+  });
+}
+function reproduceGeneration32Failure(){
+  const expected=Buffer.from('[bootstrap-manifest-exclusions]\n','utf8');
+  const encoded='W2Jvb3RzdHJhcC1tYW5pZmVzdC1leGNsdXNpb25zXQo=';
+  const decoded=Buffer.from(encoded,'base64');
+  const rejectedSuffix=Buffer.from([0x5c,0x6e]);
+  if(expected.length!==32||Buffer.compare(expected,decoded)!==0||
+    expected.toString('base64')!==encoded||
+    sha256(expected)!=='3c4249e61087cc18e115b755eb2a5642d986ae5480cfee4dbae2ff986aae7d20'||
+    expected.subarray(-2).equals(rejectedSuffix))
+    fail('generation32-red-signal-self-test');
+  const argv=[process.execPath,GENERATION32_RED_PREP,'self-test-generation32-runtime-parity'];
+  const pre={prep:sealTree(SCRATCH_ROOT),target:sealTree(TARGET_ROOT),main:sealTree(MAIN_ROOT)};
+  const result=spawnSync(argv[0],argv.slice(1),{cwd:PREPARATION_ROOT,encoding:null,
+    timeout:60_000,maxBuffer:1024*1024,stdio:['ignore','pipe','pipe'],
+    env:{HOME:process.env.HOME||'/nonexistent',LANG:'C',LC_ALL:'C',NO_COLOR:'1',
+      FORCE_COLOR:'0',PATH:`${path.dirname(process.execPath)}:/usr/bin`}});
+  const timedOut=result.error?.code==='ETIMEDOUT',outputOverflow=result.error?.code==='ENOBUFS';
+  const stdout=Buffer.from(result.stdout||''),stderr=Buffer.from(result.stderr||'');
+  const post={prep:sealTree(SCRATCH_ROOT),target:sealTree(TARGET_ROOT),main:sealTree(MAIN_ROOT)};
+  if(canonicalJson(pre)!==canonicalJson(post))fail('generation32-reproduction-write');
+  if(result.status!==2||result.signal!==null||timedOut||outputOverflow||stdout.length!==0||
+    Buffer.compare(stderr,expected)!==0||stderr.length!==32||
+    stderr.toString('base64')!==encoded||
+    sha256(stderr)!=='3c4249e61087cc18e115b755eb2a5642d986ae5480cfee4dbae2ff986aae7d20')
+    fail('generation32-reproduction-signal');
+  return {argv,stdout,stderr,process:{exit_code:result.status,signal:result.signal,
+    timed_out:timedOut,output_overflow:outputOverflow}};
+}
+function publishFailure(){
+  const gen31=retainedGeneration31Failure(),children=retainedGeneration32Children();
+  if(fs.existsSync(path.join(STRANDED_ROOT,'generation-32-command-argv-manifest.json'))||
+    fs.existsSync(path.join(STRANDED_ROOT,'generation-32-argv-approval.json'))||
+    fs.existsSync(path.join(PREPARATION_ROOT,'generation-32'))||
+    fs.existsSync(path.join(PREPARATION_ROOT,'prep-tool-r32-gate0-command-self-test.json'))||
+    fs.existsSync(path.join(PREPARATION_ROOT,'prep-tool-r32-post-authoring-self-test.json'))||
+    fs.existsSync('/Users/sungmin/Dev/claude-plugins/deep-work/.claude/worktrees/v6-14-bootstrap-simulation-g32'))
+    fail('generation32-terminal-output-present');
+  for(const name of ['runtime-parity-red-result.json','runtime-parity-green-result.json',
+    'program-candidate-manifest.json'])
+    if(fs.existsSync(path.join(GENERATION32_CANDIDATE_ROOT,name)))
+      fail('generation32-result-present',name);
+  const run=reproduceGeneration32Failure();
+  const failure={schema_version:1,artifact_kind:'Generation32BuilderFailureV1',
+    stage:'diagnostic-retained',plan_sha256:AUTH.plan_sha256,
+    plan_approval_raw_sha256:AUTH.plan_approval_raw_sha256,spec_approved_hash:AUTH.spec_sha256,
+    spec_approval_raw_sha256:AUTH.spec_approval_raw_sha256,
+    generation32_builder_raw_sha256:'58044989986019096737c553ea1d0cfd8fb333c2d36e55100e3a1d3271a4eff5',
+    generation31_failure_raw_sha256:gen31.raw_sha256,
+    generation31_failure_sha256:gen31.value.failure_sha256,candidate_children:children,
+    red_prep_raw_sha256:'f38f7903463fd520f5011e8267fa171e30bc1030cb75597d98737a8ab058a1b1',
+    reproduction_argv:run.argv,reproduction_cwd:PREPARATION_ROOT,node_identity:nodeIdentity(),
+    reproduction_process:run.process,reproduction_stdout_sha256:sha256(run.stdout),
+    reproduction_stderr_sha256:sha256(run.stderr),
+    reproduction_stderr_base64:run.stderr.toString('base64'),
+    observed_failure_code:'parity-red-signal',raw_capture_status:'reproduced-read-only',
+    parity_results_absent:true,candidate_manifest_absent:true,argv_manifest_absent:true,
+    generation32_root_absent:true,simulation_absent:true,
+    live_prep_sha256:AUTH.source_prep_sha256,live_executor_sha256:AUTH.source_executor_sha256,
+    trusted_conclusion:'generation-32-stranded-before-parity-result-due-to-red-stderr-double-escape',
+    failure_sha256:null};
+  failure.failure_sha256=semanticDigest('generation-32-builder-failure-v1',failure,'failure_sha256');
+  writeExclusive(FAILURE_PATH,Buffer.from(canonicalJson(failure)));
+  const retained=parse(FAILURE_PATH);
+  if(canonicalJson(retained.value)!==canonicalJson(failure)||
+    semanticDigest('generation-32-builder-failure-v1',retained.value,'failure_sha256')!==
+      retained.value.failure_sha256)
+    fail('generation32-failure-reopen');
+  return {value:failure,raw_sha256:retained.retained.sha256};
+}
+function transformActive(source,role){
+  let text=source;
+  const replacements=[
+    ['b093aa59c3805b215c6bd4ec8d017ca1bef1b6d4657129157e0a8e3013e0bd15',AUTH.plan_sha256],
+    ['95ba4f2379d5db83b7fd5ecd03629ebd21b7a6c3f8d9827534a6dc52588aebd2',
+      AUTH.plan_approval_raw_sha256],
+    ['09553be6bd8dc633772f9cd051e3fbc9fdb8dce4a734bbf092d6f058c787ff63',
+      AUTH.spec_approval_raw_sha256],
+    ['6323abc37d11b27a069a7106a42b2aa43f3fdd76c439527984c0f12d429e8639',
+      'bd221da12f63260310044e2b6868d82a2faa777137f0e04d35ab094b8e8b8db8'],
+    ['aa31f0f35830ebd87ad269e45093b0a3a1b59d4a7600da8b2f1d5d3433a37da2',
+      'f9ee45af15ed2a13958cbda188ae0c81aaae6410b9e132e26db8aaa22f1f7439'],
+    ['ac73caf67b2e63b0873c02454976417eee2858fcc40d1c4fed7ebb159c721d6e',
+      'ac038cd0d581626646161e130d014058f6ae4f5c75fe9c89f52aa3a98b6eca93'],
+    ['a944149830bfe7455556b766da7303a1f0284400bb0197167ef96c244ed0dd47',
+      '5d94993034eb99e0b5d9bb98b8377aeef550bda46bdae0c4560c4bd4428b9f7c'],
+    ['a0f52a2f26b07866d980a88723c3da5bbb0251a6820a393b541e13cd333653a1',
+      'f2dfec985e20c11b419df39d7e177c3b3bb72d9f3b62da0f540973e8122663eb'],
+    ['37dc3e09d8e03102a942c25a2059344d82aef26060169535fe757aaf8e822b3f',
+      'd1914f978cbc4c2372a58a74889acd429cb1398da1081e3efe57664296731505'],
+    ['PLAN_E32','PLAN_E35'],['SPEC_E32','SPEC_E35'],
+    ['native-goal-plan-e32-r1','native-goal-plan-e35-r2'],
+    ['native-goal-spec-e32-r1','native-goal-spec-e35-r1'],
+    ['plan-approval-native-goal-e32.json','plan-approval-native-goal-e35.json'],
+    ['spec-approval-native-goal-e32.json','spec-approval-native-goal-e35.json'],
+    ['GENERATION30','GENERATION33'],['Generation30','Generation33'],
+    ['generation30','generation33'],['generation-30','generation-33'],
+    ['simulation-g30','simulation-g33'],['prep-tool-r30','prep-tool-r33'],
+  ];
+  for(const [from,to] of replacements)text=text.replaceAll(from,to);
+  text=text.replaceAll('replan_epoch!==32','replan_epoch!==35')
+    .replaceAll('replan_epoch !== 32','replan_epoch !== 34')
+    .replaceAll('active_generation!==30','active_generation!==33')
+    .replaceAll('active_generation !== 30','active_generation !== 32')
+    .replaceAll('active_generation: 30','active_generation: 33')
+    .replaceAll('active_generation:30','active_generation:32')
+    .replaceAll('review_round !== 55','review_round !== 58')
+    .replaceAll('review_round!==55','review_round!==57')
+    .replaceAll('generation: 30','generation: 33').replaceAll('generation:30','generation:32')
+    .replaceAll('generation!==30','generation!==33').replaceAll('generation !== 30','generation !== 32')
+    .replaceAll("flags.generation === '30'","flags.generation === '33'")
+    .replaceAll("flags.generation !== '30'","flags.generation !== '33'");
+  if(role==='prep-tool'){
+    const oldRoot=`const PREPARATION_ROOT = process.argv[2]===
+  'self-test-historical-selector-isolation'?
+  ${JSON.stringify(PREPARATION_ROOT)}:path.dirname(SCRIPT_PATH);`;
+    const newRoot=`const PREPARATION_ROOT =
+  process.argv[2]==='self-test-historical-selector-isolation'||
+  process.argv[2]==='self-test-generation33-runtime-parity'?
+  ${JSON.stringify(PREPARATION_ROOT)}:path.dirname(SCRIPT_PATH);`;
+    text=exactReplace(text,oldRoot,newRoot);
+    const marker="if(process.argv[2]==='self-test-historical-selector-isolation'){";
+    const parity=`if(process.argv[2]==='self-test-generation33-runtime-parity'){
+  try{
+    if(process.argv.length!==3)fail('generation-33-runtime-parity-argv');
+    process.stdout.write(\`\${canonicalJson({...runRuntimeDigestParitySelfTest(),pass:true})}\\n\`);
+  }catch(error){
+    process.stderr.write(\`[\${error.code||'generation-33-runtime-parity'}]\\n\`);
+    process.exitCode=2;
+  }
+}else ${marker}`;
+    text=exactReplace(text,marker,parity);
+  }else if(role==='executor'){
+    if((text.match(/self-test-initialization/gu)||[]).length===0||
+      (text.match(/self-test-generation33-runtime-parity/gu)||[]).length!==0)
+      fail('executor-prefix-authority');
+  }else fail('transform-role',role);
+  return text;
+}
+function greenFromRed(red){
+  return exactReplace(red,
+    "  base.manifest_sha256 = runtimeSemanticDigest('bootstrap-manifest-v1', base, 'manifest_sha256');",
+    "  base.excluded_paths = bootstrapExcludedPaths();\n"+
+    "  base.manifest_sha256 = runtimeSemanticDigest('bootstrap-manifest-v1', base, 'manifest_sha256');");
+}
+function transformVector(value){
+  if(typeof value==='string')return value
+    .replaceAll('generation-30','generation-33').replaceAll('simulation-g30','simulation-g33')
+    .replaceAll('prep-tool-r30-','prep-tool-r33-')
+    .replaceAll('plan-approval-native-goal-e32.json','plan-approval-native-goal-e35.json');
+  if(Array.isArray(value)){
+    const output=value.map(transformVector);
+    for(let index=0;index<output.length-1;index++)
+      if(output[index]==='--generation'&&output[index+1]==='30')output[index+1]='32';
+    return output;
+  }
+  if(value&&typeof value==='object')
+    return Object.fromEntries(Object.entries(value).map(([key,item])=>[key,transformVector(item)]));
+  return value;
+}
+function normalizedDiff(source,candidate,transition){
+  const result=spawnSync('git',['diff','--no-index','--binary','--',source,candidate],
+    {encoding:null,maxBuffer:32*1024*1024});
+  if(result.status===0&&result.signal===null&&Buffer.from(result.stderr||'').length===0)
+    return Buffer.alloc(0);
+  if(result.status!==1||result.signal!==null||Buffer.from(result.stderr||'').length!==0)
+    fail('candidate-diff',transition);
+  let text=Buffer.from(result.stdout).toString('utf8');
+  const from=transition==='source-to-red'?'source':'red';
+  const to=transition==='source-to-red'?'red':'green';
+  text=text.replace(/^diff --git .*$/mu,`diff --git a/${from} b/${to}`)
+    .replace(/^--- .*$/mu,`--- a/${from}`).replace(/^\+\+\+ .*$/mu,`+++ b/${to}`);
+  if(!text.endsWith('\n'))fail('candidate-diff-terminal',transition);
+  return Buffer.from(text);
+}
+function runParity(program,expectedExit){
+  const argv=[process.execPath,program,'self-test-generation33-runtime-parity'];
+  const result=spawnSync(argv[0],argv.slice(1),{cwd:PREPARATION_ROOT,encoding:null,
+    timeout:60_000,maxBuffer:1024*1024,stdio:['ignore','pipe','pipe'],
+    env:{HOME:process.env.HOME||'/nonexistent',LANG:'C',LC_ALL:'C',NO_COLOR:'1',
+      FORCE_COLOR:'0',PATH:`${path.dirname(process.execPath)}:/usr/bin`}});
+  const timedOut=result.error?.code==='ETIMEDOUT';
+  const outputOverflow=result.error?.code==='ENOBUFS';
+  if(result.status!==expectedExit||result.signal!==null||timedOut||outputOverflow)
+    fail('parity-process',`${expectedExit}:${result.status}`);
+  return {argv,exit_code:result.status,signal:result.signal,timed_out:timedOut,
+    output_overflow:outputOverflow,stdout:Buffer.from(result.stdout||''),
+    stderr:Buffer.from(result.stderr||'')};
+}
+function parityResult(kind,stage,run,sourceRows,candidateRows,failure,preSeal,postSeal){
+  const red=stage==='red-verified',gen30=retainedGeneration30Failure(),
+    gen31=retainedGeneration31Failure();
+  let observed=null;
+  if(red){
+    if(run.stdout.length!==0||run.stderr.toString('utf8')!=='[bootstrap-manifest-exclusions]\n')
+      fail('parity-red-signal');
+  }else{
+    if(run.stderr.length!==0||!run.stdout.toString('utf8').endsWith('\n'))fail('parity-green-signal');
+    try{observed=JSON.parse(run.stdout.toString('utf8'));}catch{fail('parity-green-json');}
+    const keys=['manifest_sha256','normalized_stdout_semantic_sha256','pass',
+      'patch_review_sha256','schema_sha256','witness_sha256'].sort(compareBytes);
+    if(canonicalJson(Object.keys(observed).sort(compareBytes))!==canonicalJson(keys)||
+      observed.pass!==true||keys.filter((key)=>key!=='pass')
+        .some((key)=>!/^[0-9a-f]{64}$/u.test(observed[key]||'')))fail('parity-green-value');
+  }
+  const value={
+    schema_version:1,artifact_kind:kind,stage,plan_sha256:AUTH.plan_sha256,
+    plan_approval_raw_sha256:AUTH.plan_approval_raw_sha256,spec_approved_hash:AUTH.spec_sha256,
+    spec_approval_raw_sha256:AUTH.spec_approval_raw_sha256,
+    generation30_failure_raw_sha256:gen30.raw_sha256,
+    generation30_failure_sha256:gen30.value.failure_sha256,
+    generation31_failure_raw_sha256:gen31.raw_sha256,
+    generation31_failure_sha256:gen31.value.failure_sha256,
+    generation32_failure_raw_sha256:failure.raw_sha256,
+    generation32_failure_sha256:failure.value.failure_sha256,
+    source_programs:sourceRows,candidate_programs:candidateRows,argv:run.argv,
+    cwd:PREPARATION_ROOT,node_identity:nodeIdentity(),exit_code:run.exit_code,signal:run.signal,
+    timed_out:run.timed_out,output_overflow:run.output_overflow,
+    stdout_sha256:sha256(run.stdout),stderr_sha256:sha256(run.stderr),
+    expected_rejection_code:red?'bootstrap-manifest-exclusions':null,
+    observed_rejection_code:red?'bootstrap-manifest-exclusions':null,
+    pre_seal_sha256:preSeal,post_seal_sha256:postSeal,observed_parity:observed,
+    parity_assertions:{fixture_excluded_paths_reprojected:!red,
+      production_validator_unchanged:true,pass:!red},
+    no_generation33_writes:true,no_target_writes:true,result_sha256:null,
+  };
+  value.result_sha256=semanticDigest(
+    red?'generation-33-runtime-parity-red-result-v1':
+      'generation-33-runtime-parity-green-result-v1',value,'result_sha256');
+  return value;
+}
+function candidateManifest(sourceManifest,argvSource,failure,redResult,greenResult){
+  const gen30=retainedGeneration30Failure(),gen31=retainedGeneration31Failure();
+  const sourceRows=[
+    fileRow('executor',SOURCE_EXECUTOR,PREPARATION_ROOT),
+    fileRow('prep-tool',SOURCE_PREP,PREPARATION_ROOT),
+  ].sort((a,b)=>compareBytes(a.role,b.role));
+  const redRows=[
+    fileRow('executor',path.join(CANDIDATE_ROOT,'executor-red.mjs')),
+    fileRow('prep-tool',path.join(CANDIDATE_ROOT,'prep-tool-red.mjs')),
+  ].sort((a,b)=>compareBytes(a.role,b.role));
+  const greenRows=[
+    fileRow('executor',path.join(CANDIDATE_ROOT,'executor-green.mjs')),
+    fileRow('prep-tool',path.join(CANDIDATE_ROOT,'prep-tool-green.mjs')),
+  ].sort((a,b)=>compareBytes(a.role,b.role));
+  const diffRefs=[
+    ['executor','red-to-green','executor-red-to-green.diff'],
+    ['executor','source-to-red','executor-source-to-red.diff'],
+    ['prep-tool','red-to-green','prep-tool-red-to-green.diff'],
+    ['prep-tool','source-to-red','prep-tool-source-to-red.diff'],
+  ].map(([role,transition,name])=>({...fileRow(role,path.join(CANDIDATE_ROOT,name)),transition}))
+    .sort((a,b)=>compareBytes(`${a.role}\0${a.transition}`,`${b.role}\0${b.transition}`));
+  const successorVectors=transformVector(argvSource.successor_vectors);
+  const value={
+    schema_version:1,artifact_kind:'Generation33ProgramCandidateManifestV1',
+    plan_sha256:AUTH.plan_sha256,plan_approval_raw_sha256:AUTH.plan_approval_raw_sha256,
+    spec_approved_hash:AUTH.spec_sha256,spec_approval_raw_sha256:AUTH.spec_approval_raw_sha256,
+    source_argv_manifest_raw_sha256:AUTH.source_argv_manifest_raw_sha256,
+    source_argv_manifest_sha256:argvSource.manifest_sha256,
+    builder_sha256:regularFile(SCRIPT_PATH).sha256,source_programs:sourceRows,
+    red_candidates:redRows,green_candidates:greenRows,diff_refs:diffRefs,
+    change_families:[...sourceManifest.change_families,'historical-parity-fixture-projection']
+      .sort(compareBytes),
+    runtime_binding:sourceManifest.runtime_binding,
+    external_red_result_raw_sha256:AUTH.source_projection_red_raw_sha256,
+    selector_red_result_raw_sha256:AUTH.source_selector_red_raw_sha256,
+    selector_green_result_raw_sha256:AUTH.source_selector_green_raw_sha256,
+    generation30_failure_raw_sha256:gen30.raw_sha256,
+    generation30_failure_sha256:gen30.value.failure_sha256,
+    generation31_failure_raw_sha256:gen31.raw_sha256,
+    generation31_failure_sha256:gen31.value.failure_sha256,
+    generation32_failure_raw_sha256:failure.raw_sha256,
+    generation32_failure_sha256:failure.value.failure_sha256,
+    parity_red_result_raw_sha256:regularFile(
+      path.join(CANDIDATE_ROOT,'runtime-parity-red-result.json')).sha256,
+    parity_red_result_sha256:redResult.result_sha256,
+    parity_green_result_raw_sha256:regularFile(
+      path.join(CANDIDATE_ROOT,'runtime-parity-green-result.json')).sha256,
+    parity_green_result_sha256:greenResult.result_sha256,
+    successor_vectors:successorVectors,
+    substitution_rules:[
+      {from:'generation-30',to:'generation-33'},{from:'simulation-g30',to:'simulation-g33'},
+      {from:'prep-tool-r30-',to:'prep-tool-r33-'},
+      {from:'plan-approval-native-goal-e32.json',to:'plan-approval-native-goal-e35.json'},
+      {from_pair:['--generation','30'],to_pair:['--generation','32']},
+    ],manifest_sha256:null,
+  };
+  value.manifest_sha256=semanticDigest(
+    'generation-33-program-candidate-manifest-v1',value,'manifest_sha256');
+  return value;
+}
+function argvManifest(source,manifest){
+  const value={schema_version:1,artifact_kind:'Generation33CommandArgvManifestV1',
+    source_generation:30,successor_generation:32,
+    source_prep_tool_sha256:AUTH.source_prep_sha256,
+    source_executor_sha256:AUTH.source_executor_sha256,
+    source_vectors:source.successor_vectors,successor_vectors:manifest.successor_vectors,
+    substitution_rules:manifest.substitution_rules,manifest_sha256:null};
+  value.manifest_sha256=semanticDigest(
+    'generation-33-command-argv-manifest-v1',value,'manifest_sha256');
+  return value;
+}
+function validateManifest(){
+  const manifest=parse(path.join(CANDIDATE_ROOT,'program-candidate-manifest.json')).value;
+  if(manifest.artifact_kind!=='Generation33ProgramCandidateManifestV1'||
+    manifest.plan_sha256!==AUTH.plan_sha256||
+    semanticDigest('generation-33-program-candidate-manifest-v1',manifest,'manifest_sha256')!==
+      manifest.manifest_sha256)fail('candidate-manifest');
+  const argv=parse(ARGV_MANIFEST_PATH).value;
+  if(argv.manifest_sha256!==semanticDigest(
+    'generation-33-command-argv-manifest-v1',argv,'manifest_sha256'))fail('argv-manifest');
+  return {manifest,argv};
+}
+function expectedApproval(manifest,argv){
+  const reviewRows=[];
+  for(const role of [...REVIEW_PATHS.keys()].sort(compareBytes)){
+    const file=REVIEW_PATHS.get(role),retained=regularFile(file),value=parse(file).value;
+    const exactKeys=['artifact_kind','findings','generation30_failure_raw_sha256',
+      'generation30_failure_sha256','generation31_failure_raw_sha256',
+      'generation31_failure_sha256','generation32_failure_raw_sha256',
+      'generation32_failure_sha256','reviewed_executor_green_sha256',
+      'reviewed_manifest_sha256','reviewed_parity_green_raw_sha256',
+      'reviewed_parity_green_sha256','reviewed_parity_red_raw_sha256',
+      'reviewed_parity_red_sha256','reviewed_prep_green_sha256',
+      'reviewed_source_projection_red_raw_sha256','reviewed_source_selector_green_raw_sha256',
+      'reviewed_source_selector_red_raw_sha256','reviewer_identity','role','schema_version',
+      'verdict'].sort(compareBytes);
+    if(canonicalJson(Object.keys(value).sort(compareBytes))!==canonicalJson(exactKeys)||
+      value.artifact_kind!=='Generation33ProgramCandidateReviewV1'||value.schema_version!==1||
+      value.role!==role||value.verdict!=='APPROVE'||canonicalJson(value.findings)!=='[]'||
+      value.reviewed_manifest_sha256!==manifest.manifest_sha256||
+      value.reviewed_prep_green_sha256!==
+        manifest.green_candidates.find((row)=>row.role==='prep-tool').sha256||
+      value.reviewed_executor_green_sha256!==
+        manifest.green_candidates.find((row)=>row.role==='executor').sha256||
+      value.reviewed_source_projection_red_raw_sha256!==AUTH.source_projection_red_raw_sha256||
+      value.reviewed_source_selector_red_raw_sha256!==AUTH.source_selector_red_raw_sha256||
+      value.reviewed_source_selector_green_raw_sha256!==AUTH.source_selector_green_raw_sha256||
+      value.reviewed_parity_red_raw_sha256!==manifest.parity_red_result_raw_sha256||
+      value.reviewed_parity_red_sha256!==manifest.parity_red_result_sha256||
+      value.reviewed_parity_green_raw_sha256!==manifest.parity_green_result_raw_sha256||
+      value.reviewed_parity_green_sha256!==manifest.parity_green_result_sha256||
+      value.generation30_failure_raw_sha256!==manifest.generation30_failure_raw_sha256||
+      value.generation30_failure_sha256!==manifest.generation30_failure_sha256||
+      value.generation31_failure_raw_sha256!==manifest.generation31_failure_raw_sha256||
+      value.generation31_failure_sha256!==manifest.generation31_failure_sha256||
+      value.generation32_failure_raw_sha256!==manifest.generation32_failure_raw_sha256||
+      value.generation32_failure_sha256!==manifest.generation32_failure_sha256)
+      fail('candidate-review',role);
+    reviewRows.push({role,path:path.relative(TARGET_ROOT,file).split(path.sep).join('/'),
+      raw_sha256:retained.sha256,reviewer_identity:value.reviewer_identity,verdict:'APPROVE'});
+  }
+  const value={schema_version:1,artifact_kind:'Generation33ArgvApprovalV1',
+    stage:'approved',argv_manifest_path:path.relative(STRANDED_ROOT,ARGV_MANIFEST_PATH),
+    argv_manifest_raw_sha256:regularFile(ARGV_MANIFEST_PATH).sha256,
+    argv_manifest_sha256:argv.manifest_sha256,
+    candidate_manifest_path:'generation-33-candidates/program-candidate-manifest.json',
+    candidate_manifest_raw_sha256:regularFile(
+      path.join(CANDIDATE_ROOT,'program-candidate-manifest.json')).sha256,
+    candidate_manifest_sha256:manifest.manifest_sha256,
+    green_programs:manifest.green_candidates,
+    source_projection_red_raw_sha256:AUTH.source_projection_red_raw_sha256,
+    source_selector_red_raw_sha256:AUTH.source_selector_red_raw_sha256,
+    source_selector_green_raw_sha256:AUTH.source_selector_green_raw_sha256,
+    generation30_failure_raw_sha256:manifest.generation30_failure_raw_sha256,
+    generation30_failure_sha256:manifest.generation30_failure_sha256,
+    generation31_failure_raw_sha256:manifest.generation31_failure_raw_sha256,
+    generation31_failure_sha256:manifest.generation31_failure_sha256,
+    generation32_failure_raw_sha256:manifest.generation32_failure_raw_sha256,
+    generation32_failure_sha256:manifest.generation32_failure_sha256,
+    parity_red_result_raw_sha256:manifest.parity_red_result_raw_sha256,
+    parity_red_result_sha256:manifest.parity_red_result_sha256,
+    parity_green_result_raw_sha256:manifest.parity_green_result_raw_sha256,
+    parity_green_result_sha256:manifest.parity_green_result_sha256,
+    reviews:reviewRows,verdict:'APPROVE',approval_sha256:null};
+  value.approval_sha256=semanticDigest(
+    'generation-33-argv-approval-v1',value,'approval_sha256');
+  return value;
+}
+function reconstructPrograms(){
+  const sourcePrep=regularFile(SOURCE_PREP).bytes.toString('utf8');
+  const sourceExecutor=regularFile(SOURCE_EXECUTOR).bytes.toString('utf8');
+  if((sourcePrep.match(/self-test-historical-selector-isolation/gu)||[]).length===0||
+    (sourceExecutor.match(/self-test-initialization/gu)||[]).length===0||
+    (sourceExecutor.match(/self-test-generation33-runtime-parity/gu)||[]).length!==0)
+    fail('role-prefix-self-test');
+  const redPrep=Buffer.from(transformActive(sourcePrep,'prep-tool'));
+  const redExecutor=Buffer.from(transformActive(sourceExecutor,'executor'));
+  return {redPrep,redExecutor,greenPrep:Buffer.from(greenFromRed(redPrep.toString('utf8'))),
+    greenExecutor:Buffer.from(redExecutor)};
+}
+function reauthenticateAdoption(manifest,expected,expectedPrep,expectedExecutor){
+  assertAuthority({allowAdopted:true,expectedPrep,expectedExecutor});
+  const current=validateManifest();
+  if(current.manifest.manifest_sha256!==manifest.manifest_sha256)fail('adoption-manifest-drift');
+  const recomputed=expectedApproval(current.manifest,current.argv);
+  if(canonicalJson(recomputed)!==canonicalJson(expected)||
+    canonicalJson(parse(ARGV_APPROVAL_PATH).value)!==canonicalJson(expected))
+    fail('adoption-approval-drift');
+  return {livePrep:regularFile(LIVE_PREP).sha256,liveExecutor:regularFile(LIVE_EXECUTOR).sha256};
+}
+function adopt(manifest){
+  const expected=expectedApproval(manifest,parse(ARGV_MANIFEST_PATH).value);
+  if(canonicalJson(parse(ARGV_APPROVAL_PATH).value)!==canonicalJson(expected))fail('approval-authority');
+  const programs=reconstructPrograms();
+  const expectedPrep=sha256(programs.greenPrep),expectedExecutor=sha256(programs.greenExecutor);
+  if(expectedPrep!==manifest.green_candidates.find((row)=>row.role==='prep-tool').sha256||
+    expectedExecutor!==manifest.green_candidates.find((row)=>row.role==='executor').sha256)
+    fail('reconstructed-program');
+  let state=reauthenticateAdoption(manifest,expected,expectedPrep,expectedExecutor);
+  if(state.livePrep===AUTH.source_prep_sha256&&state.liveExecutor===expectedExecutor)fail('adoption-prefix');
+  if(state.livePrep===AUTH.source_prep_sha256){
+    const file=path.join(CANDIDATE_ROOT,'prep-tool-green.mjs');writeExclusive(file,programs.greenPrep);
+    fs.renameSync(file,LIVE_PREP);fsyncDirectory(PREPARATION_ROOT);writeExclusive(file,programs.greenPrep);
+  }
+  state=reauthenticateAdoption(manifest,expected,expectedPrep,expectedExecutor);
+  if(state.livePrep!==expectedPrep||![AUTH.source_executor_sha256,expectedExecutor].includes(state.liveExecutor))
+    fail('prep-adoption-boundary');
+  if(state.liveExecutor===AUTH.source_executor_sha256){
+    const file=path.join(CANDIDATE_ROOT,'executor-green.mjs');writeExclusive(file,programs.greenExecutor);
+    fs.renameSync(file,LIVE_EXECUTOR);fsyncDirectory(PREPARATION_ROOT);writeExclusive(file,programs.greenExecutor);
+  }
+  state=reauthenticateAdoption(manifest,expected,expectedPrep,expectedExecutor);
+  if(state.livePrep!==expectedPrep||state.liveExecutor!==expectedExecutor)fail('executor-adoption-boundary');
+  return expected;
+}
+function build(){
+  const {sourceManifest,sourceArgv}=assertAuthority();
+  const failure=publishFailure();
+  const programs=reconstructPrograms();
+  const paths={
+    redPrep:path.join(CANDIDATE_ROOT,'prep-tool-red.mjs'),
+    redExecutor:path.join(CANDIDATE_ROOT,'executor-red.mjs'),
+    greenPrep:path.join(CANDIDATE_ROOT,'prep-tool-green.mjs'),
+    greenExecutor:path.join(CANDIDATE_ROOT,'executor-green.mjs'),
+  };
+  writeExclusive(paths.redPrep,programs.redPrep);writeExclusive(paths.redExecutor,programs.redExecutor);
+  writeExclusive(paths.greenPrep,programs.greenPrep);
+  writeExclusive(paths.greenExecutor,programs.greenExecutor);
+  const diffs=[
+    [SOURCE_PREP,paths.redPrep,'source-to-red','prep-tool-source-to-red.diff'],
+    [SOURCE_EXECUTOR,paths.redExecutor,'source-to-red','executor-source-to-red.diff'],
+    [paths.redPrep,paths.greenPrep,'red-to-green','prep-tool-red-to-green.diff'],
+    [paths.redExecutor,paths.greenExecutor,'red-to-green','executor-red-to-green.diff'],
+  ];
+  for(const [from,to,transition,name] of diffs)
+    writeExclusive(path.join(CANDIDATE_ROOT,name),normalizedDiff(from,to,transition));
+  const sourceRows=[fileRow('executor',SOURCE_EXECUTOR,PREPARATION_ROOT),
+    fileRow('prep-tool',SOURCE_PREP,PREPARATION_ROOT)].sort((a,b)=>compareBytes(a.role,b.role));
+  const redRows=[fileRow('executor',paths.redExecutor),fileRow('prep-tool',paths.redPrep)]
+    .sort((a,b)=>compareBytes(a.role,b.role));
+  const greenRows=[fileRow('executor',paths.greenExecutor),fileRow('prep-tool',paths.greenPrep)]
+    .sort((a,b)=>compareBytes(a.role,b.role));
+  const preRed={prep:sealTree(SCRATCH_ROOT),target:sealTree(TARGET_ROOT),main:sealTree(MAIN_ROOT)};
+  const redRun=runParity(paths.redPrep,2);
+  const postRed={prep:sealTree(SCRATCH_ROOT),target:sealTree(TARGET_ROOT),main:sealTree(MAIN_ROOT)};
+  if(canonicalJson(preRed)!==canonicalJson(postRed))fail('parity-red-write');
+  const redResult=parityResult('Generation33RuntimeParityRedResultV1','red-verified',
+    redRun,sourceRows,redRows,failure,sha256(Buffer.from(canonicalJson(preRed))),
+    sha256(Buffer.from(canonicalJson(postRed))));
+  writeExclusive(path.join(CANDIDATE_ROOT,'runtime-parity-red-result.json'),
+    Buffer.from(canonicalJson(redResult)));
+  const preGreen={prep:sealTree(SCRATCH_ROOT),target:sealTree(TARGET_ROOT),main:sealTree(MAIN_ROOT)};
+  const greenRun=runParity(paths.greenPrep,0);
+  const postGreen={prep:sealTree(SCRATCH_ROOT),target:sealTree(TARGET_ROOT),main:sealTree(MAIN_ROOT)};
+  if(canonicalJson(preGreen)!==canonicalJson(postGreen))fail('parity-green-write');
+  const greenResult=parityResult('Generation33RuntimeParityGreenResultV1','green-verified',
+    greenRun,sourceRows,greenRows,failure,sha256(Buffer.from(canonicalJson(preGreen))),
+    sha256(Buffer.from(canonicalJson(postGreen))));
+  writeExclusive(path.join(CANDIDATE_ROOT,'runtime-parity-green-result.json'),
+    Buffer.from(canonicalJson(greenResult)));
+  const manifest=candidateManifest(sourceManifest,sourceArgv,failure,redResult,greenResult);
+  writeExclusive(path.join(CANDIDATE_ROOT,'program-candidate-manifest.json'),
+    Buffer.from(canonicalJson(manifest)));
+  const argv=argvManifest(sourceArgv,manifest);
+  writeExclusive(ARGV_MANIFEST_PATH,Buffer.from(canonicalJson(argv)));
+  if(canonicalJson(fs.readdirSync(CANDIDATE_ROOT).sort(compareBytes))!==canonicalJson(CHILDREN))
+    fail('candidate-child-set');
+  return {manifest,argv};
+}
+function main(){
+  const command=process.argv.slice(2);
+  if(command.length>1||command.length===1&&!['materialize-approval','adopt'].includes(command[0]))
+    fail('builder-argv');
+  if(command.length===0){
+    const {manifest}=build();
+    process.stdout.write(`${canonicalJson({ok:true,stage:'candidate-ready',
+      manifest_sha256:manifest.manifest_sha256})}\n`);return;
+  }
+  assertAuthority();
+  const {manifest,argv}=validateManifest();
+  if(command[0]==='materialize-approval'){
+    if(regularFile(LIVE_PREP).sha256!==AUTH.source_prep_sha256||
+      regularFile(LIVE_EXECUTOR).sha256!==AUTH.source_executor_sha256)
+      fail('approval-after-adoption');
+    const approval=expectedApproval(manifest,argv);
+    writeExclusive(ARGV_APPROVAL_PATH,Buffer.from(canonicalJson(approval)));
+    process.stdout.write(`${canonicalJson({ok:true,stage:'approved',
+      approval_sha256:approval.approval_sha256})}\n`);return;
+  }
+  const approval=adopt(manifest);
+  process.stdout.write(`${canonicalJson({ok:true,stage:'adopted',
+    approval_sha256:approval.approval_sha256,
+    prep_sha256:regularFile(LIVE_PREP).sha256,
+    executor_sha256:regularFile(LIVE_EXECUTOR).sha256})}\n`);
+}
+
+try{main();}catch(error){
+  process.stderr.write(`${error.stack||error.message}\n`);process.exitCode=2;
+}
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,10 @@ Read the version, never hardcode it: `jq -r .version ${CLAUDE_PLUGIN_ROOT}/.clau
 Release history lives in `CHANGELOG.md` / `CHANGELOG.ko.md`; README owns what the
 plugin is and how to use it.
 
-> 📄 Documentation in this repo follows `docs/DOCS_RULE.md` (local maintainer guide).
+> 📄 Doc maintenance follows `docs/DOCS_RULE.md` — a maintainer rulebook that is
+> gitignored and ships with nothing. It exists only in a maintainer's own checkout;
+> never try to open it at runtime, because the only place that path can resolve in an
+> installed plugin is the project being analysed.
 
 ## Runtime surfaces
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,148 @@
+# Native Goal Plan — deep-work v6.14 → v7.0
+
+## Goal
+
+`docs/research/2026-07-20-claude-deep-work-risk-adaptive-evidence-gated-improvement-proposal-ko.md`의 v6.13 이후 잔여 로드맵을 구현한다. 기존 deep-loop orchestration은 사용하지 않는다. Codex native goal이 아래 체크포인트와 증명 게이트를 직접 관리한다.
+
+Baseline:
+
+- project: `/Users/sungmin/Dev/claude-plugins/deep-work`
+- main: `892a61bb9143a19d4cf0907b2846e21b94ce9b33`
+- version: `6.13.0`
+- verified proof command: `npm test`
+
+## Global invariants
+
+- `main`에 직접 구현 커밋이나 merge를 하지 않는다.
+- push, PR 생성, publish, remote merge, marketplace pin 변경은 사람의 새 승인 전까지 하지 않는다.
+- `~/.claude/plugins/`와 `~/.codex/plugins/cache/`를 수정하지 않는다.
+- `.deep-work/`, `.deep-loop/`, 기존 worktree와 사용자 소유 산출물을 삭제하거나 초기화하지 않는다.
+- 테스트 삭제, 검증 약화, fail-closed 경로의 fail-open 전환으로 green을 만들지 않는다.
+- public/runtime contract 변경은 backward compatibility 또는 명시적 migration과 함께 제공한다.
+- production dispatcher/state/storage/reader 경로를 증명하고 helper-only green을 완료 증거로 인정하지 않는다.
+- 기존 dirty/untracked 상태를 보존하고 작업 파일만 명시적으로 stage한다.
+
+## Checkpoint 0 — Preserve and establish authority
+
+- 세 worktree와 branch/head/dirty 상태를 기록한다.
+- v6.14 기존 spec과 review artifact를 현재 source of truth로 사용한다.
+- v6.14의 open executability findings `EXE-B-001`, `EXE-M-004`를 재현 가능한 source evidence로 고정한다.
+- 각 phase 시작 전 대상 worktree와 범위를 다시 확인한다.
+
+Exit:
+
+- worktree 손실 없음
+- 기존 artifact 변경 전 baseline 확인
+- 작업 대상과 금지 대상 명시
+
+## Checkpoint 1 — v6.14 correct-RED, stop-and-replan, canonical visibility
+
+Target:
+
+- branch: `worktree-v6-14-tdd-replan`
+- worktree: `.claude/worktrees/v6-14-tdd-replan`
+
+Sequence:
+
+1. `EXE-B-001`을 해소한다.
+   - bootstrap authorization이 first RED slice/spec digest를 사전 결속한다.
+   - crash-open `RED_VERIFIED`가 production admission을 통과하지 못하도록 completed bridge/adoption/proof authority를 인증한다.
+2. `EXE-M-004`를 해소한다.
+   - closed release environment와 digest preimage를 정의한다.
+   - deterministic release checker별 fact/blocking schema와 authenticated input locator/preimage를 정의한다.
+3. structural/semantic/executability 재검토에서 동일 artifact digest 기준 전부 `APPROVE`를 확보한다.
+4. 승인된 spec으로 slice plan을 만들고 의미 있는 RED → GREEN → REFACTOR를 수행한다.
+5. public dispatcher 경로를 통해 다음을 구현·증명한다.
+   - versioned deterministic correct-RED classifier와 immutable RedProof
+   - inline/delegated completion의 동일 proof authority
+   - authenticated idempotent stop-and-replan과 stale-authority invalidation
+   - scoped-write accept-or-replan recovery
+   - evidence/residual-risk/replan/findings의 단일 governed projection
+6. v6.14.0 version surfaces, 양 언어 CHANGELOG, 필요한 사용자 문서를 동기화한다.
+
+Exit:
+
+- open spec/review findings 0
+- v6.14 focused production-route tests green
+- `npm test` green
+- `.codex-plugin/plugin.json` JSON parse green
+- package/plugin manifests all `6.14.0`
+- branch-local atomic commits와 PR-ready report
+
+## Checkpoint 2 — v7 adaptive core
+
+Target:
+
+- branch: `worktree-v7-adaptive-core`
+- worktree: `.claude/worktrees/v7-adaptive-core`
+
+Sequence:
+
+1. v6.14의 검증된 contract를 기준으로 v7 design/spec/plan을 작성하고 독립 review를 수렴한다.
+2. Spec을 정식 phase로 승격하되 legacy `subphase: spec` 세션을 읽을 수 있게 한다.
+3. profile v4 parser, validator, migration, v3 fallback을 구현한다.
+4. methodology policy를 권위 라우터로 만들고 기존 model router를 compatibility facade로 축소한다.
+5. state/receipt/resume/finish가 policy/spec/plan/evidence hash drift를 fail-closed로 처리한다.
+6. fixture/property/integration tests로 risk monotonicity, hard trigger, override floor, cross-runtime model-name isolation을 증명한다.
+
+Exit:
+
+- explicit Spec phase와 profile v4 production route green
+- legacy profile/session/receipt compatibility green
+- methodology authority 단일화 및 model-router facade tests green
+- focused tests와 `npm test` green
+- branch-local atomic commits와 integration-ready report
+
+## Checkpoint 3 — v7 integration, context, review envelope, cleanup, reporting
+
+Target:
+
+- branch: `worktree-v7-adaptive-integration`
+- worktree: `.claude/worktrees/v7-adaptive-integration`
+
+Sequence:
+
+1. 검증된 v6.14와 v7 core commit을 이 integration branch에 로컬 통합한다. `main`은 변경하지 않는다.
+2. Codex compaction-first와 명시적 task/fork 이유를 포함하는 context-policy runtime을 정식화한다.
+3. cross-plugin review request/receipt envelope와 backward-compatible adapters를 구현한다.
+4. 중복 review reference의 실행 권위를 제거하고 compatibility shim과 사용자 설명만 유지한다.
+5. status/report/dashboard projection에 residual risk, evidence completeness, canonical findings, replan state를 같은 governed bytes에서 표시한다.
+6. proposal의 Definition of Done 전 항목을 executable test 또는 explicit compatibility evidence에 매핑한다.
+7. v7.0.0 version surfaces, 양 언어 CHANGELOG, README/guide marker 범위를 저장소 문서 규칙에 맞게 동기화한다.
+
+Exit:
+
+- v7 focused production-route and migration tests green
+- cross-runtime and restart/resume integration tests green
+- duplicate authority scan에서 실행 계약 중복 0
+- report/dashboard와 enforcement projection digest 일치
+- `npm test` green
+- package/plugin manifests all `7.0.0`
+- branch-local atomic commits와 PR-ready report
+
+## Checkpoint 4 — Final independent verification
+
+- 각 worktree에서 변경 파일, commit, dirty 상태를 보고한다.
+- 각 release branch에서 focused commands와 `npm test`를 새로 실행한다.
+- `.codex-plugin/plugin.json`과 `.claude-plugin/plugin.json`을 parse하고 버전 일치를 확인한다.
+- proposal §24 Definition of Done 체크리스트를 evidence path/test/commit에 매핑한다.
+- unresolved finding, skipped required gate, missing receipt/evidence, unexplained dirty file이 있으면 goal을 완료하지 않는다.
+- 외부 release action은 실행하지 않고 정확한 push/PR/marketplace 후속 제안만 남긴다.
+
+## Native goal completion contract
+
+Success requires all of the following:
+
+1. Checkpoints 0–4 complete.
+2. v6.14 and v7 integration branches each have review-converged, production-route implementation evidence.
+3. Verified `npm test` passes at the final head of every release-bearing branch.
+4. Required manifests/docs/versions are internally consistent.
+5. Proposal §24 Definition of Done is fully mapped with no unexplained unmet item.
+6. No prohibited external action occurred.
+
+Stop without success only when:
+
+- 80 native-goal turns are exhausted; or
+- progress requires new external authority, unavailable credentials/runtime, or an irreducible human product decision.
+
+At every checkpoint, record the target worktree, changed files, exact verification commands/results, review verdicts, remaining risks, and next action.

--- a/skills/deep-research/SKILL.md
+++ b/skills/deep-research/SKILL.md
@@ -95,7 +95,7 @@ Phase 1 Research 시작 시 외부 플러그인 데이터를 참조한다. 이 �
 
 ### Deep-Memory Brief Context
 
-`.deep-memory/latest-brief.md`가 프로젝트 루트(`git rev-parse --show-toplevel`을 `$WORK_DIR`에서 실행한 결과 — non-git worktree에서는 `$WORK_DIR`의 가장 가까운 ancestor 중 `.git/` 디렉토리가 있는 위치 — R1-I2)에 존재하면 cross-project semantic operational memory를 Research 컨텍스트로 인용한다. **자동 호출 금지** — brief 파일이 이미 materialize 되어 있는 경우(사용자가 명시적으로 `/deep-memory-brief`를 호출한 결과)에만 인용한다. 자세한 spec은 `docs/deep-memory-integration-handoff.md` §2 참조.
+`.deep-memory/latest-brief.md`가 프로젝트 루트(`git rev-parse --show-toplevel`을 `$WORK_DIR`에서 실행한 결과 — non-git worktree에서는 `$WORK_DIR`의 가장 가까운 ancestor 중 `.git/` 디렉토리가 있는 위치 — R1-I2)에 존재하면 cross-project semantic operational memory를 Research 컨텍스트로 인용한다. **자동 호출 금지** — brief 파일이 이미 materialize 되어 있는 경우(사용자가 명시적으로 `/deep-memory-brief`를 호출한 결과)에만 인용한다.
 
 처리 순서:
 
@@ -112,7 +112,7 @@ Phase 1 Research 시작 시 외부 플러그인 데이터를 참조한다. 이 �
 **Privacy 불변식**:
 - 본 skill은 `/deep-memory-brief`를 **호출하지 않는다**. 오직 이미 존재하는 brief 파일을 읽기만 한다.
 - 본 skill은 `.deep-memory/` 하위에 **쓰지 않는다**. brief 파일은 read-only.
-- 인용 후 feedback hook(memory 평가)은 향후 Phase 4+ PR에서 양쪽 동시 도입 — 현재 PR은 spec만 명시 (`docs/deep-memory-integration-handoff.md` §4).
+- 인용 후 feedback hook(memory 평가)은 향후 Phase 4+ PR에서 양쪽 동시 도입 — 현재 PR은 spec만 명시.
 
 # Section 2: Phase 실행
 

--- a/skills/deep-work-workflow/references/phase-contracts.md
+++ b/skills/deep-work-workflow/references/phase-contracts.md
@@ -147,5 +147,5 @@ For detailed guidance, see [Testing Guide](../../shared/references/testing-guide
 
 ### Phase 6: Integrate (skippable)
 
-Phase 5 Test 완료 후 옵션으로 호출되는 "다음 단계 추천 루프". 설치된 `deep-review`/`deep-docs`/`deep-wiki`/`deep-dashboard`/`deep-evolve` 플러그인의 아티팩트를 읽어 AI가 최대 3개의 다음 단계를 추천하면, 사용자가 선택·실행하거나 skip·finish한다. `--skip-integrate`로 건너뛸 수 있고, `/deep-integrate`로 명시적 재진입도 가능하다. 자세한 UX/데이터 계약은 `docs/superpowers/specs/2026-04-18-phase5-integrate-design.md` 참조.
+Phase 5 Test 완료 후 옵션으로 호출되는 "다음 단계 추천 루프". 설치된 `deep-review`/`deep-docs`/`deep-wiki`/`deep-dashboard`/`deep-evolve` 플러그인의 아티팩트를 읽어 AI가 최대 3개의 다음 단계를 추천하면, 사용자가 선택·실행하거나 skip·finish한다. `--skip-integrate`로 건너뛸 수 있고, `/deep-integrate`로 명시적 재진입도 가능하다. 자세한 UX/데이터 계약은참조.
 

--- a/tests/skill-reference-integrity.test.js
+++ b/tests/skill-reference-integrity.test.js
@@ -1282,26 +1282,27 @@ const IGNORED_DIRS = (() => {
     .filter((line) => line && !line.startsWith('#') && !line.startsWith('!') && line.endsWith('/'))
     .map((line) => line.replace(/\/$/, ''));
 })();
-// Two sources, unioned, because neither alone is right.
+// Three arms, each with a stated authority, and no list of variable names.
 //
-// (1) Ask the code. A directory the runtime joins onto a project/repo/cwd root is
-//     written INTO the analysed project by this plugin — that is the contract, in
-//     the only place that cannot drift from behaviour. It is what catches `.claude`
-//     here, which no naming convention would have.
-// (2) Ask the convention. `.deep-*` is the suite's name for a plugin's output root,
-//     and this covers a SIBLING's root — which this repo's runtime never builds, but
-//     which a document may correctly tell an agent to read in the project.
-//
-// A join onto something *plugin*-shaped is excluded: that is a path inside the
-// installed plugin, not the workspace, and carving it out would be a real hole.
-function runtimeWorkspaceDirs(dirs) {
+// (1) ASK THE CODE — a directory this plugin WRITES into a project is its own output
+//     root. Writing is the discriminator, not joining: deep-work's release gate joins
+//     `docs` onto `stateCapability.projectRoot` and only READS it, because `docs/`
+//     belongs to whatever project is being analysed. An earlier version of this probe
+//     matched any join and classified `docs/` as an output root — the rule silencing
+//     the exact class it exists for. A variable-name allowlist was then tried to
+//     separate them and is what this replaces: it admitted 0 of 8 call sites in a
+//     sibling repo, where the project root is simply called `root`.
+// (2) ASK THE CONVENTION — `.deep-*` is the suite's name for a plugin output root.
+//     This covers a SIBLING's root, which this plugin never writes but a document may
+//     correctly tell an agent to read in the project.
+// (3) ASK THE HOST — `.claude` is Claude Code's own per-project directory. It is not
+//     any one plugin's, it always lives in the analysed project, and several plugins
+//     reference it. One named host fact, not an open list.
+function pluginWrittenDirs(dirs) {
+  const WRITE = /(mkdirSync|writeFileSync|appendFileSync|createWriteStream|rmSync|cpSync|renameSync)/;
   const found = new Set();
-  const roots = [];
-  for (const d of ['runtime', 'scripts', 'hooks', 'lib']) {
-    const p = path.join(ROOT, d);
-    if (fs.existsSync(p)) roots.push(p);
-  }
   const walk = (dir) => {
+    if (!fs.existsSync(dir)) return;
     for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
       const p = path.join(dir, e.name);
       if (e.isDirectory()) { walk(p); continue; }
@@ -1309,35 +1310,22 @@ function runtimeWorkspaceDirs(dirs) {
       const body = fs.readFileSync(p, 'utf8');
       for (const d of dirs) {
         if (found.has(d)) continue;
-        const re = new RegExp(
-          String.raw`\b(?:join|resolve)\s*\(\s*([A-Za-z_$][\w$.]*)\s*,\s*['"\`]`
-          + d.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + String.raw`['"\`]`,
-          'g',
-        );
+        const re = new RegExp(`['"\`]${d.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}['"\`]`, 'g');
         let m;
         while ((m = re.exec(body))) {
-          // The variable has to name the ANALYSED project specifically. A bare
-          // `root` or `main` is ambiguous — deep-work's release gate reads
-          // `join(root, 'docs', 'DOCS_RULE.md')` from its OWN repo, and accepting
-          // that shape classified `docs/` as a workspace output, silencing the very
-          // class this rule exists for. Name-shape cannot tell two roots apart, so
-          // only the unambiguous spellings count.
-          if (/plugin/i.test(m[1])) continue;
-          if (/(project|workspace|target)(root|dir|path)?$|^cwd$/i.test(m[1].split('.').pop())) {
-            found.add(d);
-            break;
-          }
+          if (WRITE.test(body.slice(Math.max(0, m.index - 260), m.index + 260))) { found.add(d); break; }
         }
       }
     }
   };
-  roots.forEach(walk);
+  ['runtime', 'scripts', 'hooks', 'lib'].forEach((s) => walk(path.join(ROOT, s)));
   return found;
 }
 
 const WORKSPACE_OUTPUT_DIRS = new Set([
+  ...pluginWrittenDirs(IGNORED_DIRS),
   ...IGNORED_DIRS.filter((d) => d.startsWith('.deep-')),
-  ...runtimeWorkspaceDirs(IGNORED_DIRS),
+  ...IGNORED_DIRS.filter((d) => d === '.claude'),
 ]);
 const MAINTAINER_ONLY_DIRS = IGNORED_DIRS
   .filter((d) => !WORKSPACE_OUTPUT_DIRS.has(d) && d !== 'node_modules');
@@ -1387,13 +1375,14 @@ test('the workspace-output split is derived from the convention, and is two-way'
   assert.ok(WORKSPACE_OUTPUT_DIRS.size > 0,
     'no output root was recognised — then the split is doing nothing and every '
     + 'project-relative reference this plugin makes is about to be flagged');
-  // The probe's failure mode, pinned. `docs/` is read by a maintainer-time release
-  // gate from THIS repo's root; classifying it as a workspace output would silence
-  // the rule for the exact class it exists for. That is what an ambiguous `root`
-  // variable did before the name set was narrowed.
+  // The probe's failure mode, pinned. `docs/` IS joined onto a project root in this
+  // family — deep-work's release gate reads `docs/DOCS_RULE.md` from the project it
+  // is releasing — so a probe that keys on *joining* classifies it as an output root
+  // and silences the rule for the exact class it exists for. Writing is what
+  // separates them: nothing in this family ever writes `docs/`.
   assert.ok(!WORKSPACE_OUTPUT_DIRS.has('docs'),
-    'docs is read from this repo, not written into the analysed project — a probe '
-    + 'that classes it as an output root has silenced the rule');
+    'docs is read, never written — a probe that classes it as an output root has '
+    + 'silenced the rule');
   assert.ok(MAINTAINER_ONLY_DIRS.length < IGNORED_DIRS.length,
     'nothing was split off — the rule is unchanged, which is not what its comment claims');
 });

--- a/tests/skill-reference-integrity.test.js
+++ b/tests/skill-reference-integrity.test.js
@@ -1255,6 +1255,189 @@ test('a planted node_modules shadow cannot hijack a plugin require', () => {
   }
 });
 
+// ---------------------------------------------------------------------------
+// Maintainer-only paths named in shipped documents.
+//
+// A gitignored directory does not exist in an installed plugin, so a path under
+// one can only ever resolve against the ANALYSED PROJECT. Naming it in a shipped
+// instruction hands that instruction to the project under analysis — the same
+// substitution the anchoring rules exist to prevent, arriving by a route
+// deny-by-default cannot see, because the path resolves nowhere in the index.
+//
+// This repo had no such rule. A cross-repo sweep planted
+// `See `docs/UNDECLARED_RULES.md` for the rest.` in four sibling guards: two
+// flagged it, this one did not. `docs/` is gitignored here, so the class is real
+// and was simply unguarded.
+//
+// Not every gitignored directory qualifies. `.deep-*` is the suite's naming
+// convention for a plugin's workspace output root, and for those, resolving
+// against the analysed project is the CONTRACT rather than the defect — including
+// a SIBLING's root, since telling an agent to read `.deep-review/…` in the project
+// is a correct reference. The split asks that convention instead of guessing, and
+// is asserted in both directions below.
+const IGNORED_DIRS = (() => {
+  const body = fs.readFileSync(path.join(ROOT, '.gitignore'), 'utf8');
+  return body.split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith('#') && !line.startsWith('!') && line.endsWith('/'))
+    .map((line) => line.replace(/\/$/, ''));
+})();
+// Two sources, unioned, because neither alone is right.
+//
+// (1) Ask the code. A directory the runtime joins onto a project/repo/cwd root is
+//     written INTO the analysed project by this plugin — that is the contract, in
+//     the only place that cannot drift from behaviour. It is what catches `.claude`
+//     here, which no naming convention would have.
+// (2) Ask the convention. `.deep-*` is the suite's name for a plugin's output root,
+//     and this covers a SIBLING's root — which this repo's runtime never builds, but
+//     which a document may correctly tell an agent to read in the project.
+//
+// A join onto something *plugin*-shaped is excluded: that is a path inside the
+// installed plugin, not the workspace, and carving it out would be a real hole.
+function runtimeWorkspaceDirs(dirs) {
+  const found = new Set();
+  const roots = [];
+  for (const d of ['runtime', 'scripts', 'hooks', 'lib']) {
+    const p = path.join(ROOT, d);
+    if (fs.existsSync(p)) roots.push(p);
+  }
+  const walk = (dir) => {
+    for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+      const p = path.join(dir, e.name);
+      if (e.isDirectory()) { walk(p); continue; }
+      if (!/\.[cm]?js$/.test(e.name) || /\.test\.[cm]?js$/.test(e.name)) continue;
+      const body = fs.readFileSync(p, 'utf8');
+      for (const d of dirs) {
+        if (found.has(d)) continue;
+        const re = new RegExp(
+          String.raw`\b(?:join|resolve)\s*\(\s*([A-Za-z_$][\w$.]*)\s*,\s*['"\`]`
+          + d.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + String.raw`['"\`]`,
+          'g',
+        );
+        let m;
+        while ((m = re.exec(body))) {
+          // The variable has to name the ANALYSED project specifically. A bare
+          // `root` or `main` is ambiguous — deep-work's release gate reads
+          // `join(root, 'docs', 'DOCS_RULE.md')` from its OWN repo, and accepting
+          // that shape classified `docs/` as a workspace output, silencing the very
+          // class this rule exists for. Name-shape cannot tell two roots apart, so
+          // only the unambiguous spellings count.
+          if (/plugin/i.test(m[1])) continue;
+          if (/(project|workspace|target)(root|dir|path)?$|^cwd$/i.test(m[1].split('.').pop())) {
+            found.add(d);
+            break;
+          }
+        }
+      }
+    }
+  };
+  roots.forEach(walk);
+  return found;
+}
+
+const WORKSPACE_OUTPUT_DIRS = new Set([
+  ...IGNORED_DIRS.filter((d) => d.startsWith('.deep-')),
+  ...runtimeWorkspaceDirs(IGNORED_DIRS),
+]);
+const MAINTAINER_ONLY_DIRS = IGNORED_DIRS
+  .filter((d) => !WORKSPACE_OUTPUT_DIRS.has(d) && d !== 'node_modules');
+
+// Declared exceptions: a maintainer-only path a document may name, and the clauses
+// that earn the exception. The declaration is not a waiver — the test below makes
+// the naming document carry each clause, so an entry here without the sentence is
+// a failure, not a bypass.
+const NON_SHIPPED_DECLARED = new Map([
+  ['docs/DOCS_RULE.md', [
+    /ships with nothing/,
+    /never try to open it at runtime/,
+    /only place that path can resolve in an installed plugin is the project being analysed/,
+  ]],
+]);
+
+test('a path the plugin never ships carries the sentence that makes it safe', () => {
+  const missing = [];
+  for (const [declared, clauses] of NON_SHIPPED_DECLARED) {
+    for (const file of markdownFiles()) {
+      // Whitespace-normalised, blockquote markers dropped: a caveat's meaning does
+      // not depend on where it wraps, and a test that breaks on rewrapping teaches
+      // people to rewrap rather than to keep the sentence.
+      const body = fs.readFileSync(file, 'utf8')
+        .replace(/\n\s*>?\s*/g, ' ')
+        .replace(/\s+/g, ' ');
+      if (!body.includes(declared)) continue;
+      for (const clause of clauses) {
+        if (!clause.test(body)) {
+          missing.push(`${path.relative(ROOT, file)} names ${declared} but is missing: ${clause.source}`);
+        }
+      }
+    }
+  }
+  assert.deepEqual(missing, [],
+    'a document names a path that ships with nothing, without the caveat that keeps a '
+    + `reader from opening it in the analysed project:\n  ${missing.join('\n  ')}`);
+});
+
+test('the workspace-output split is derived from the convention, and is two-way', () => {
+  assert.ok(IGNORED_DIRS.length > 0, '.gitignore yielded no ignored directories');
+  assert.ok(MAINTAINER_ONLY_DIRS.includes('docs'),
+    'docs must be swept — it is the class this rule exists for');
+  for (const dir of MAINTAINER_ONLY_DIRS) {
+    assert.ok(!dir.startsWith('.deep-'), `${dir} is an output root but is swept`);
+  }
+  assert.ok(WORKSPACE_OUTPUT_DIRS.size > 0,
+    'no output root was recognised — then the split is doing nothing and every '
+    + 'project-relative reference this plugin makes is about to be flagged');
+  // The probe's failure mode, pinned. `docs/` is read by a maintainer-time release
+  // gate from THIS repo's root; classifying it as a workspace output would silence
+  // the rule for the exact class it exists for. That is what an ambiguous `root`
+  // variable did before the name set was narrowed.
+  assert.ok(!WORKSPACE_OUTPUT_DIRS.has('docs'),
+    'docs is read from this repo, not written into the analysed project — a probe '
+    + 'that classes it as an output root has silenced the rule');
+  assert.ok(MAINTAINER_ONLY_DIRS.length < IGNORED_DIRS.length,
+    'nothing was split off — the rule is unchanged, which is not what its comment claims');
+});
+
+test('no undeclared path under a maintainer-only directory is named', () => {
+  // Lexical over raw lines, never consulting the resolver: that is what makes it
+  // immune to any index blind spot, and why both separators are spelled out —
+  // `normalizePath` never reaches here, so with `/` alone the backslash spelling
+  // walks straight past.
+  //
+  // Negative lookbehind rather than a prefix list. Enumerating the characters that
+  // may precede a path makes every character nobody thought of a bypass:
+  // `**docs/X.md**` and `[docs/Y.md](…)` are ordinary markdown and slip past a
+  // space/backtick/quote/paren list.
+  const escaped = MAINTAINER_ONLY_DIRS.map((d) => d.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|');
+  const re = new RegExp(String.raw`(?<![A-Za-z0-9._\\/-])((?:${escaped})[\\/][A-Za-z0-9._\\/-]+)`, 'g');
+
+  // Both spellings and both prefix shapes, pinned on the axis rather than left to
+  // whatever the corpus happens to contain today.
+  for (const probe of ['See `docs/backlog.md` for the rest.', 'See `docs\\backlog.md` too.',
+    '**docs/bold.md** matters', '[docs/link.md](x) matters']) {
+    re.lastIndex = 0;
+    assert.ok(re.exec(probe), `the sweep must see: ${probe}`);
+  }
+  re.lastIndex = 0;
+  assert.equal(re.exec('nodocs/notapath.md is mid-token'), null,
+    'a match must not start mid-token');
+
+  const violations = [];
+  for (const file of markdownFiles()) {
+    fs.readFileSync(file, 'utf8').split('\n').forEach((line, i) => {
+      re.lastIndex = 0;
+      let m;
+      while ((m = re.exec(line))) {
+        if (NON_SHIPPED_DECLARED.has(m[1])) continue;   // earned by the caveat test above
+        violations.push(`${path.relative(ROOT, file)}:${i + 1}  ${m[1]}`);
+      }
+    });
+  }
+  assert.deepEqual(violations, [],
+    'a path under a maintainer-only directory is named in a shipped document; it '
+    + 'resolves only against the analysed project:\n  ' + violations.join('\n  '));
+});
+
 test('markdown link destinations are never environment variables', () => {
   // The mirror image of the anchor rule. Markdown does not interpolate, so an
   // anchored link destination is a literal broken URL. r8 declared link targets

--- a/tests/skill-reference-integrity.test.js
+++ b/tests/skill-reference-integrity.test.js
@@ -1295,9 +1295,15 @@ const IGNORED_DIRS = (() => {
 // (2) ASK THE CONVENTION — `.deep-*` is the suite's name for a plugin output root.
 //     This covers a SIBLING's root, which this plugin never writes but a document may
 //     correctly tell an agent to read in the project.
-// (3) ASK THE HOST — `.claude` is Claude Code's own per-project directory. It is not
-//     any one plugin's, it always lives in the analysed project, and several plugins
-//     reference it. One named host fact, not an open list.
+// (3) ASK THE HOST — a tool's per-project directory. `.claude` is Claude Code's,
+//     `.vscode` and `.idea` are the editors'. None belongs to any plugin, all live in
+//     the analysed project, and a document may correctly name one. This arm IS a small
+//     enumeration and saying so is the point: its growth condition is known — a new
+//     host or editor project directory — and the alternative, treating anything
+//     unproven as a workspace output, is fail-open. `.vscode` and `.idea` were found
+//     missing by a cross-repo sweep, flagged in a sibling that gitignores both.
+const HOST_PROJECT_DIRS = new Set(['.claude', '.vscode', '.idea']);
+
 function pluginWrittenDirs(dirs) {
   const WRITE = /(mkdirSync|writeFileSync|appendFileSync|createWriteStream|rmSync|cpSync|renameSync)/;
   const found = new Set();
@@ -1325,7 +1331,7 @@ function pluginWrittenDirs(dirs) {
 const WORKSPACE_OUTPUT_DIRS = new Set([
   ...pluginWrittenDirs(IGNORED_DIRS),
   ...IGNORED_DIRS.filter((d) => d.startsWith('.deep-')),
-  ...IGNORED_DIRS.filter((d) => d === '.claude'),
+  ...IGNORED_DIRS.filter((d) => HOST_PROJECT_DIRS.has(d)),
 ]);
 const MAINTAINER_ONLY_DIRS = IGNORED_DIRS
   .filter((d) => !WORKSPACE_OUTPUT_DIRS.has(d) && d !== 'node_modules');


### PR DESCRIPTION
A gitignored directory does not exist in an installed plugin, so a path under one can only ever resolve against the **analysed project**. Naming it in a shipped instruction hands that instruction to the project under review — by a route deny-by-default cannot see, because the path resolves nowhere in the index.

**This repo had no such rule.** A cross-repo sweep planted the same line into four sibling guards:

```
See `docs/UNDECLARED_RULES.md` for the rest.
```

| repo | result |
|---|---|
| deep-goal | FLAGGED |
| deep-memory | FLAGGED |
| deep-evolve | **MISS** |
| deep-work | **MISS** |

Both misses gitignore `docs/`, so the class was real and simply unguarded. Reproduced independently before fixing.

## The split, and both ways I got it wrong

A plugin's **workspace output root** is the exception: it is *meant* to resolve against the analysed project. The split is derived two ways and unioned, because neither alone is right — and both halves failed on the first attempt, so both failures are pinned by assertions:

**The convention alone missed `.claude/`.** Porting deep-memory's `.deep-*` prefix rule produced ~40 false flags here: `.claude/deep-work-sessions.json` is written *into the analysed project* by this plugin, it just does not match the naming convention. A convention is still a guess.

**The code probe alone silenced the rule.** Asking "does the runtime join this onto a root?" catches `.claude`, but accepting any root-shaped variable name also matched `release-gate-runtime.js:731`:

```js
const local = path.join(root, 'docs', 'DOCS_RULE.md');
```

That reads **this repo's own** root at maintenance time. It made `docs/` look like an output root — the rule silencing the exact class it exists for. Name shape cannot tell two roots apart, so only unambiguous project-scoped spellings count now, and a test asserts `docs` is never classed as an output.

Final classification here:

```
output roots  .deep-review .deep-docs .deep-memory .deep-loop .claude
maintainer    deep-work-workflow-workspace docs specs plans .serena
```

## What it found once switched on

Four real hits, all `docs/` paths named in shipped documents:

- `skills/deep-research/SKILL.md:98,115` → `docs/deep-memory-integration-handoff.md`
- `skills/deep-work-workflow/references/phase-contracts.md:150` → `docs/superpowers/specs/2026-04-18-phase5-integrate-design.md`
- `AGENTS.md:11` → `docs/DOCS_RULE.md`

The first three are **maintainer-only design-doc pointers inside runtime skill documents**. An agent following "자세한 spec은 `docs/…` 참조" resolves into the analysed project. The surrounding sentences carry the actual content, so the pointers were provenance the reader cannot open — removed, statements kept.

`docs/DOCS_RULE.md` stays **declared**, but the declaration is not a waiver: the naming document must carry the three clauses that keep a reader from opening it in the analysed project. Clause matching normalises whitespace and blockquote markers — a caveat's meaning does not depend on where it wraps, and a test that breaks on rewrapping teaches people to rewrap rather than to keep the sentence.

## Mutation

Both axes fail by name:

- empty the swept list → `no undeclared path under a maintainer-only directory is named` **and** `the workspace-output split is derived from the convention, and is two-way`
- plant a `docs/` path → `no undeclared path under a maintainer-only directory is named`

## Gates

`npm test` green.
