### PR TITLE
feat(implement): judge plan mismatches by contract impact

### DIFF
--- a/agents/implement-slice-worker.md
+++ b/agents/implement-slice-worker.md
@@ -40,6 +40,13 @@ parent relies on your receipts for verification.
     delegated context; coach observations go to receipt.notes instead)
 - evaluator_model (for Slice Review Stage 1/2)
 
+## Implementation Judgment Contract (before any target-workspace edit)
+
+Read("${CLAUDE_PLUGIN_ROOT}/skills/shared/references/implementation-guide.md")
+and apply its plan-fidelity and plan/reality-mismatch rules before writing a
+test or production file. The guide's `Agent Delegation Pattern` remains owned
+by the calling `deep-implement` skill; do not redispatch from this worker.
+
 ## Unified slice review record
 
 Read `${CLAUDE_PLUGIN_ROOT}/skills/shared/references/adaptive-review-protocol.md` (plugin root 기준 절대 경로 — 해석 결과가 plugin root 밖이면 읽지 말고 중단). Worker는 Stage 1 semantic finding을

--- a/skills/deep-implement/SKILL.md
+++ b/skills/deep-implement/SKILL.md
@@ -74,6 +74,11 @@ Section 1 전체 완료 후, Section 2 First Action 진입 **전에** 실행 모
 
 # Section 2: Phase 실행
 
+## Implementation Judgment Contract
+
+첫 편집 전에 다음 근거 계약을 읽고, 계획 충실도와 현실 불일치를 그 기준으로 판단한다:
+Read("${CLAUDE_PLUGIN_ROOT}/skills/shared/references/implementation-guide.md")
+
 ## First Action (즉시 실행 — 건너뛰기 금지)
 
 Section 1 state 로드, Plan 파싱, Resume Detection, 완료-marker 감지가 silent하게 끝난 뒤 **즉시** 다음 메시지를 출력한다:
@@ -97,7 +102,8 @@ Section 1 state 로드, Plan 파싱, Resume Detection, 완료-marker 감지가 s
 
 ## Critical Constraints
 
-- **Follow the plan EXACTLY. Do not deviate.**
+- **Preserve plan fidelity: do not change the acceptance contract, public interface, scope, or verification evidence without approval.**
+- **A local adaptation within the active slice may proceed only when it does not change those approved boundaries; document and verify it. If a mismatch changes a boundary, stop the affected slice for approval or replanning.**
 - **TDD mandatory** (strict/coaching): failing test → production code → refactor
 - **Do NOT add features not in the plan**
 - **Do NOT modify files outside the active slice's scope**
@@ -417,7 +423,7 @@ Read("${CLAUDE_PLUGIN_ROOT}/skills/shared/references/phase-review-gate.md") — 
 - Document: 구현된 코드 전체 (git diff)
 - Self-review: 계획 충실도, 크로스 슬라이스 일관성, 미구현 항목
 
-상세: Read("${CLAUDE_PLUGIN_ROOT}/skills/shared/references/implementation-guide.md")
+상세 판단 기준은 Section 2 진입 전에 로드한 implementation guide를 따른다.
 
 # Section 3: 완료
 

--- a/skills/shared/references/implementation-guide.md
+++ b/skills/shared/references/implementation-guide.md
@@ -6,9 +6,13 @@ The Implementation phase is about **mechanical execution** of the approved plan.
 
 ## Implementation Methodology
 
-### Core Principle: Boring is Good
+### Core Principle: Plan Fidelity Preserves Evidence
 
-The best implementation phase is a boring one. No surprises, no creativity, no "while I'm here" improvements. Just faithful execution of the plan.
+The approved plan defines the behavior that the acceptance contract and slice receipts
+verify. Implementing against that plan keeps the evidence attached to the change that was
+actually approved. When implementation reveals a worthwhile improvement outside those
+boundaries, preserve the idea in `Issues Encountered` for a later plan cycle instead of
+silently changing the target of verification.
 
 ### Step-by-Step Execution
 
@@ -24,7 +28,11 @@ SLICE-003: path/to/file.ts — Adding UserService class
 Always read the target file before modifying it. Things may have changed since the research phase.
 
 #### 3. Implement
