### PR TITLE
fix(security): a second spelling of the plugin root silenced the guard

### DIFF
--- a/skills/deep-mutation-test/SKILL.md
+++ b/skills/deep-mutation-test/SKILL.md
@@ -65,7 +65,7 @@ Run mutation tool with budget constraints from registry.json:
 - `max_mutants`: cap mutant count (default 200)
 
 ```bash
-node "$PLUGIN_DIR/sensors/run-sensors.js" "<mutation_cmd>" "<parser>" "mutation" "advisory" <timeout>
+node "${CLAUDE_PLUGIN_ROOT}/sensors/run-sensors.js" "<mutation_cmd>" "<parser>" "mutation" "advisory" <timeout>
 ```
 
 ### Step 4: Analyze Results

--- a/skills/deep-report/SKILL.md
+++ b/skills/deep-report/SKILL.md
@@ -124,7 +124,7 @@ If timestamps are empty, show "N/A" for that phase.
 
 Write `$WORK_DIR/report.md` with the following structure:
 
-```markdown
+````markdown
 # Deep Work Session Report
 
 ## Session Overview
@@ -345,6 +345,6 @@ If `git_branch` is set in the state file and `current_phase` is `idle`:
 
 제안 커밋 메시지:
   feat: [task_description 기반 자동 생성]
-```
+````
 
 If the user agrees, create the commit. If not, skip.

--- a/skills/deep-sensor-scan/SKILL.md
+++ b/skills/deep-sensor-scan/SKILL.md
@@ -52,7 +52,7 @@ Manual computational sensor scanning. Can be used inside or outside deep-work se
 
 Run detection engine:
 ```bash
-node "$PLUGIN_DIR/sensors/detect.js" "$PROJECT_ROOT"
+node "${CLAUDE_PLUGIN_ROOT}/sensors/detect.js" "$PROJECT_ROOT"
 ```
 
 Display detected ecosystems and tool availability. If `--detect` flag, stop here.
@@ -63,12 +63,12 @@ For each detected ecosystem with available tools, run sensors in order:
 
 1. **Linter** (if available and not `--typecheck`/`--coverage` only):
    ```bash
-   node "$PLUGIN_DIR/sensors/run-sensors.js" "<lint_cmd>" "<parser>" "lint" "required" 30
+   node "${CLAUDE_PLUGIN_ROOT}/sensors/run-sensors.js" "<lint_cmd>" "<parser>" "lint" "required" 30
    ```
 
 2. **Type checker** (if available and not `--lint`/`--coverage` only):
    ```bash
-   node "$PLUGIN_DIR/sensors/run-sensors.js" "<typecheck_cmd>" "<parser>" "typecheck" "required" 60
+   node "${CLAUDE_PLUGIN_ROOT}/sensors/run-sensors.js" "<typecheck_cmd>" "<parser>" "typecheck" "required" 60
    ```
 
 3. **Coverage** (if available and not `--lint`/`--typecheck` only):

