### PR TITLE
docs: close session-policy prerequisite evaluation (v7.1.4)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deep-work",
-  "version": "7.1.3",
+  "version": "7.1.4",
   "description": "Evidence-Driven Development Protocol — 24 command-equivalent skill surfaces plus a skill-native deep-work entry alias (cross-platform: Claude Code skills + Codex / Copilot CLI / Gemini CLI / SDK), 3-layer architecture with Skill-based phase dispatch, computational enforcement (worktree guard + phase transition injection), TDD enforcement, and receipt validation",
   "author": {
     "name": "sungmin"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deep-work",
-  "version": "7.1.3",
+  "version": "7.1.4",
   "description": "Evidence-Driven Development Protocol with skill-based phase dispatch, computational enforcement, TDD discipline, and receipt validation",
   "author": {
     "name": "sungmin"

--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -7,6 +7,13 @@ Deep Work 플러그인의 모든 주요 변경 사항을 이 파일에 기록합
 형식은 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)를 따르며,
 이 프로젝트는 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)을 준수합니다.
 
+## [7.1.4] — 2026-08-06 (Session-Policy 선행조건 종료)
+
+### Changed
+
+- **Session-policy 선행조건 handoff에 독립 검토된 terminal no-go를 기록했습니다.** 프로젝트가 제어하는 Git 구조는 worktree 밖의 repository-wide authority를 인증할 수 없고, deep-work는 그 신뢰를 제공해야 하는 별도 설치형 repository-authority 및 approval-broker 제품을 소유하지 않습니다. 따라서 기존 inline policy pipeline이 계속 authoritative하며, 실험적 P1 구현과 `scripts/session-policy-cli.js`는 배포하지 않습니다.
+- 재개 계약은 signed broker package와 독립 검증된 OS 설치·enrollment receipt를 요구합니다. 사람의 승인은 진행 권한이지 존재하지 않는 authority의 증거가 아닙니다.
+
 ## [7.1.3] — 2026-08-03 (이중 Root Hook Bootstrap)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable changes to the Deep Work plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.1.4] — 2026-08-06 (Session-Policy Prerequisite Closure)
+
+### Changed
+
+- **The session-policy prerequisite handoff now records its terminal reviewed no-go.** A project-controlled Git layout cannot authenticate repository-wide authority outside the worktree, and deep-work does not own the separately installed repository-authority and approval-broker products required to provide that trust. The existing inline policy pipeline therefore remains authoritative; the experimental P1 implementation and `scripts/session-policy-cli.js` are not shipped.
+- The restart contract now requires signed broker packages plus independently verified OS installation and enrollment receipts. Human approval remains permission to proceed, not evidence that an absent authority exists.
+
 ## [7.1.3] — 2026-08-03 (Dual-Root Hook Bootstrap)
 
 ### Fixed

--- a/docs/handoff/2026-08-06-session-policy-prerequisites-handoff.md
+++ b/docs/handoff/2026-08-06-session-policy-prerequisites-handoff.md
@@ -245,3 +245,44 @@ WS2 is complete only when all of the following are true:
 - integration has its own explicit human authorization.
 
 Until then, the correct production state is the existing inline pipeline.
