### PR TITLE
fix: optimize GPT model routing by host

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deep-work",
-  "version": "7.1.1",
+  "version": "7.1.2",
   "description": "Evidence-Driven Development Protocol — 24 command-equivalent skill surfaces plus a skill-native deep-work entry alias (cross-platform: Claude Code skills + Codex / Copilot CLI / Gemini CLI / SDK), 3-layer architecture with Skill-based phase dispatch, computational enforcement (worktree guard + phase transition injection), TDD enforcement, and receipt validation",
   "author": {
     "name": "sungmin"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deep-work",
-  "version": "7.1.1",
+  "version": "7.1.2",
   "description": "Evidence-Driven Development Protocol with skill-based phase dispatch, computational enforcement, TDD discipline, and receipt validation",
   "author": {
     "name": "sungmin"

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ specs/
 plans/
 
 # Dev tooling caches and local-only artifacts (never committed)
+/package-lock.json
 .claude/
 .deep-review/
 .deep-docs/

--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -7,6 +7,18 @@ Deep Work 플러그인의 모든 주요 변경 사항을 이 파일에 기록합
 형식은 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)를 따르며,
 이 프로젝트는 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)을 준수합니다.
 
+## [7.1.2] — 2026-08-03 (호스트 명시형 GPT 라우팅)
+
+### Changed
+
+- **Codex 라우팅이 risk floor를 약화하지 않고 GPT-5.6 가격·성능 프런티어를 따릅니다.** light·standard·deep 슬롯은 각각 GPT-5.6 Luna·Terra·Sol로 유지하며, 가격만의 산식이 아니라 methodology risk와 오류 비용이 최소 tier를 계속 결정합니다.
+- **모델 라우팅이 실제 host를 명시적으로 결속합니다.** orchestrator와 authoritative research reroute가 현재 `Agent` 도구 사용 가능 여부로 `claude`/`codex`를 판정하고 같은 shell invocation에서 routing CLI에 runtime을 전달하며, host를 확정하지 못하면 fail closed로 중단합니다. persisted runtime과 child-process 환경 marker는 현재 host 판정을 덮어쓸 수 없습니다.
+
+### Fixed
+
+- **라우팅 contract 테스트가 실행 가능한 shadow assignment를 거부합니다.** split fence, comment, indentation, semicolon/logical separator, pipe, background command, export, quote, escape, Bash backslash-newline token splicing mutant를 포괄하면서 정상적인 continued argument는 허용합니다.
+- **저장소 로컬 npm lockfile은 로컬에만 남습니다.** npm 검증 과정에서 생긴 루트 `package-lock.json`이 릴리스 commit에 섞이지 않도록 ignore합니다.
+
 ## [7.1.1] — 2026-07-28 (경로 구분자 정규화)
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable changes to the Deep Work plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.1.2] — 2026-08-03 (Host-Explicit GPT Routing)
+
+### Changed
+
+- **Codex routing follows the GPT-5.6 price-performance frontier without weakening risk floors.** The light, standard, and deep slots remain pinned to GPT-5.6 Luna, Terra, and Sol respectively, while methodology risk and error cost continue to set the minimum tier rather than a price-only formula.
+- **Model routing now binds the actual host explicitly.** The orchestrator and authoritative research reroute derive `claude` versus `codex` from live `Agent` tool availability, pass that runtime to the routing CLI in the same shell invocation, and fail closed when the host cannot be resolved. Persisted runtime and child-process environment markers cannot override the current host.
+
+### Fixed
+
+- **Routing contract tests now reject executable shadow assignments.** Regression mutants cover split fences, comments, indentation, semicolon/logical separators, pipes, background commands, exports, quoting, escapes, and Bash backslash-newline token splicing while preserving valid continued arguments.
+- **Repository-local npm lockfiles stay local.** The root `package-lock.json` is ignored so npm verification does not leak an untracked lockfile into release commits.
+
 ## [7.1.1] — 2026-07-28 (Separator Normalisation)
 
 ### Security

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-deep-work/deep-work",
-  "version": "7.1.1",
+  "version": "7.1.2",
   "engines": {
     "node": ">=22"
   },

