### PR TITLE
chore: release deep-work v7.1.5

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deep-work",
-  "version": "7.1.4",
+  "version": "7.1.5",
   "description": "Evidence-Driven Development Protocol — 24 command-equivalent skill surfaces plus a skill-native deep-work entry alias (cross-platform: Claude Code skills + Codex / Copilot CLI / Gemini CLI / SDK), 3-layer architecture with Skill-based phase dispatch, computational enforcement (worktree guard + phase transition injection), TDD enforcement, and receipt validation",
   "author": {
     "name": "sungmin"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deep-work",
-  "version": "7.1.4",
+  "version": "7.1.5",
   "description": "Evidence-Driven Development Protocol with skill-based phase dispatch, computational enforcement, TDD discipline, and receipt validation",
   "author": {
     "name": "sungmin"

--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -7,6 +7,13 @@ Deep Work 플러그인의 모든 주요 변경 사항을 이 파일에 기록합
 형식은 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)를 따르며,
 이 프로젝트는 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)을 준수합니다.
 
+## [7.1.5] — 2026-08-13 (Strict Recovery Evidence Closure)
+
+### Fixed
+
+- **Strict recovery evidence가 rollback·retry 전환에서 fail-closed로 동작합니다.** Receipt admission, completion evidence, release gate와 test result가 이전 시도의 stale evidence를 받아들이지 않고 현재 recovery generation과 authoritative state에 결속됩니다.
+- **Recovery·receipt 계약이 identity와 ordering 보장을 유지합니다.** Rollback, retry, receipt identity, governed context와 strict completion 경로에 대한 회귀 테스트를 추가했습니다.
+
 ## [7.1.4] — 2026-08-06 (Session-Policy 선행조건 종료)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable changes to the Deep Work plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.1.5] — 2026-08-13 (Strict Recovery Evidence Closure)
+
+### Fixed
+
+- **Strict recovery evidence now fails closed across rollback and retry transitions.** Receipt admission, completion evidence, release gates, and test results remain bound to the active recovery generation and authoritative state instead of accepting stale evidence from an earlier attempt.
+- **Recovery and receipt contracts now preserve identity and ordering guarantees.** Added regression coverage for rollback, retry, receipt identity, governed context, and strict completion paths.
+
 ## [7.1.4] — 2026-08-06 (Session-Policy Prerequisite Closure)
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-deep-work/deep-work",
-  "version": "7.1.4",
+  "version": "7.1.5",
   "engines": {
     "node": ">=22"
   },

--- a/tests/integration/v6.4.0-smoke.test.js
+++ b/tests/integration/v6.4.0-smoke.test.js
@@ -211,8 +211,8 @@ describe('v6.4.0 integration — Health Engine command contracts', () => {
 });
 
 describe('release metadata', () => {
-  it('active release metadata is bumped to 7.1.4 with evergreen usage docs', () => {
-    const version = '7.1.4';
+  it('active release metadata is bumped to 7.1.5 with evergreen usage docs', () => {
+    const version = '7.1.5';
     const featureVersion = '6.9.0';
     const root = path.join(__dirname, '..', '..');
     const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
@@ -227,13 +227,17 @@ describe('release metadata', () => {
     assert.equal(claudePlugin.version, version);
     assert.equal(codexPlugin.version, version);
 
-    // Current release (7.1.4) — session-policy prerequisite closure.
+    // Current release (7.1.5) — strict recovery evidence closure.
     const changelogCurrent = releaseSection(changelog, version);
     const changelogKoCurrent = releaseSection(changelogKo, version);
-    assert.match(changelogCurrent,/terminal reviewed no-go/);
-    assert.match(changelogKoCurrent,/terminal no-go/);
-    assert.match(changelogCurrent,/existing inline policy pipeline therefore remains authoritative/);
-    assert.match(changelogKoCurrent,/기존 inline policy pipeline이 계속 authoritative/);
+    assert.match(changelogCurrent,/Strict recovery evidence now fails closed across rollback and retry transitions/);
+    assert.match(changelogKoCurrent,/Strict recovery evidence가 rollback·retry 전환에서 fail-closed로 동작합니다/);
+    assert.match(changelogCurrent,/Recovery and receipt contracts now preserve identity and ordering guarantees/);
+    assert.match(changelogKoCurrent,/Recovery·receipt 계약이 identity와 ordering 보장을 유지합니다/);
+    assert.match(releaseSection(changelog, '7.1.4'),/terminal reviewed no-go/);
+    assert.match(releaseSection(changelogKo, '7.1.4'),/terminal no-go/);
+    assert.match(releaseSection(changelog, '7.1.4'),/existing inline policy pipeline therefore remains authoritative/);
+    assert.match(releaseSection(changelogKo, '7.1.4'),/기존 inline policy pipeline이 계속 authoritative/);
     assert.match(releaseSection(changelog, '7.1.3'),/Dual-root hook bootstrap/);
     assert.match(releaseSection(changelogKo, '7.1.3'),/이중 root hook bootstrap/);
     assert.match(releaseSection(changelog, '7.1.2'),/Model routing now binds the actual host explicitly/);


### PR DESCRIPTION
## Summary

- Bump the deep-work version triple to `7.1.5`.
- Publish strict recovery evidence closure across rollback and retry transitions.
- Add release metadata regression coverage while retaining the reviewed v7.1.4 no-go history.

## Validation

- `npm test`: 1858 tests, 1841 passed, 0 failed, 17 skipped.
- Targeted release metadata integration: 8 passed, 0 failed.
- `git diff --check`: passed.
- Claude and Codex manifests plus `package.json` parse and agree on `7.1.5`.

## Release notes

The release keeps receipt admission, completion evidence, release gates, and test results bound to the active recovery generation and authoritative state, with regression coverage for rollback, retry, receipt identity, governed context, and strict completion paths.