-Make the change exactly as described in the plan. If the plan says "add a method called `authenticate`", add exactly that — don't rename it to `verifyCredentials` because you think it's better.
+Treat names and public shapes specified by the plan as contract terms. If the plan says
+"add a method called `authenticate`", keep that name because acceptance checks and receipt
+evidence are bound to the approved interface. If repository facts make the term invalid or
+unsafe, classify the mismatch by contract impact below rather than silently substituting a
+different interface.
 
 #### 4. Verify
 Run applicable checks:
@@ -45,12 +53,24 @@ Brief status update:
 SLICE-003 완료: UserService 클래스 추가됨
 ```
 
-## Error Handling Protocol
+## Handling Plan/Reality Mismatches
 
-### When Something Doesn't Work as Planned
+### Decide by Contract Impact
 
-1. **Stop immediately** — don't try to hack around it
-2. **Document the issue** in `$WORK_DIR/plan.md`:
+When something does not work as planned, first decide whether the response changes the
+acceptance contract, public interface, scope, or verification evidence.
+
+- A local mismatch that **does not change those approved boundaries** may be adapted in
+  place. Record the observed difference and the adaptation in `$WORK_DIR/plan.md`, run the
+  applicable checks, and continue. Typical examples are a repository-local import path,
+  formatting needed to match nearby code, or a private-name collision whose resolution
+  leaves the approved behavior and evidence unchanged.
+- A mismatch that **does change an approved boundary** requires a new decision. Stop the
+  affected slice, document the issue, explain the impact to the user, and wait for approval
+  or a replan before changing the contract.
+
+Use this issue format for either path:
+
    ```markdown
    ## Issues Encountered
 
