### PR TITLE
docs(contributing): correct the Node floor and name the field it must track

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,8 @@ git clone https://github.com/Sungmin-Cho/claude-deep-work.git
 cd claude-deep-work
 ```
 
-Node 20+ is required. The plugin's runtime is zero-dependency (Node built-ins +
+Node 22+ is required (`package.json` `engines`). The plugin's runtime is
+zero-dependency (Node built-ins +
 bash hooks); there is no install step for development.
 
 ## Tests


### PR DESCRIPTION
## What

`CONTRIBUTING.md` said **"Node 20+ is required"**. It was the only place in the repo that said 20.

| Source | Value |
|---|---|
| `package.json` `engines` (authority) | `>=22` |
| `AGENTS.md` §Runtime surfaces | Node ≥ 22 |
| `.github/workflows/tests.yml` (both jobs) | `node-version: '22'` |
| **`CONTRIBUTING.md`** | **20+ ← outlier** |

A contributor following it would develop on a runtime the package refuses to install under and that CI never exercises.

## Why it survived

No test reads `CONTRIBUTING.md`. The four places that state the floor do not check each other, so the drift was invisible to `npm test` and to CI.

Correcting the number alone would leave that intact, so the line now names `package.json` `engines` inline as the authority — the next reader can see where the value comes from instead of having to go find it.

## Scope

Docs-only, one line. No behaviour change, so no CHANGELOG entry per `CONTRIBUTING.md` §Pull requests.

Found while auditing this repo's context layers against [the new rules of context engineering for Claude 5 generation models](https://claude.com/blog/the-new-rules-of-context-engineering-for-claude-5-generation-models) — this is the "conflicting guidance across layers" case that article describes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RP4DpxiA8EXmMC16UFGCqD