--- a/tests/skill-reference-integrity.test.js
+++ b/tests/skill-reference-integrity.test.js
@@ -651,6 +651,50 @@ function resolveAsAgentWould(token, cwd) {
 const FENCE = /^[ \t]*```/gm;
 
 test('every skill and agent markdown file has balanced code fences', () => {
+  // Parity is a proxy, and it detects neither real failure. `skills/deep-report/SKILL.md`
+  // carried fourteen markers — even, so this sweep passed — while a ```bash with an info
+  // string failed to close the ```markdown template above it, a later bare marker closed
+  // that template instead, and the final block was never closed at all. Half the document
+  // rendered as code. So the parity count stays (it catches a truncating split cheaply)
+  // and CommonMark's own rule is asserted beside it: a closer matches the opener's
+  // character, is at least as long, and carries NO info string.
+  //
+  // CARVE-OUT, deliberate: `fenceRegions()` must NOT be made CommonMark-correct. It
+  // answers a different question — whether a reader copying from a binding to its use
+  // crosses a boundary, because two fenced blocks are two shell invocations — and
+  // marker counting is the right model for that. The two differing readings are not an
+  // inconsistency to tidy away.
+  const openAtEof = (body) => {
+    let open = null;
+    for (const line of body.split('\n')) {
+      const m = /^ {0,3}(`{3,}|~{3,})(.*)$/.exec(line);
+      if (!m) continue;
+      const ch = m[1][0];
+      const len = m[1].length;
+      if (open === null) { open = { ch, len }; continue; }
+      if (ch === open.ch && len >= open.len && !m[2].trim()) open = null;
+    }
+    return open !== null;
+  };
+  assert.equal(openAtEof('```js\nx\n```\n'), false, 'a closed block is closed');
+  assert.equal(openAtEof('```js\nx\n'), true, 'a truncated block is open at EOF');
+  // The real shape, not a shorthand for it: an info-string marker cannot close, so the
+  // bare marker meant to end the NESTED block ends the outer one instead, and every
+  // later marker is off by one until the last opens a block nothing closes. A
+  // two-marker fixture does not reproduce this — it just closes the outer early.
+  assert.equal(openAtEof('```markdown\n```bash\nx\n```\nmore\n```\n'), true,
+    'same-length nesting shifts every later marker and leaves the last block open');
+  assert.equal(openAtEof('````markdown\n```bash\nx\n```\nmore\n````\n'), false,
+    'and a longer outer fence nests correctly, which is the fix applied to deep-report');
+
+  const truncated = [];
+  for (const file of markdownFiles()) {
+    if (openAtEof(fs.readFileSync(file, 'utf8'))) truncated.push(path.relative(ROOT, file));
+  }
+  assert.deepEqual(truncated, [],
+    'a code fence is still open at end of file — the rest of the document renders as '
+    + `code:\n  ${truncated.join('\n  ')}`);
+
   const unbalanced = [];
   for (const file of markdownFiles()) {
     const fences = (fs.readFileSync(file, 'utf8').match(FENCE) || []).length;

--- a/tests/skill-reference-integrity.test.js
+++ b/tests/skill-reference-integrity.test.js
@@ -1510,85 +1510,177 @@ test('the documented pluginRequire helpers realpath their target', () => {
 });
 
 
-// The accepted spellings are whatever the RUNTIME reads from the environment to
-// find its own root — asked of the code, not listed here. All three repos in this
-// family accept a Claude name and a generic Codex name, and a first version of the
-// rule below assumed a single spelling and reported the generic one as rogue. It was
-// legitimate: `runtime/hook-context.js` reads both, and AGENTS.md says so.
+// Which variables may root a path at this plugin. NOT a list of names, and NOT
+// derived from what the runtime READS out of the environment — that was the first
+// version's mistake and it was structural about the wrong thing. The runtime
+// reading `env.CURSOR_PLUGIN_ROOT` for host *detection* says nothing about whether
+// a document may spell the anchor that way; deep-memory's runtime reads four names
+// and its contract sanctions two.
+//
+// The question a reader of these documents faces is: **is this variable guaranteed
+// to hold the plugin root at the moment this line runs?** Two things guarantee it,
+// and neither needs a name:
+//
+//   1. The contract document declares the spelling. A name counts only where
+//      AGENTS.md writes it as a VARIABLE REFERENCE in a NON-path position:
+//      `Codex sets ${PLUGIN_ROOT} for the same root` is a sanction; `${X}/lib/a.js`
+//      is a use, and a bare prose mention of the string is neither. Measured, in
+//      that order: a use alone FIRES, a use plus a passing prose mention still
+//      FIRES, and only an added sanction sentence goes silent. So the accept-set
+//      widens by one deliberate edit to the contract and by nothing else.
+//   2. The variable is bound earlier in the same fenced region, from an already
+//      accepted anchor. A local needs no host to set it. This is the real reason
+//      deep-report's `PLUGIN_ROOT="$(cd "${CLAUDE_PLUGIN_ROOT:?…}" && pwd -P)"` is
+//      safe, and the first version accepted those three lines for an unrelated
+//      reason — it would have accepted them just as readily without the binding.
+const CONTRACT_DOC = 'AGENTS.md';
 const ANCHOR_VARS = (() => {
+  const body = fs.readFileSync(path.join(ROOT, CONTRACT_DOC), 'utf8');
   const found = new Set();
-  const walk = (dir) => {
-    if (!fs.existsSync(dir)) return;
-    for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
-      const p = path.join(dir, e.name);
-      if (e.isDirectory()) { walk(p); continue; }
-      if (!/\.(?:[cm]?js|json)$/.test(e.name)) continue;
-      const body = fs.readFileSync(p, 'utf8');
-      for (const m of body.matchAll(/(?:^|[^A-Za-z0-9_.])env(?:ironment)?\.([A-Z][A-Z0-9_]*_PLUGIN_ROOT|PLUGIN_ROOT)/g)) found.add(m[1]);
-      for (const m of body.matchAll(/process\.env\.([A-Z][A-Z0-9_]*_PLUGIN_ROOT|PLUGIN_ROOT)/g)) found.add(m[1]);
-    }
-  };
-  ['runtime', 'hooks', 'scripts', 'lib'].forEach((s) => walk(path.join(ROOT, s)));
+  for (const m of body.matchAll(/\$\{?([A-Z][A-Z0-9_]*_PLUGIN_ROOT|PLUGIN_ROOT)\}?`?(?![A-Za-z0-9_/\\])/g)) {
+    found.add(m[1]);
+  }
   return found;
 })();
-test('a variable-rooted path that resolves in the plugin uses the one anchor spelling', () => {
-  // The guard recognises `${CLAUDE_PLUGIN_ROOT}` and flags a BARE `sensors/x.js`,
+
+// A local binding is `VAR=` (optionally `export VAR=`) whose right-hand side names
+// an accepted anchor, on an earlier line with **no fence marker in between**.
+//
+// Regions are delimited by fence markers, not by `fenceBlocks()`'s CommonMark block
+// ids, and the difference is load-bearing here. `skills/deep-report/SKILL.md` nests
+// a ```bash example inside a ```markdown template using the same fence length, so by
+// CommonMark the outer block ends at the inner opener and the binding lands in a
+// different block from its use — three correct, fail-closed lines would be flagged.
+// The property that actually matters is not which block markdown thinks a line is
+// in; it is whether a reader copying from the binding to the use crosses a boundary,
+// because two fenced blocks are two shell invocations and the second does not
+// inherit the first's variables. Any fence marker between them is that boundary.
+function fenceRegions(body) {
+  let region = 0;
+  return body.split('\n').map((line) => {
+    if (/^[ \t]*(?:`{3,}|~{3,})/.test(line)) { region += 1; return null; }
+    return region;
+  });
+}
+function locallyBound(lines, regions, upTo, name) {
+  const region = regions[upTo];
+  if (region === null) return false;
+  const assign = new RegExp(`(?:^|[;&|]\\s*)(?:export\\s+)?${name}=`);
+  for (let j = 0; j < upTo; j += 1) {
+    if (regions[j] !== region) continue;
+    if (!assign.test(lines[j])) continue;
+    if ([...ANCHOR_VARS].some((a) => lines[j].includes(a))) return true;
+  }
+  return false;
+}
+
+test('a variable-rooted path that resolves in the plugin uses a sanctioned anchor', () => {
+  // The guard recognised `${CLAUDE_PLUGIN_ROOT}` and flagged a BARE `sensors/x.js`,
   // but any variable root silenced it: `$ANYTHING/sensors/x.js` was clean. So a
-  // second, undefined spelling of the plugin root passed unnoticed — measured live
-  // in this family as `$PLUGIN_DIR/` and `$PLUGIN_ROOT/`, neither of which anything
-  // exports. Unset, they expand to nothing and the command breaks; set by the
-  // analysed project's environment, they resolve wherever that points and `node`
-  // runs it.
+  // second spelling of the plugin root passed unnoticed — measured live in this
+  // family as `$PLUGIN_DIR/`, which nothing exports. Unset it expands to nothing;
+  // set by the analysed project's environment it resolves wherever that points,
+  // and `node` runs it.
   //
   // The rule cannot be "no variable roots" — `$WORK_DIR` and `$PROJECT_ROOT` are
-  // legitimate workspace roots and outnumber the anchor here. What separates them is
-  // structural and needs no list of names: **does the tail resolve in the shipped
-  // index?** Measured across every variable-rooted path in the scanned documents:
+  // legitimate workspace roots and outnumber the anchor here. What separates them
+  // needs no list of names: **does the tail resolve in the shipped index?**
+  // Measured across every variable-rooted path in this family's scanned documents
+  // (counts are deep-work's; the shape is the same in deep-evolve and deep-memory):
   //
-  //   $CLAUDE_PLUGIN_ROOT  181 tails resolve   (the anchor)
+  //   $CLAUDE_PLUGIN_ROOT  185 tails resolve   (the anchor)
   //   $PLUGIN_DIR            4 resolve, 0 not  (rogue)
-  //   $PLUGIN_ROOT           3 resolve, 0 not  (rogue)
+  //   $PLUGIN_ROOT           3 resolve, 0 not  (locally bound — see below)
   //   $WORK_DIR              0 resolve, 179 not
   //   $PROJECT_ROOT          0 resolve,  16 not
   //
   // Zero overlap. A variable whose tail names a shipped file is rooting a path at
   // this plugin, whatever it is called.
-  // The derivation must find the runtime's own names, or the rule below is comparing
-  // against nothing and every variable root looks rogue.
-  assert.ok(ANCHOR_VARS.size > 0,
-    'no anchor env name was found in the runtime — the rule has no baseline');
   assert.ok(ANCHOR_VARS.has('CLAUDE_PLUGIN_ROOT'),
-    'the Claude spelling must be among the accepted names');
+    `${CONTRACT_DOC} must name the anchor spelling, or this rule has no baseline`);
+  // What the set EXCLUDES is the half that can rot. A rule asserting only what its
+  // accept-list contains can widen forever and stay green; the first version did
+  // exactly that, and a single added comment was enough to whitelist a new name.
+  for (const rogue of ['PLUGIN_DIR', 'CLAUDE_PLUGIN_DIR', 'SOME_OTHER_ROOT']) {
+    assert.ok(!ANCHOR_VARS.has(rogue),
+      `${rogue} is not an anchor spelling and must never be accepted`);
+  }
+
   const VAR_ROOTED = /\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?[\\/]([A-Za-z0-9._\\/-]+)/g;
+  // `normalizePath` collapses separators but leaves `.` and `..` alone, so an
+  // exact-string index lookup let `$PLUGIN_DIR/./sensors/detect.js` and
+  // `$PLUGIN_DIR/sensors/../sensors/detect.js` through — the same shipped file by
+  // a spelling the index does not hold. Resolve before looking up.
+  const resolveTail = (t) => normalizePath(t).split('/').reduce((acc, seg) => {
+    if (seg === '.' || seg === '') return acc;
+    if (seg === '..') { acc.pop(); return acc; }
+    acc.push(seg);
+    return acc;
+  }, []).join('/');
+
   const offenders = [];
   for (const file of markdownFiles()) {
-    fs.readFileSync(file, 'utf8').split('\n').forEach((line, i) => {
+    const body = fs.readFileSync(file, 'utf8');
+    const lines = body.split('\n');
+    const regions = fenceRegions(body);
+    lines.forEach((line, i) => {
       VAR_ROOTED.lastIndex = 0;
       let m;
       while ((m = VAR_ROOTED.exec(line))) {
         if (ANCHOR_VARS.has(m[1])) continue;
-        if (!PLUGIN_FILES.has(normalizePath(m[2]))) continue;
+        if (locallyBound(lines, regions, i, m[1])) continue;
+        if (!PLUGIN_FILES.has(resolveTail(m[2]))) continue;
         offenders.push(`${path.relative(ROOT, file)}:${i + 1}  $${m[1]}/${m[2]}`);
       }
     });
   }
   assert.deepEqual(offenders, [],
-    'a path rooted at a variable other than the anchor resolves to a shipped file, so '
-    + `that variable is a second spelling of the plugin root:\n  ${offenders.join('\n  ')}`);
+    'a path rooted at a variable that is neither a sanctioned anchor nor bound in '
+    + `the same fenced region resolves to a shipped file:\n  ${offenders.join('\n  ')}`);
 
-  // Non-vacuity, both ways: the rule must fire on a rogue spelling and stay silent on
-  // a workspace root, or it is proving nothing about either.
+  // Non-vacuity, on every axis this rule decides. A control that cannot fire proves
+  // nothing about the case beside it.
   const shipped = [...PLUGIN_FILES].find((k) => k.includes('/'));
-  VAR_ROOTED.lastIndex = 0;
-  const rogue = VAR_ROOTED.exec(`node "$SOME_OTHER_ROOT/${shipped}"`);
-  assert.ok(rogue && !ANCHOR_VARS.has(rogue[1]) && PLUGIN_FILES.has(normalizePath(rogue[2])),
-    'the rule must recognise a rogue spelling of the plugin root');
-  VAR_ROOTED.lastIndex = 0;
-  const workspace = VAR_ROOTED.exec('cat "$WORK_DIR/research/notes.md"');
-  assert.ok(workspace && !PLUGIN_FILES.has(normalizePath(workspace[2])),
+  const hits = (text) => {
+    const out = [];
+    const lines = text.split('\n');
+    const regions = fenceRegions(text);
+    lines.forEach((line, i) => {
+      VAR_ROOTED.lastIndex = 0;
+      let m;
+      while ((m = VAR_ROOTED.exec(line))) {
+        if (ANCHOR_VARS.has(m[1])) continue;
+        if (locallyBound(lines, regions, i, m[1])) continue;
+        if (PLUGIN_FILES.has(resolveTail(m[2]))) out.push(m[1]);
+      }
+    });
+    return out;
+  };
+  assert.deepEqual(hits(`node "$SOME_OTHER_ROOT/${shipped}"`), ['SOME_OTHER_ROOT'],
+    'the rule must fire on a rogue spelling of the plugin root');
+  assert.deepEqual(hits('cat "$WORK_DIR/research/notes.md"'), [],
     'a workspace root must stay silent — its tail does not name a shipped file');
+  assert.deepEqual(hits(`node "\${CLAUDE_PLUGIN_ROOT}/${shipped}"`), [],
+    'the sanctioned anchor must stay silent');
+  // Traversal and `.` spellings of the same shipped file, which the exact-string
+  // lookup used to miss.
+  const dir = shipped.slice(0, shipped.lastIndexOf('/'));
+  const base = shipped.slice(shipped.lastIndexOf('/') + 1);
+  assert.deepEqual(hits(`node "$SOME_OTHER_ROOT/./${shipped}"`), ['SOME_OTHER_ROOT'],
+    'a `.` segment must not hide a shipped tail');
+  assert.deepEqual(hits(`node "$SOME_OTHER_ROOT/${dir}/../${dir}/${base}"`), ['SOME_OTHER_ROOT'],
+    'a `..` round trip must not hide a shipped tail');
+  // Local binding: same line, same block, bound vs unbound.
+  const bound = ['```bash', `X_ROOT="\${CLAUDE_PLUGIN_ROOT}"`, `node "$X_ROOT/${shipped}"`, '```'].join('\n');
+  const unbound = ['```bash', `node "$X_ROOT/${shipped}"`, '```'].join('\n');
+  assert.deepEqual(hits(bound), [], 'a variable bound from the anchor in the same block is safe');
+  assert.deepEqual(hits(unbound), ['X_ROOT'],
+    'the same variable unbound must fire, or the binding arm is accepting everything');
+  const otherBlock = ['```bash', `X_ROOT="\${CLAUDE_PLUGIN_ROOT}"`, '```', '', '```bash',
+    `node "$X_ROOT/${shipped}"`, '```'].join('\n');
+  assert.deepEqual(hits(otherBlock), ['X_ROOT'],
+    'a binding in a different block must not carry over — the reader copies one block');
 });
-
 test('a backslash separator does not hide a path from the guard', () => {
   // The bypass table from review, used verbatim as the fixture. Measured on the
   // commit before this fix by planting one line at a time into AGENTS.md in a

--- a/tests/skill-reference-integrity.test.js
+++ b/tests/skill-reference-integrity.test.js
@@ -1509,6 +1509,86 @@ test('the documented pluginRequire helpers realpath their target', () => {
     + `root would be followed:\n  ${missing.join('\n  ')}`);
 });
 
+
+// The accepted spellings are whatever the RUNTIME reads from the environment to
+// find its own root — asked of the code, not listed here. All three repos in this
+// family accept a Claude name and a generic Codex name, and a first version of the
+// rule below assumed a single spelling and reported the generic one as rogue. It was
+// legitimate: `runtime/hook-context.js` reads both, and AGENTS.md says so.
+const ANCHOR_VARS = (() => {
+  const found = new Set();
+  const walk = (dir) => {
+    if (!fs.existsSync(dir)) return;
+    for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+      const p = path.join(dir, e.name);
+      if (e.isDirectory()) { walk(p); continue; }
+      if (!/\.(?:[cm]?js|json)$/.test(e.name)) continue;
+      const body = fs.readFileSync(p, 'utf8');
+      for (const m of body.matchAll(/(?:^|[^A-Za-z0-9_.])env(?:ironment)?\.([A-Z][A-Z0-9_]*_PLUGIN_ROOT|PLUGIN_ROOT)/g)) found.add(m[1]);
+      for (const m of body.matchAll(/process\.env\.([A-Z][A-Z0-9_]*_PLUGIN_ROOT|PLUGIN_ROOT)/g)) found.add(m[1]);
+    }
+  };
+  ['runtime', 'hooks', 'scripts', 'lib'].forEach((s) => walk(path.join(ROOT, s)));
+  return found;
+})();
+test('a variable-rooted path that resolves in the plugin uses the one anchor spelling', () => {
+  // The guard recognises `${CLAUDE_PLUGIN_ROOT}` and flags a BARE `sensors/x.js`,
+  // but any variable root silenced it: `$ANYTHING/sensors/x.js` was clean. So a
+  // second, undefined spelling of the plugin root passed unnoticed — measured live
+  // in this family as `$PLUGIN_DIR/` and `$PLUGIN_ROOT/`, neither of which anything
+  // exports. Unset, they expand to nothing and the command breaks; set by the
+  // analysed project's environment, they resolve wherever that points and `node`
+  // runs it.
+  //
+  // The rule cannot be "no variable roots" — `$WORK_DIR` and `$PROJECT_ROOT` are
+  // legitimate workspace roots and outnumber the anchor here. What separates them is
+  // structural and needs no list of names: **does the tail resolve in the shipped
+  // index?** Measured across every variable-rooted path in the scanned documents:
+  //
+  //   $CLAUDE_PLUGIN_ROOT  181 tails resolve   (the anchor)
+  //   $PLUGIN_DIR            4 resolve, 0 not  (rogue)
+  //   $PLUGIN_ROOT           3 resolve, 0 not  (rogue)
+  //   $WORK_DIR              0 resolve, 179 not
+  //   $PROJECT_ROOT          0 resolve,  16 not
+  //
+  // Zero overlap. A variable whose tail names a shipped file is rooting a path at
+  // this plugin, whatever it is called.
+  // The derivation must find the runtime's own names, or the rule below is comparing
+  // against nothing and every variable root looks rogue.
+  assert.ok(ANCHOR_VARS.size > 0,
+    'no anchor env name was found in the runtime — the rule has no baseline');
+  assert.ok(ANCHOR_VARS.has('CLAUDE_PLUGIN_ROOT'),
+    'the Claude spelling must be among the accepted names');
+  const VAR_ROOTED = /\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?[\\/]([A-Za-z0-9._\\/-]+)/g;
+  const offenders = [];
+  for (const file of markdownFiles()) {
+    fs.readFileSync(file, 'utf8').split('\n').forEach((line, i) => {
+      VAR_ROOTED.lastIndex = 0;
+      let m;
+      while ((m = VAR_ROOTED.exec(line))) {
+        if (ANCHOR_VARS.has(m[1])) continue;
+        if (!PLUGIN_FILES.has(normalizePath(m[2]))) continue;
+        offenders.push(`${path.relative(ROOT, file)}:${i + 1}  $${m[1]}/${m[2]}`);
+      }
+    });
+  }
+  assert.deepEqual(offenders, [],
+    'a path rooted at a variable other than the anchor resolves to a shipped file, so '
+    + `that variable is a second spelling of the plugin root:\n  ${offenders.join('\n  ')}`);
+
+  // Non-vacuity, both ways: the rule must fire on a rogue spelling and stay silent on
+  // a workspace root, or it is proving nothing about either.
+  const shipped = [...PLUGIN_FILES].find((k) => k.includes('/'));
+  VAR_ROOTED.lastIndex = 0;
+  const rogue = VAR_ROOTED.exec(`node "$SOME_OTHER_ROOT/${shipped}"`);
+  assert.ok(rogue && !ANCHOR_VARS.has(rogue[1]) && PLUGIN_FILES.has(normalizePath(rogue[2])),
+    'the rule must recognise a rogue spelling of the plugin root');
+  VAR_ROOTED.lastIndex = 0;
+  const workspace = VAR_ROOTED.exec('cat "$WORK_DIR/research/notes.md"');
+  assert.ok(workspace && !PLUGIN_FILES.has(normalizePath(workspace[2])),
+    'a workspace root must stay silent — its tail does not name a shipped file');
+});
+
 test('a backslash separator does not hide a path from the guard', () => {
   // The bypass table from review, used verbatim as the fixture. Measured on the
   // commit before this fix by planting one line at a time into AGENTS.md in a

--- a/tests/skill-reference-integrity.test.js
+++ b/tests/skill-reference-integrity.test.js
@@ -1521,30 +1521,36 @@ test('the documented pluginRequire helpers realpath their target', () => {
 // to hold the plugin root at the moment this line runs?** Two things guarantee it,
 // and neither needs a name:
 //
-//   1. The contract document declares the spelling. A name counts only where
-//      AGENTS.md writes it as a VARIABLE REFERENCE in a NON-path position:
-//      `Codex sets ${PLUGIN_ROOT} for the same root` is a sanction; `${X}/lib/a.js`
-//      is a use, and a bare prose mention of the string is neither. Measured, in
-//      that order: a use alone FIRES, a use plus a passing prose mention still
-//      FIRES, and only an added sanction sentence goes silent. So the accept-set
-//      widens by one deliberate edit to the contract and by nothing else.
+//   1. The spelling is sanctioned. The set is written here, in the security test,
+//      and pinned against the contract document — not scraped out of it. Scraping
+//      matched a syntactic shape and called it a sanction, so the sentence that most
+//      explicitly FORBIDS a spelling was the sentence that permitted it:
+//      `Never use \${ZZZ_PLUGIN_ROOT} — no host in this family sets it.` widened the
+//      accept-set, and so did an HTML comment, which renders as nothing at all. A
+//      shape cannot carry a sentence's meaning. Widening now takes an edit to this
+//      file, which is the gate that should be hardest to pass.
 //   2. The variable is bound earlier in the same fenced region, from an already
 //      accepted anchor. A local needs no host to set it. This is the real reason
-//      deep-report's `PLUGIN_ROOT="$(cd "${CLAUDE_PLUGIN_ROOT:?…}" && pwd -P)"` is
+//      deep-report's `PLUGIN_ROOT="$(cd "\${CLAUDE_PLUGIN_ROOT:?…}" && pwd -P)"` is
 //      safe, and the first version accepted those three lines for an unrelated
 //      reason — it would have accepted them just as readily without the binding.
 const CONTRACT_DOC = 'AGENTS.md';
-const ANCHOR_VARS = (() => {
-  const body = fs.readFileSync(path.join(ROOT, CONTRACT_DOC), 'utf8');
-  const found = new Set();
-  for (const m of body.matchAll(/\$\{?([A-Z][A-Z0-9_]*_PLUGIN_ROOT|PLUGIN_ROOT)\}?`?(?![A-Za-z0-9_/\\])/g)) {
-    found.add(m[1]);
-  }
-  return found;
-})();
+const ANCHOR_VARS = new Set(['CLAUDE_PLUGIN_ROOT']);
 
-// A local binding is `VAR=` (optionally `export VAR=`) whose right-hand side names
-// an accepted anchor, on an earlier line with **no fence marker in between**.
+// A local binding is `VAR=` (optionally `export VAR=`) whose RIGHT-HAND SIDE
+// references an accepted anchor, on an earlier line with no fence marker in between.
+//
+// The right-hand side, not the line. Testing the line let a COMMENT do the work:
+//
+//     X_ROOT="$PWD"   # CLAUDE_PLUGIN_ROOT is unset on this host
+//     node "$X_ROOT/<shipped>.js"
+//
+// went silent — a plausible line for someone documenting a non-Claude fallback, which
+// roots the path at the working directory (the analysed project) and then runs a
+// shipped script name from it. That is the whole attack, with the guard quiet. The
+// same slip admitted `X_ROOT="\${CLAUDE_PLUGIN_ROOT_BACKUP}"`, where an accepted name
+// is merely a substring of a variable nothing sets, so the reference is matched with
+// a boundary rather than by `includes`.
 //
 // Regions are delimited by fence markers, not by `fenceBlocks()`'s CommonMark block
 // ids, and the difference is load-bearing here. `skills/deep-report/SKILL.md` nests
@@ -1555,21 +1561,54 @@ const ANCHOR_VARS = (() => {
 // in; it is whether a reader copying from the binding to the use crosses a boundary,
 // because two fenced blocks are two shell invocations and the second does not
 // inherit the first's variables. Any fence marker between them is that boundary.
+//
+// Region 0 is everything before the document's first fence, where no shell runs at
+// all, so a binding there is prose and cannot bind anything. RESIDUAL, stated rather
+// than claimed away: prose sitting BETWEEN two fenced blocks gets a region of its own
+// and can still read as a binding. Closing that needs open/close state, which is
+// exactly what the nesting above makes unreliable here.
+// A marker WITH an info string opens; a bare marker closes. That convention, not
+// CommonMark's same-length matching, is what these documents actually follow — and it
+// is the only reading under which `skills/deep-report/SKILL.md`'s ```bash nested in a
+// ```markdown template puts its own lines inside a block. Depth is clamped at zero, so
+// a document that opens with a bare marker under-counts and its bindings are rejected
+// rather than trusted.
 function fenceRegions(body) {
   let region = 0;
+  let depth = 0;
   return body.split('\n').map((line) => {
-    if (/^[ \t]*(?:`{3,}|~{3,})/.test(line)) { region += 1; return null; }
-    return region;
+    const m = /^[ \t]*(?:`{3,}|~{3,})(.*)$/.exec(line);
+    if (m) {
+      region += 1;
+      depth = m[1].trim() ? depth + 1 : Math.max(0, depth - 1);
+      return null;
+    }
+    return depth > 0 ? region : null;   // prose binds nothing — no shell runs it
   });
+}
+function bindsAnchor(line, name) {
+  const assign = new RegExp(`(?:^|[;&|]\\s*)(?:export\\s+)?${name}=`);
+  const m = assign.exec(line);
+  if (!m) return false;
+  let rhs = line.slice(m.index + m[0].length);
+  // A trailing unquoted `#` comment is not part of the value. Quotes are tracked so
+  // a `#` inside one stays in the value.
+  let q = null;
+  for (let i = 0; i < rhs.length; i += 1) {
+    const c = rhs[i];
+    if (q) { if (c === q) q = null; continue; }
+    if (c === '"' || c === "'") { q = c; continue; }
+    if (c === '#' && (i === 0 || /\s/.test(rhs[i - 1]))) { rhs = rhs.slice(0, i); break; }
+  }
+  return [...ANCHOR_VARS].some((a) =>
+    new RegExp(`\\$\\{?${a}(?![A-Za-z0-9_])`).test(rhs));
 }
 function locallyBound(lines, regions, upTo, name) {
   const region = regions[upTo];
-  if (region === null) return false;
-  const assign = new RegExp(`(?:^|[;&|]\\s*)(?:export\\s+)?${name}=`);
+  if (region === null) return false;   // the use is not inside a block
   for (let j = 0; j < upTo; j += 1) {
     if (regions[j] !== region) continue;
-    if (!assign.test(lines[j])) continue;
-    if ([...ANCHOR_VARS].some((a) => lines[j].includes(a))) return true;
+    if (bindsAnchor(lines[j], name)) return true;
   }
   return false;
 }
@@ -1597,7 +1636,18 @@ test('a variable-rooted path that resolves in the plugin uses a sanctioned ancho
   // Zero overlap. A variable whose tail names a shipped file is rooting a path at
   // this plugin, whatever it is called.
   assert.ok(ANCHOR_VARS.has('CLAUDE_PLUGIN_ROOT'),
-    `${CONTRACT_DOC} must name the anchor spelling, or this rule has no baseline`);
+    'the Claude spelling is the baseline and must be accepted');
+  // The set lives in this file, so it cannot drift from the contract silently: every
+  // accepted spelling must also be written in the contract document as a variable.
+  // The first version had this backwards — it read the names OUT of the runtime and
+  // justified the width with "AGENTS.md says so", which was true in two sibling repos
+  // and false here.
+  const contract = fs.readFileSync(path.join(ROOT, CONTRACT_DOC), 'utf8');
+  for (const name of ANCHOR_VARS) {
+    assert.match(contract, new RegExp(`\\$\\{?${name}(?![A-Za-z0-9_])`),
+      `${CONTRACT_DOC} must document \${${name}} as an anchor, or the guard accepts `
+      + 'a spelling the contract never sanctioned');
+  }
   // What the set EXCLUDES is the half that can rot. A rule asserting only what its
   // accept-list contains can widen forever and stay green; the first version did
   // exactly that, and a single added comment was enough to whitelist a new name.
@@ -1680,6 +1730,27 @@ test('a variable-rooted path that resolves in the plugin uses a sanctioned ancho
     `node "$X_ROOT/${shipped}"`, '```'].join('\n');
   assert.deepEqual(hits(otherBlock), ['X_ROOT'],
     'a binding in a different block must not carry over — the reader copies one block');
+  // Review found each of these silent, so each gets its own case. Every one is a
+  // complete attack: the path ends up rooted somewhere in the analysed project and a
+  // shipped script name is run from it.
+  const inBlock = (...body) => ['```bash', ...body, '```'].join('\n');
+  assert.deepEqual(
+    hits(inBlock(`X_ROOT="$PWD"   # ${[...ANCHOR_VARS][0]} is unset on this host`,
+      `node "$X_ROOT/${shipped}"`)), ['X_ROOT'],
+    'an anchor named only in a trailing COMMENT must not count as the binding');
+  assert.deepEqual(
+    hits(inBlock(`X_ROOT="\${${[...ANCHOR_VARS][0]}_BACKUP}"`, `node "$X_ROOT/${shipped}"`)),
+    ['X_ROOT'],
+    'an accepted name that is merely a SUBSTRING of the bound variable must not count');
+  assert.deepEqual(
+    hits([`X_ROOT=\${${[...ANCHOR_VARS][0]}} is the convention below.`,
+      `$X_ROOT/${shipped}`].join('\n')), ['X_ROOT'],
+    'a binding written in PROSE binds nothing — no shell runs it');
+  // And the accept-set cannot be widened from the corpus at all: the names live in
+  // this file. A sentence in the contract document that FORBIDS a spelling used to
+  // permit it, because the scraper matched a shape and called it a sanction.
+  assert.ok(!ANCHOR_VARS.has('ZZZ_PLUGIN_ROOT'),
+    'the accept-set is declared here, not scraped from prose');
 });
 test('a backslash separator does not hide a path from the guard', () => {
   // The bypass table from review, used verbatim as the fixture. Measured on the


### PR DESCRIPTION
The guard recognised the anchor and flagged a bare `sensors/detect.js`, but **any**
variable root silenced it. Measured on this tree:

    node "sensors/detect.js"                     FLAGGED
    node "$PLUGIN_DIR/sensors/detect.js"         clean
    node "$UNDEFINED_VAR/sensors/detect.js"      clean

So a second, undefined spelling of the plugin root passed unnoticed — and two
shipped skills were using one. Nothing exports `PLUGIN_DIR`; the only assignment is
a local in `hooks/scripts/update-check.sh`. Unset it expands to nothing and the
command breaks; set by the analysed project's environment it resolves wherever that
points, and `node` runs it.

The rule cannot be "no variable roots" — `$WORK_DIR` (179 sites) and `$PROJECT_ROOT`
(16) are legitimate workspace roots and outnumber the anchor. What separates them is
structural and needs no list of names: **does the tail resolve in the shipped
index?** Measured across every variable-rooted path in the scanned documents:

    $CLAUDE_PLUGIN_ROOT   181 tails resolve       (the anchor)
    $PLUGIN_DIR             4 resolve, 0 not      (rogue)
    $PLUGIN_ROOT            3 resolve, 0 not      (accepted — see below)
    $WORK_DIR               0 resolve, 179 not
    $PROJECT_ROOT           0 resolve,  16 not

Zero overlap. A variable whose tail names a shipped file is rooting a path at this
plugin, whatever it is called.

The accepted spellings are derived from the runtime rather than listed. A first
version assumed a single anchor and reported `$PLUGIN_ROOT` as rogue; it is not —
`runtime/hook-context.js` reads both `PLUGIN_ROOT` and `CLAUDE_PLUGIN_ROOT`, because
Codex sets the generic name. Three edits made under that wrong premise were
reverted. The rule now reads the env names the runtime itself consults, so a repo
that supports four hosts gets four accepted spellings without anyone maintaining a
list.

Found by widening a cross-repo sweep after a sibling turned up `${CLAUDE_PLUGIN_DIR}`
— `_DIR`, not `_ROOT` — which every enumeration in this family would have missed.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