@@ -61,22 +81,15 @@ SLICE-003 완료: UserService 클래스 추가됨
    - **Possible causes**: [analysis]
    - **Suggested fix**: [if obvious]
    ```
-3. **Inform the user** — explain what happened and ask for guidance
-4. **Wait** — do not proceed until the user decides how to handle it
 
-### When NOT to Improvise
+Some findings remain mechanism-bound regardless of how local they look:
 
-- The planned approach doesn't work → **Ask the user**
 - You notice a bug in unrelated code → **Note it in Issues, don't fix it**
-- You think of a better way to do something → **Note it in Issues, follow the plan**
 - A dependency is missing → **Report it, don't install it without asking**
 - Tests are failing → **Report the failures, don't modify tests without plan approval**
 
-### When It's OK to Adapt
-
-- Minor syntax adjustments (import paths slightly different)
-- Whitespace/formatting to match file conventions
-- Variable names adjusted to avoid conflicts with existing code (document the change)
+Improvement ideas are not discarded: record them in Issues and route them through the next
+plan cycle so their scope and evidence can be approved deliberately.
 
 ## Rollback Procedures
 
@@ -120,7 +133,7 @@ For testing phase details, see [Testing Guide](testing-guide.md).
 ## Quality Criteria
 
 A good implementation:
-- Follows the plan exactly — no additions, no omissions
+- Matches the approved plan at contract boundaries; local adaptations are documented and verified
 - Each task is verified before moving to the next
 - Issues are documented, not silently worked around
 - The user is kept informed throughout

--- a/tests/plan-quality-contract.test.js
+++ b/tests/plan-quality-contract.test.js
@@ -42,6 +42,75 @@ test('planning references reject vague task checklists', () => {
   assert.doesNotMatch(implementationGuide, /Task \d+\/\d+/);
 });
 
+test('implementation guidance uses contract-impact judgment without weakening safeguards', () => {
+  const implementationGuide = readRepoFile('skills/shared/references/implementation-guide.md');
+  const deepImplement = readRepoFile('skills/deep-implement/SKILL.md');
+  const sliceWorker = readRepoFile('agents/implement-slice-worker.md');
+  const agentGuide = readRepoFile('AGENTS.md');
+
+  assert.ok(implementationGuide.includes('### Core Principle: Plan Fidelity Preserves Evidence'));
+  assert.ok(implementationGuide.includes('acceptance contract and slice receipts'));
+  assert.match(
+    implementationGuide,
+    /changes the\s+acceptance contract, public interface, scope, or verification evidence/,
+  );
+  assert.ok(implementationGuide.includes('does not change those approved boundaries'));
+
+  for (const obsoleteRule of [
+    'No surprises, no creativity',
+    "don't rename it to `verifyCredentials` because you think it's better",
+    '**Stop immediately**',
+    '**Wait** — do not proceed until the user decides how to handle it',
+    '### When NOT to Improvise',
+    '### When It\'s OK to Adapt',
+    'Follows the plan exactly — no additions, no omissions',
+  ]) {
+    assert.ok(!implementationGuide.includes(obsoleteRule), `obsolete rule remains: ${obsoleteRule}`);
+  }
+
+  for (const safeguard of [
+    "bug in unrelated code",
+    "don't install it without asking",
+    "don't modify tests without plan approval",
+    '## Agent Delegation Pattern (v3.1.0)',
+  ]) {
+    assert.ok(implementationGuide.includes(safeguard), `mechanism safeguard missing: ${safeguard}`);
+  }
+
+  const preExecutionGuideRead =
+    'Read("${CLAUDE_PLUGIN_ROOT}/skills/shared/references/implementation-guide.md")';
+  assert.ok(deepImplement.includes(preExecutionGuideRead));
+  assert.ok(
+    deepImplement.indexOf(preExecutionGuideRead) < deepImplement.indexOf('## First Action'),
+    'implementation judgment must be loaded before the first edit',
+  );
+  assert.ok(!deepImplement.includes('Follow the plan EXACTLY. Do not deviate.'));
+  assert.match(
+    deepImplement,
+    /acceptance contract, public interface, scope, or verification evidence/,
+  );
+  assert.match(deepImplement, /local adaptation[\s\S]*document[\s\S]*verify/i);
+
+  assert.ok(sliceWorker.includes(preExecutionGuideRead));
+  assert.ok(
+    sliceWorker.indexOf(preExecutionGuideRead) < sliceWorker.indexOf('# TDD Protocol'),
+    'delegated implementation judgment must be loaded before the first edit',
+  );
+  assert.match(
+    agentGuide,
+    /run that worker's own protocol inline in the calling skill/,
+    'Codex must retain the no-Agent inline worker fallback',
+  );
+  assert.ok(deepImplement.includes('**TDD mandatory**'));
+  assert.ok(deepImplement.includes('**Do NOT modify files outside the active slice\'s scope**'));
+  assert.ok(deepImplement.includes('verify-delegated-receipt.sh'));
+  assert.match(deepImplement, /pass해야 Phase Review Gate에 도달/);
+  assert.ok(sliceWorker.includes('# TDD Protocol (prompt-embedded — hook not applied)'));
+  assert.ok(sliceWorker.includes('DO NOT modify files outside the union'));
+  assert.ok(sliceWorker.includes('parent relies on your receipts for verification'));
+  assert.ok(sliceWorker.includes('do not redispatch from this worker'));
+});
+
 test('plan templates expose worker handoff and verification plan', () => {
   const existingTemplate = readRepoFile('skills/shared/templates/plan-template-existing.md');
   const zeroBaseTemplate = readRepoFile('skills/shared/templates/plan-template-zerobase.md');


### PR DESCRIPTION
## What changed

- replace rigid "follow the plan exactly" guidance with contract-impact judgment
- require implementation workers to load the shared judgment contract before editing
- preserve TDD, scope, receipt, dependency, and unrelated-code safeguards
- add regression coverage for inline and delegated implementation paths

## Why

The previous guidance treated every plan/reality mismatch as a mandatory stop, even when a repository-local adaptation did not change the approved acceptance contract, public interface, scope, or verification evidence. This produced avoidable approval friction while providing no additional evidence integrity.

## Impact

Implementers may now make documented and verified local adaptations inside an active slice when approved boundaries remain unchanged. Boundary-changing mismatches still stop for approval or replanning.

## Validation

- `node --test tests/plan-quality-contract.test.js` — 8 passed
- `npm test` — 1,813 passed, 0 failed, 17 skipped
- `git diff --check`