--- a/runtime/model-catalog.js
+++ b/runtime/model-catalog.js
@@ -3,13 +3,13 @@
 const TIERS = Object.freeze(['light', 'standard', 'deep']);
 const MAIN = 'main';
 const CATALOG_VERSION = 1;
-// codex 슬롯은 Task 12(실기 검증)에서 pin됨 — 로컬 설치 codex-cli 0.144.6 실기 조사
-// (~/.codex/models_cache.json, fetched_at 2026-07-19T18:48:19Z, client_version 0.145.0) 근거:
+// codex 슬롯은 로컬 catalog와 OpenAI의 2026-07-30 GPT-5.6 price-performance 지침에 따라 pin됨.
+// (~/.codex/models_cache.json, fetched_at 2026-08-02T07:47Z, client_version 0.146.0) 근거:
 // visibility:"list"(비-hidden/비-deprecated) 상위 3개 모델을 priority 오름차순 + description으로 매핑
 //   gpt-5.6-luna  (priority 3, "Fast and affordable agentic coding model.")      → light
 //   gpt-5.6-terra (priority 2, "Balanced agentic coding model for everyday work.") → standard
 //   gpt-5.6-sol   (priority 1, "Latest frontier agentic coding model." / "Our most capable model yet") → deep
-// 상세 근거: .superpowers/sdd/task-12-report.md
+// 가격 자체는 routing formula에 넣지 않는다. stakes/error cost는 기존 methodology risk floor가 담당한다.
 const DEFAULT_CATALOG = Object.freeze({
   claude: Object.freeze({ light: 'haiku', standard: 'sonnet', deep: 'opus', main: MAIN }),
   codex: Object.freeze({ light: 'gpt-5.6-luna', standard: 'gpt-5.6-terra', deep: 'gpt-5.6-sol', main: MAIN }),

--- a/skills/deep-research/SKILL.md
+++ b/skills/deep-research/SKILL.md
@@ -234,13 +234,25 @@ rm -f "$RISK_IN"
 
 3. 성공한 authoritative class로 재라우팅한다. 초기 spawn에서 이미
    Read(`${CLAUDE_PLUGIN_ROOT}/skills/shared/references/model-routing-guide.md#model-routing-state-decode-v612`)를
-   수행했으므로 pin은 `decodedRoutingMeta.pinned`, runtime은 CLI 자동 감지를 사용한다.
+   수행했으므로 pin은 `decodedRoutingMeta.pinned`에서 재사용한다. runtime은 reroute 시점의
+   현재 host `Agent` 도구 사용 가능 여부를 직접 확인해 refresh하며, persisted runtime 재사용은 금지한다.
+   manifest와 child process env marker도 host authority로 사용하지 않는다.
    v1이면 `methodology_policy_json.policy_sha256`를 먼저 검증한다. legacy
    v6.12 shape는 closed fallback parser로 읽어 새 authority로 승격한다. `RISK_OUT`은 새
    authoritative risk와 직전 floor를 결합한 `methodology_authority`를 산출하며,
    이 authority 전체를 router facade에 넘긴다.
 
+   Agent tool available인 Claude Code host는 `claude`, Agent tool unavailable인 Codex
+   host는 `codex`를 선택한다. 아래 블록을 실행하기 전에 placeholder 전체를 그 literal
+   하나로 치환한다. 대입과 소비는 반드시 이 한 shell invocation 안에서 함께 실행하며,
+   host를 확정할 수 없거나 placeholder가 남아 있으면 fail closed로 중단한다.
+
 ```bash
+ROUTING_RUNTIME="<current host: claude or codex>"
+case "$ROUTING_RUNTIME" in
+  claude|codex) ;;
+  *) printf '%s\n' 'ERROR: current host runtime is unresolved' >&2; exit 1 ;;
+esac
 AUTH_CLASS=$(printf '%s' "$RISK_OUT" | node -e \
   'const r=JSON.parse(require("fs").readFileSync(0,"utf8"));process.stdout.write(r.risk_profile?.class||"")')
 METHODOLOGY_AUTHORITY=$(printf '%s' "$RISK_OUT" | node -e \
@@ -249,6 +261,7 @@ METHODOLOGY_AUTHORITY=$(printf '%s' "$RISK_OUT" | node -e \
 MR_OUT=$(node "${CLAUDE_PLUGIN_ROOT}/scripts/model-routing-cli.js" \
   --root "$PROJECT_ROOT" --task "$TASK_TEXT" --difficulty "${REC_TASK_DIFFICULTY:-}" \
   --pinned "<decodedRoutingMeta.pinned as phase=value CSV>" \
+  --runtime "$ROUTING_RUNTIME" \
   --methodology-policy "$METHODOLOGY_AUTHORITY")
 ```
 

--- a/skills/deep-work-orchestrator/SKILL.md
+++ b/skills/deep-work-orchestrator/SKILL.md
@@ -136,10 +136,24 @@ router를 직접 우회하는 것은 금지한다.
 
 **2단계 — methodology-authority routing facade:**
 
+현재 host의 `Agent` 도구 사용 가능 여부를 직접 확인한다. Agent tool available인
+Claude Code host는 `claude`, Agent tool unavailable인 Codex host는 `codex`를 선택한다.
+manifest, child process env marker, 이전 session state는 이 판정의 authority가 아니다.
+
+아래 블록을 실행하기 전에 placeholder 전체를 관측한 host의 literal 하나로 치환한다.
+대입과 소비는 반드시 이 한 shell invocation 안에서 함께 실행한다. host를 확정할 수
+없거나 placeholder가 남아 있으면 fail closed로 중단한다.
+
 ```bash
+ROUTING_RUNTIME="<current host: claude or codex>"
+case "$ROUTING_RUNTIME" in
+  claude|codex) ;;
+  *) printf '%s\n' 'ERROR: current host runtime is unresolved' >&2; exit 1 ;;
+esac
 MR_OUT=$(node "${CLAUDE_PLUGIN_ROOT}/scripts/model-routing-cli.js" \
   --root "$PROJECT_ROOT" --task "$TASK_TEXT" \
   --difficulty "${REC_TASK_DIFFICULTY:-}" --pinned "${FLAGS.model_routing:-}" \
+  --runtime "$ROUTING_RUNTIME" \
   --methodology-policy "$METHODOLOGY_AUTHORITY")
 ```
 

--- a/tests/integration/v6.4.0-smoke.test.js
+++ b/tests/integration/v6.4.0-smoke.test.js
@@ -211,8 +211,8 @@ describe('v6.4.0 integration — Health Engine command contracts', () => {
 });
 
 describe('release metadata', () => {
-  it('active release metadata is bumped to 7.1.1 with evergreen usage docs', () => {
-    const version = '7.1.1';
+  it('active release metadata is bumped to 7.1.2 with evergreen usage docs', () => {
+    const version = '7.1.2';
     const featureVersion = '6.9.0';
     const root = path.join(__dirname, '..', '..');
     const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
@@ -227,21 +227,25 @@ describe('release metadata', () => {
     assert.equal(claudePlugin.version, version);
     assert.equal(codexPlugin.version, version);
 
-    // Current release (7.1.1) — separator normalisation in the plugin-path guard.
+    // Current release (7.1.2) — host-explicit GPT routing.
     const changelogCurrent = releaseSection(changelog, version);
     const changelogKoCurrent = releaseSection(changelogKo, version);
-    assert.match(changelogCurrent,/Windows-style path spelling no longer escapes the plugin-path guard/);
-    assert.match(changelogKoCurrent,/Windows 방식으로 쓴 경로가 플러그인 경로 가드를 우회할 수 없습니다/);
-    // The prior release (7.1.0) keeps its own context-diet headlines; a patch
+    assert.match(changelogCurrent,/Model routing now binds the actual host explicitly/);
+    assert.match(changelogKoCurrent,/모델 라우팅이 실제 host를 명시적으로 결속합니다/);
+    assert.match(changelogCurrent,/backslash-newline token splicing/);
+    assert.match(changelogKoCurrent,/backslash-newline token splicing/);
+    // Prior patch and feature releases keep their own headlines; this patch
     // release must not absorb them into its own section.
+    assert.match(releaseSection(changelog, '7.1.1'),/Windows-style path spelling no longer escapes the plugin-path guard/);
+    assert.match(releaseSection(changelogKo, '7.1.1'),/Windows 방식으로 쓴 경로가 플러그인 경로 가드를 우회할 수 없습니다/);
     assert.match(releaseSection(changelog, '7.1.0'),/Per-skill `references\/` split/);
     assert.match(releaseSection(changelog, '7.1.0'),/`AGENTS\.md` is the single agent guide/);
     assert.match(releaseSection(changelogKo, '7.1.0'),/스킬별 `references\/` 분할/);
     assert.match(releaseSection(changelogKo, '7.1.0'),/`AGENTS\.md`가 단일 에이전트 가이드/);
     assert.equal(changelogCurrent.includes('Per-skill `references/` split'), false,
-      'CHANGELOG.md 7.1.1 section must not absorb the 7.1.0 context-diet note');
+      'CHANGELOG.md 7.1.2 section must not absorb the 7.1.0 context-diet note');
     assert.equal(changelogKoCurrent.includes('스킬별 `references/` 분할'), false,
-      'CHANGELOG.ko.md 7.1.1 section must not absorb the 7.1.0 context-diet note');
+      'CHANGELOG.ko.md 7.1.2 section must not absorb the 7.1.0 context-diet note');
     // The prior release (7.0.0) section keeps its own Spec / methodology-authority
     // headlines; the 7.1.x promotions must not clobber or absorb them.
     assert.match(releaseSection(changelog, '7.0.0'),/Explicit Spec phase and profile v4/);

--- a/tests/v6.12-routing-wiring-contract.test.js
+++ b/tests/v6.12-routing-wiring-contract.test.js
@@ -2,11 +2,160 @@
 
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const { execFileSync } = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
 
 const ROOT = path.resolve(__dirname, '..');
 const read = (relativePath) => fs.readFileSync(path.join(ROOT, relativePath), 'utf8');
+
+function routingCallWindow(skill, anchor) {
+  const anchorIndex = skill.indexOf(anchor);
+  assert.ok(anchorIndex >= 0, `missing routing anchor: ${anchor}`);
+  const callIndex = skill.indexOf('MR_OUT=$(node "${CLAUDE_PLUGIN_ROOT}/scripts/model-routing-cli.js"', anchorIndex);
+  assert.ok(callIndex > anchorIndex, `missing model-routing call after: ${anchor}`);
+  return skill.slice(anchorIndex, callIndex + 700);
+}
+
+function bashFences(block) {
+  return [...block.matchAll(/```bash\n([\s\S]*?)```/g)].map((match) => match[1]);
+}
+
+function unquotedShellSurface(shell) {
+  let surface = '';
+  let quote = null;
+  let escaped = false;
+  let comment = false;
+  for (let index = 0; index < shell.length; index++) {
+    const char = shell[index];
+    if (comment) {
+      if (char === '\n') {
+        comment = false;
+        surface += '\n';
+      } else {
+        surface += ' ';
+      }
+      continue;
+    }
+    if (escaped) {
+      surface += ' ';
+      escaped = false;
+      continue;
+    }
+    if (quote) {
+      if (char === '\\' && quote === '"' && shell[index + 1] === '\n') {
+        index++;
+        continue;
+      }
+      if (char === '\\' && quote === '"') escaped = true;
+      else if (char === quote) quote = null;
+      surface += ' ';
+      continue;
+    }
+    if (char === '\\' && shell[index + 1] === '\n') {
+      index++;
+    } else if (char === '\\') {
+      escaped = true;
+      surface += ' ';
+    } else if (char === '"' || char === "'") {
+      quote = char;
+      surface += ' ';
+    } else if (char === '#' && (index === 0 || /[\s;|&()]/.test(shell[index - 1]))) {
+      comment = true;
+      surface += ' ';
+    } else {
+      surface += char;
+    }
+  }
+  return surface;
+}
+
+function runtimeAssignments(shell) {
+  const surface = unquotedShellSurface(shell);
+  return [...surface.matchAll(/(?:^|\n|;|&&|\|\||\||&)\s*(?:export\s+)?ROUTING_RUNTIME\s*=/g)];
+}
+
+function assertCurrentHostRuntimeWiring(block, surface) {
+  assert.match(block, /Agent[^\n]*(?:도구|tool)[^\n]*(?:available|가용|사용 가능)/,
+    `${surface} must derive the runtime from Agent tool availability`);
+  assert.match(block, /Agent[\s\S]{0,120}?(?:available|가용|사용 가능)[\s\S]{0,80}?claude/i,
+    `${surface} must map Agent availability to claude`);
+  assert.match(block, /Agent[\s\S]{0,180}?(?:unavailable|없|사용 불가)[\s\S]{0,80}?codex/i,
+    `${surface} must map Agent unavailability to codex`);
+
+  const routingFences = bashFences(block)
+    .filter((fence) => fence.includes('scripts/model-routing-cli.js'));
+  assert.equal(routingFences.length, 1,
+    `${surface} must define exactly one executable routing fence`);
+  const routingFence = routingFences[0];
+  const assignments = runtimeAssignments(routingFence);
+  assert.equal(assignments.length, 1,
+    `${surface} must assign the selected runtime exactly once in the routing fence`);
+  assert.match(routingFence, /^ROUTING_RUNTIME="<current host: claude or codex>"$/m,
+    `${surface} must require one host-selected literal assignment`);
+  assert.match(routingFence, /case "\$ROUTING_RUNTIME" in[\s\S]*claude\|codex\)[\s\S]*\*\)[\s\S]*exit 1/,
+    `${surface} must fail closed unless the selected literal is claude or codex`);
+  assert.match(routingFence, /--runtime "\$ROUTING_RUNTIME"/,
+    `${surface} must consume the asserted runtime in the same shell fence`);
+
+  const otherFences = bashFences(block).filter((fence) => fence !== routingFence);
+  assert.ok(otherFences.every((fence) => runtimeAssignments(fence).length === 0),
+    `${surface} must not assign runtime in a separate shell fence`);
+}
+
+test('production routing calls assert the current host runtime explicitly', () => {
+  const orchestrator = routingCallWindow(
+    read('skills/deep-work-orchestrator/SKILL.md'),
+    '**2단계 — methodology-authority routing facade:**',
+  );
+  const research = routingCallWindow(
+    read('skills/deep-research/SKILL.md'),
+    '3. 성공한 authoritative class로 재라우팅한다.',
+  );
+
+  assertCurrentHostRuntimeWiring(orchestrator, 'orchestrator initial routing');
+  assertCurrentHostRuntimeWiring(research, 'research authoritative reroute');
+  assert.match(research, /persisted[^\n]*runtime[^\n]*(?:재사용|reuse)[^\n]*(?:금지|않)/i,
+    'authoritative reroute must refresh the current host instead of reusing persisted runtime');
+});
+
+test('runtime wiring contract rejects unsafe executable and prose-only shapes', () => {
+  const prefix = [
+    'Agent tool available maps to claude.',
+    'Agent tool unavailable maps to codex.',
+  ].join('\n');
+  const call = 'MR_OUT=$(node "${CLAUDE_PLUGIN_ROOT}/scripts/model-routing-cli.js" --runtime "$ROUTING_RUNTIME")';
+  const guard = 'case "$ROUTING_RUNTIME" in\n  claude|codex) ;;\n  *) exit 1 ;;\nesac';
+  const splice = String.fromCharCode(92) + '\n';
+
+  assert.throws(() => assertCurrentHostRuntimeWiring(`${prefix}\n\`\`\`bash\nROUTING_RUNTIME="claude"\nROUTING_RUNTIME="codex"\n${call}\n\`\`\``, 'dual assignment'));
+  assert.throws(() => assertCurrentHostRuntimeWiring(`${prefix}\n\`\`\`bash\nROUTING_RUNTIME="<current host: claude or codex>"\ncase "$ROUTING_RUNTIME" in\n  claude|codex) ;;\n  *) exit 1 ;;\nesac\n  ROUTING_RUNTIME="codex"\n${call}\n\`\`\``, 'indented dual assignment'));
+  assert.throws(() => assertCurrentHostRuntimeWiring(`${prefix}\n\`\`\`bash\nROUTING_RUNTIME="<current host: claude or codex>"\ncase "$ROUTING_RUNTIME" in\n  claude|codex) ;;\n  *) exit 1 ;;\nesac\ntrue | ROUTING_RUNTIME="codex"\n${call}\n\`\`\``, 'pipe-prefixed dual assignment'));
+  assert.throws(() => assertCurrentHostRuntimeWiring(`${prefix}\n\`\`\`bash\nROUTING_RUNTIME="<current host: claude or codex>"\ncase "$ROUTING_RUNTIME" in\n  claude|codex) ;;\n  *) exit 1 ;;\nesac\ntrue & ROUTING_RUNTIME="codex"\n${call}\n\`\`\``, 'background-prefixed dual assignment'));
+  assert.throws(() => assertCurrentHostRuntimeWiring(`${prefix}\n\`\`\`bash\nROUTING_RUNTIME="<current host: claude or codex>"\n${guard}\nROUTING_${splice}RUNTIME="codex"\n${call}\n\`\`\``, 'spliced-name dual assignment'));
+  assert.doesNotThrow(() => assertCurrentHostRuntimeWiring(`${prefix}\n\`\`\`bash\nROUTING_RUNTIME="<current host: claude or codex>"\n${guard}\ntrue ${splice}ROUTING_RUNTIME="codex"\n${call}\n\`\`\``, 'continued argument'));
+  assert.throws(() => assertCurrentHostRuntimeWiring(`${prefix}\n\`\`\`bash\nROUTING_RUNTIME="<current host: claude or codex>"\n\`\`\`\n\`\`\`bash\n${call}\n\`\`\``, 'separate fences'));
+  assert.throws(() => assertCurrentHostRuntimeWiring(`${prefix}\n\`\`\`bash\n# ROUTING_RUNTIME="<current host: claude or codex>"\n${call}\n\`\`\``, 'comment-only assignment'));
+});
+
+test('model routing selects the matching Claude and Codex catalogs', () => {
+  const route = (runtime) => JSON.parse(execFileSync(process.execPath, [
+    'scripts/model-routing-cli.js',
+    '--root', '.',
+    '--task', 'runtime wiring contract probe',
+    '--difficulty', 'medium',
+    '--runtime', runtime,
+  ], { cwd: ROOT, encoding: 'utf8' }));
+
+  const claude = route('claude');
+  const codex = route('codex');
+  assert.equal(claude.meta.runtime, 'claude');
+  assert.equal(claude.model_routing.research, 'sonnet');
+  assert.equal(claude.model_routing.test, 'haiku');
+  assert.equal(codex.meta.runtime, 'codex');
+  assert.equal(codex.model_routing.research, 'gpt-5.6-terra');
+  assert.equal(codex.model_routing.test, 'gpt-5.6-luna');
+});
 
 test('orchestrator init wires risk-only -> methodology authority -> routing facade', () => {
   const skill = read('skills/deep-work-orchestrator/SKILL.md');


### PR DESCRIPTION
## Summary

- bind automatic model routing to the live host via Agent-tool availability
- preserve methodology risk floors while documenting the GPT-5.6 Luna/Terra/Sol price-performance mapping
- harden routing contract tests against executable shadow assignments, including Bash backslash-newline splicing
- release deep-work 7.1.2 with synchronized manifests, bilingual changelogs, and a root-only package-lock ignore

## Verification

- independent GPT-only implementation review: APPROVE (0 Critical, 0 Warning)
- focused routing suite: 54/54
- release-integration focused bundle: 62/62
- full `npm test`: 1,791 total / 1,775 passed / 0 failed / 16 skipped
- `git diff --check`
- both plugin manifests and `package.json` parse and report version 7.1.2

## Source

Routing rationale follows OpenAI's GPT-5.6 price-performance guidance while retaining deep-work's existing risk/error-cost floors.