+
+## Terminal closure — 2026-08-06
+
+Follow-up run `01KZAKSQ5C4XV7CT66RDADCVY4` tested whether the prerequisite
+program could safely begin in this repository. It ended as an independently
+reviewed no-go, not as a P1-P5 implementation.
+
+The P1 experiment demonstrated that a project capability cannot authenticate a
+repository-wide authority outside its own worktree. A project under analysis can
+fabricate a fully reciprocal `.git` / `gitdir` / `commondir` layout, so structural
+Git consistency cannot authorize writes to an external common directory. The
+same review also required transactional compare-and-swap plus immutable terminal
+evidence anchoring; local row/receipt files alone cannot reject a coordinated
+rewrite.
+
+The corrected design therefore requires independently installed products:
+
+- a repository-authority service that enrolls member worktrees outside project
+  state and atomically owns admission rows and append-only transition anchors;
+- an approval broker that owns human-presence, signing, rotation, revocation,
+  and one-time risk-lowering lifecycle state.
+
+The exact corrected design received a fresh independent review with Critical 0
+and Warning 0. Execution remained blocked because no broker source/package owner,
+signed service identity, release trust root, OS installation/enrollment, or
+provider receipt exists, and the user confirmed that deep-work does not own those
+broker products. This repository must not invent their protocols or trust keys.
+
+Consequences:
+
+- keep the existing inline session-policy pipeline authoritative;
+- do not merge the experimental P1 implementation;
+- do not add `scripts/session-policy-cli.js`;
+- treat user approval as permission to act, never as substitute evidence for an
+  absent external authority;
+- start a new run only after both signed broker packages and their independently
+  verified installation/enrollment receipts exist.
+
+This closure supersedes the handoff's invitation to begin P1 in isolation. The
+technical requirements remain useful as a future consumer contract, but the
+provider boundary must exist first.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-deep-work/deep-work",
-  "version": "7.1.3",
+  "version": "7.1.4",
   "engines": {
     "node": ">=22"
   },

--- a/tests/integration/v6.4.0-smoke.test.js
+++ b/tests/integration/v6.4.0-smoke.test.js
@@ -211,8 +211,8 @@ describe('v6.4.0 integration — Health Engine command contracts', () => {
 });
 
 describe('release metadata', () => {
-  it('active release metadata is bumped to 7.1.3 with evergreen usage docs', () => {
-    const version = '7.1.3';
+  it('active release metadata is bumped to 7.1.4 with evergreen usage docs', () => {
+    const version = '7.1.4';
     const featureVersion = '6.9.0';
     const root = path.join(__dirname, '..', '..');
     const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
@@ -227,11 +227,15 @@ describe('release metadata', () => {
     assert.equal(claudePlugin.version, version);
     assert.equal(codexPlugin.version, version);
 
-    // Current release (7.1.3) — dual-root hook bootstrap.
+    // Current release (7.1.4) — session-policy prerequisite closure.
     const changelogCurrent = releaseSection(changelog, version);
     const changelogKoCurrent = releaseSection(changelogKo, version);
-    assert.match(changelogCurrent,/Dual-root hook bootstrap/);
-    assert.match(changelogKoCurrent,/이중 root hook bootstrap/);
+    assert.match(changelogCurrent,/terminal reviewed no-go/);
+    assert.match(changelogKoCurrent,/terminal no-go/);
+    assert.match(changelogCurrent,/existing inline policy pipeline therefore remains authoritative/);
+    assert.match(changelogKoCurrent,/기존 inline policy pipeline이 계속 authoritative/);
+    assert.match(releaseSection(changelog, '7.1.3'),/Dual-root hook bootstrap/);
+    assert.match(releaseSection(changelogKo, '7.1.3'),/이중 root hook bootstrap/);
     assert.match(releaseSection(changelog, '7.1.2'),/Model routing now binds the actual host explicitly/);
     assert.match(releaseSection(changelogKo, '7.1.2'),/모델 라우팅이 실제 host를 명시적으로 결속합니다/);
     assert.match(releaseSection(changelog, '7.1.2'),/backslash-newline token splicing/);


### PR DESCRIPTION
## Summary

- record the independently reviewed terminal no-go for the session-policy prerequisite program
- keep the existing inline policy pipeline authoritative and exclude the experimental P1 implementation
- release deep-work v7.1.4 with synchronized manifests, package metadata, changelogs, and regression coverage

## Verification

- `node --test tests/integration/v6.4.0-smoke.test.js` — 8 passed, 0 failed
- `npm test` — 1,830 tests; 1,813 passed; 17 platform skips; 0 failed
- `git diff --check`
- independent gpt-5.6-sol review — APPROVE, Critical 0, Warning 0
