### PR TITLE
feat: shadow-compare deep-model-router decisions

### DIFF
--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -7,6 +7,12 @@ Deep Work 플러그인의 모든 주요 변경 사항을 이 파일에 기록합
 형식은 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)를 따르며,
 이 프로젝트는 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)을 준수합니다.
 
+## [Unreleased]
+
+### Added
+
+- **Model-router 섀도 비교.** `model-routing-cli.js` 직후 세션 초기화와 research 재라우팅이 `model_routing_meta_json.router_shadow`에 관측만 기록합니다. dispatch 권위는 기존 CLI JSON입니다.
+
 ## [7.1.5] — 2026-08-13 (Strict Recovery Evidence Closure)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to the Deep Work plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Model-router shadow comparison.** After `model-routing-cli.js`, session init and research reroute record a `router_shadow` observation on `model_routing_meta_json`. Dispatch authority stays the existing CLI JSON.
+
 ## [7.1.5] — 2026-08-13 (Strict Recovery Evidence Closure)
 
 ### Fixed

--- a/runtime/release-source-scanner.js
+++ b/runtime/release-source-scanner.js
@@ -396,6 +396,13 @@ function scanLaunchSites(path,bytes,{platformName=process.platform}={}){
         /probe\(\s*['"]gemini['"]\s*,\s*safeEnv\s*\)/.test(source)){
       optional.add('codex');optional.add('gemini');continue;
     }
+    if(first.type==='string'&&first.value==='python3'&&
+        (path==='scripts/router-shadow.js'||
+          path==='scripts/lib/locate-deep-model-router.js')&&
+        (/spawnSync\(\s*['"]python3['"]/.test(source)||
+          /exec\(\s*['"]python3['"]/.test(source))){
+      optional.add('python3');continue;
+    }
     if(path==='hooks/scripts/hook-runtime-portability.test.js'&&
         call.value==='spawnSync'&&first.type==='identifier'&&
         first.value==='resolveWindowsPowerShell'){

--- a/runtime/release-source-scanner.test.js
+++ b/runtime/release-source-scanner.test.js
@@ -354,6 +354,14 @@ test('review probes remain optional release tools',()=>{
   assert.deepEqual(launch.optional_tools,['codex','gemini']);
 });
 
+test('router-shadow python3 remains an optional release tool',()=>{
+  const shadow=scanner.scanLaunchSites('scripts/router-shadow.js',
+    Buffer.from("const {spawnSync}=require('node:child_process');\n"+
+      "spawnSync('python3',[cli,'--request-json',reqPath,'--format','json']);\n"));
+  assert.deepEqual(shadow.required_tools,[]);
+  assert.deepEqual(shadow.optional_tools,['python3']);
+});
+
 test('exact committed production release graph is scannable',
   {skip:process.platform==='win32'},()=>{
     const root=path.resolve(__dirname,'..');
@@ -361,8 +369,9 @@ test('exact committed production release graph is scannable',
       require('./platform.js').resolveGitExecutable(process.env,fs)});
     const files=scanner.loadCommittedFiles({root,gitIdentity,
       requireWorktreeMatch:false});
-    assert.doesNotThrow(()=>scanner.scanReleaseSources({
-      committedFiles:files}));
+    const result=scanner.scanReleaseSources({committedFiles:files});
+    assert.equal(result.required_tools.includes('python3'),false);
+    assert.equal(result.optional_tools.includes('python3'),true);
   });
 
 test('committed source loading binds an authenticated git and rejects worktree drift',

--- a/scripts/lib/locate-deep-model-router.js
+++ b/scripts/lib/locate-deep-model-router.js
@@ -27,14 +27,28 @@ function isRouteTask(filePath) {
   }
 }
 
-function resolveRouteTask(filePath) {
+function isForbiddenRelativeCheckout(p) {
+  return RELATIVE_SIBLING.test(normalize(p));
+}
+
+function isInstalledCacheRouteTask(filePath) {
+  const text = normalize(filePath);
+  return versionFromCachePath(text) !== null
+    && (text.includes('/.claude/plugins/cache/') || text.includes('/.codex/plugins/'));
+}
+
+function resolveRouteTask(filePath, { installedOnly = false } = {}) {
+  if (isForbiddenRelativeCheckout(filePath) || isPersonalSkillPath(filePath)) return null;
   if (!isRouteTask(filePath)) return null;
-  if (isPersonalSkillPath(filePath)) return null;
+  let resolved;
   try {
-    return fs.realpathSync(filePath);
+    resolved = fs.realpathSync(filePath);
   } catch {
     return null;
   }
+  if (isForbiddenRelativeCheckout(resolved) || isPersonalSkillPath(resolved)) return null;
+  if (installedOnly && !isInstalledCacheRouteTask(resolved)) return null;
+  return resolved;
 }
 
 function parseSemver(raw) {
@@ -98,15 +112,17 @@ function locateDeepModelRouter({ env, home, cwd } = {}) {
 
   const cli = e.DEEP_MODEL_ROUTER_CLI;
   if (cli) {
-    if (!RELATIVE_SIBLING.test(cli) && !isPersonalSkillPath(cli)) {
-      const hit = resolveRouteTask(path.isAbsolute(cli) ? cli : path.resolve(cwd || process.cwd(), cli));
-      if (hit) return hit;
-    }
+    const candidate = path.isAbsolute(cli) ? cli : path.resolve(cwd || process.cwd(), cli);
+    const hit = resolveRouteTask(candidate);
+    if (hit) return hit;
   }
 
   const root = e.DEEP_MODEL_ROUTER_ROOT;
   if (root) {
-    const hit = resolveRouteTask(path.join(root, 'skills', 'model-router', 'scripts', ROUTE_TASK));
+    const hit = resolveRouteTask(
+      path.join(root, 'skills', 'model-router', 'scripts', ROUTE_TASK),
+      { installedOnly: true },
+    );
     if (hit) return hit;
   }
 
@@ -118,22 +134,16 @@ function locateDeepModelRouter({ env, home, cwd } = {}) {
 function findPython3({ env, execFileSync } = {}) {
   const exec = execFileSync || require('node:child_process').execFileSync;
   const e = env || process.env;
-  const candidates = [];
-  if (e.PYTHON3) candidates.push(e.PYTHON3);
-  candidates.push('python3');
-  for (const bin of candidates) {
-    try {
-      exec(bin, ['-c', 'import sys'], {
-        encoding: 'utf8',
-        env: e,
-        stdio: ['ignore', 'ignore', 'ignore'],
-      });
-      return bin;
-    } catch {
-      /* try next */
-    }
+  try {
+    exec('python3', ['-c', 'import sys'], {
+      encoding: 'utf8',
+      env: e,
+      stdio: ['ignore', 'ignore', 'ignore'],
+    });
+    return 'python3';
+  } catch {
+    return null;
   }
-  return null;
 }
 
 module.exports = { locateDeepModelRouter, findPython3 };

--- a/scripts/lib/locate-deep-model-router.js
+++ b/scripts/lib/locate-deep-model-router.js
@@ -1,0 +1,139 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const ROUTE_TASK = 'route_task.py';
+const RELATIVE_SIBLING = /\.\.[/\\]+deep-model-router\b/;
+
+function normalize(p) {
+  return String(p).replace(/\\/g, '/');
+}
+
+function isPersonalSkillPath(p) {
+  const text = normalize(p);
+  return text.includes('/.claude/skills/model-router')
+    || text.includes('/.codex/skills/model-router');
+}
+
+function isRouteTask(filePath) {
+  try {
+    const resolved = fs.realpathSync(filePath);
+    if (path.basename(resolved) !== ROUTE_TASK) return false;
+    return fs.statSync(resolved).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function resolveRouteTask(filePath) {
+  if (!isRouteTask(filePath)) return null;
+  if (isPersonalSkillPath(filePath)) return null;
+  try {
+    return fs.realpathSync(filePath);
+  } catch {
+    return null;
+  }
+}
+
+function parseSemver(raw) {
+  const m = String(raw).match(/^(\d+)\.(\d+)\.(\d+)/);
+  if (!m) return null;
+  return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+function compareSemver(a, b) {
+  const pa = parseSemver(a);
+  const pb = parseSemver(b);
+  if (pa && pb) {
+    for (let i = 0; i < 3; i += 1) {
+      if (pa[i] !== pb[i]) return pa[i] - pb[i];
+    }
+    return 0;
+  }
+  if (pa && !pb) return 1;
+  if (!pa && pb) return -1;
+  return String(a).localeCompare(String(b));
+}
+
+function walkFiles(dir, acc) {
+  let entries;
+  try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return acc; }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walkFiles(full, acc);
+    else if (entry.isFile()) acc.push(full);
+  }
+  return acc;
+}
+
+function versionFromCachePath(filePath) {
+  const text = normalize(filePath);
+  const m = text.match(/\/deep-model-router\/([^/]+)\/skills\/model-router\/scripts\/route_task\.py$/);
+  return m ? m[1] : null;
+}
+
+function isCacheRouteTask(filePath) {
+  return versionFromCachePath(filePath) !== null && isRouteTask(filePath)
+    && !isPersonalSkillPath(filePath);
+}
+
+function bestCacheHit(cacheRoot) {
+  if (!cacheRoot) return null;
+  try {
+    if (!fs.statSync(cacheRoot).isDirectory()) return null;
+  } catch {
+    return null;
+  }
+  const hits = walkFiles(cacheRoot, []).filter(isCacheRouteTask);
+  if (!hits.length) return null;
+  hits.sort((a, b) => compareSemver(versionFromCachePath(a), versionFromCachePath(b)));
+  return fs.realpathSync(hits[hits.length - 1]);
+}
+
+function locateDeepModelRouter({ env, home, cwd } = {}) {
+  const e = env || process.env;
+  const homeDir = home || os.homedir();
+
+  const cli = e.DEEP_MODEL_ROUTER_CLI;
+  if (cli) {
+    if (!RELATIVE_SIBLING.test(cli) && !isPersonalSkillPath(cli)) {
+      const hit = resolveRouteTask(path.isAbsolute(cli) ? cli : path.resolve(cwd || process.cwd(), cli));
+      if (hit) return hit;
+    }
+  }
+
+  const root = e.DEEP_MODEL_ROUTER_ROOT;
+  if (root) {
+    const hit = resolveRouteTask(path.join(root, 'skills', 'model-router', 'scripts', ROUTE_TASK));
+    if (hit) return hit;
+  }
+
+  const claude = bestCacheHit(path.join(homeDir, '.claude', 'plugins', 'cache'));
+  if (claude) return claude;
+  return bestCacheHit(path.join(homeDir, '.codex', 'plugins'));
+}
+
+function findPython3({ env, execFileSync } = {}) {
+  const exec = execFileSync || require('node:child_process').execFileSync;
+  const e = env || process.env;
+  const candidates = [];
+  if (e.PYTHON3) candidates.push(e.PYTHON3);
+  candidates.push('python3');
+  for (const bin of candidates) {
+    try {
+      exec(bin, ['-c', 'import sys'], {
+        encoding: 'utf8',
+        env: e,
+        stdio: ['ignore', 'ignore', 'ignore'],
+      });
+      return bin;
+    } catch {
+      /* try next */
+    }
+  }
+  return null;
+}
+
+module.exports = { locateDeepModelRouter, findPython3 };

--- a/scripts/lib/locate-deep-model-router.test.js
+++ b/scripts/lib/locate-deep-model-router.test.js
@@ -34,8 +34,8 @@ test('DEEP_MODEL_ROUTER_CLI wins when it is an executable route_task.py', () => 
 
 test('DEEP_MODEL_ROUTER_CLI from the source checkout is accepted (dev/CI override)', () => {
   const home = tmpHome('dw-locate-src-');
-  const sourceCli = '/Users/sungmin/Dev/claude-plugins/deep-model-router/skills/model-router/scripts/route_task.py';
-  assert.ok(fs.existsSync(sourceCli), 'P2a tests require the local router checkout');
+  const sourceCli = writeRouteTask(path.join(home, 'claude-plugins', 'deep-model-router',
+    'skills', 'model-router', 'scripts', 'route_task.py'));
   const found = locateDeepModelRouter({
     env: { DEEP_MODEL_ROUTER_CLI: sourceCli },
     home,

--- a/scripts/lib/locate-deep-model-router.test.js
+++ b/scripts/lib/locate-deep-model-router.test.js
@@ -1,0 +1,132 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  locateDeepModelRouter,
+  findPython3,
+} = require('./locate-deep-model-router.js');
+
+function tmpHome(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function writeRouteTask(filePath) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, '#!/usr/bin/env python3\nprint("ok")\n');
+  fs.chmodSync(filePath, 0o755);
+  return filePath;
+}
+
+test('DEEP_MODEL_ROUTER_CLI wins when it is an executable route_task.py', () => {
+  const home = tmpHome('dw-locate-cli-');
+  const cli = writeRouteTask(path.join(home, 'injected', 'route_task.py'));
+  const found = locateDeepModelRouter({
+    env: { DEEP_MODEL_ROUTER_CLI: cli },
+    home,
+  });
+  assert.equal(found, fs.realpathSync(cli));
+});
+
+test('DEEP_MODEL_ROUTER_CLI from the source checkout is accepted (dev/CI override)', () => {
+  const home = tmpHome('dw-locate-src-');
+  const sourceCli = '/Users/sungmin/Dev/claude-plugins/deep-model-router/skills/model-router/scripts/route_task.py';
+  assert.ok(fs.existsSync(sourceCli), 'P2a tests require the local router checkout');
+  const found = locateDeepModelRouter({
+    env: { DEEP_MODEL_ROUTER_CLI: sourceCli },
+    home,
+  });
+  assert.equal(found, fs.realpathSync(sourceCli));
+});
+
+test('DEEP_MODEL_ROUTER_ROOT locates skills/model-router/scripts/route_task.py', () => {
+  const home = tmpHome('dw-locate-root-');
+  const root = path.join(home, 'plugin-root');
+  const cli = writeRouteTask(path.join(root, 'skills', 'model-router', 'scripts', 'route_task.py'));
+  const found = locateDeepModelRouter({
+    env: { DEEP_MODEL_ROUTER_ROOT: root },
+    home,
+  });
+  assert.equal(found, fs.realpathSync(cli));
+});
+
+test('Claude cache hit prefers the highest semver directory', () => {
+  const home = tmpHome('dw-locate-cache-');
+  writeRouteTask(path.join(home, '.claude', 'plugins', 'cache', 'mkt',
+    'deep-model-router', '1.0.0', 'skills', 'model-router', 'scripts', 'route_task.py'));
+  const newer = writeRouteTask(path.join(home, '.claude', 'plugins', 'cache', 'mkt',
+    'deep-model-router', '1.10.0', 'skills', 'model-router', 'scripts', 'route_task.py'));
+  writeRouteTask(path.join(home, '.claude', 'plugins', 'cache', 'mkt',
+    'deep-model-router', '1.2.0', 'skills', 'model-router', 'scripts', 'route_task.py'));
+  const found = locateDeepModelRouter({ env: {}, home });
+  assert.equal(found, fs.realpathSync(newer));
+});
+
+test('Codex cache is used when Claude cache is empty', () => {
+  const home = tmpHome('dw-locate-codex-');
+  const cli = writeRouteTask(path.join(home, '.codex', 'plugins', 'cache',
+    'deep-model-router', '1.0.0', 'skills', 'model-router', 'scripts', 'route_task.py'));
+  const found = locateDeepModelRouter({ env: {}, home });
+  assert.equal(found, fs.realpathSync(cli));
+});
+
+test('missing router returns null', () => {
+  const home = tmpHome('dw-locate-miss-');
+  assert.equal(locateDeepModelRouter({ env: {}, home }), null);
+});
+
+test('personal ~/.claude/skills/model-router symlink is never returned', () => {
+  const home = tmpHome('dw-locate-symlink-');
+  const personal = writeRouteTask(path.join(home, '.claude', 'skills', 'model-router',
+    'scripts', 'route_task.py'));
+  assert.equal(locateDeepModelRouter({
+    env: { DEEP_MODEL_ROUTER_CLI: personal },
+    home,
+  }), null);
+  assert.equal(locateDeepModelRouter({ env: {}, home }), null);
+});
+
+test('relative ../deep-model-router is never returned', () => {
+  const home = tmpHome('dw-locate-rel-');
+  const found = locateDeepModelRouter({
+    env: { DEEP_MODEL_ROUTER_CLI: '../deep-model-router/skills/model-router/scripts/route_task.py' },
+    home,
+    cwd: home,
+  });
+  assert.equal(found, null);
+});
+
+test('non-executable or non-route_task CLI path is ignored', () => {
+  const home = tmpHome('dw-locate-badcli-');
+  const other = path.join(home, 'not-the-router.py');
+  fs.writeFileSync(other, 'print(1)\n');
+  fs.chmodSync(other, 0o755);
+  assert.equal(locateDeepModelRouter({
+    env: { DEEP_MODEL_ROUTER_CLI: other },
+    home,
+  }), null);
+});
+
+test('python3-unavailable: findPython3 returns null when the binary cannot run', () => {
+  const found = findPython3({
+    env: { PYTHON3: '/definitely/missing/python3', PATH: '' },
+    execFileSync: () => { throw new Error('ENOENT'); },
+  });
+  assert.equal(found, null);
+});
+
+test('python3-unavailable: findPython3 returns the working binary', () => {
+  const found = findPython3({
+    env: { PYTHON3: '/opt/custom/python3' },
+    execFileSync: (bin, args) => {
+      assert.equal(bin, '/opt/custom/python3');
+      assert.deepEqual(args, ['-c', 'import sys']);
+      return '';
+    },
+  });
+  assert.equal(found, '/opt/custom/python3');
+});

--- a/scripts/lib/locate-deep-model-router.test.js
+++ b/scripts/lib/locate-deep-model-router.test.js
@@ -43,15 +43,43 @@ test('DEEP_MODEL_ROUTER_CLI from the source checkout is accepted (dev/CI overrid
   assert.equal(found, fs.realpathSync(sourceCli));
 });
 
-test('DEEP_MODEL_ROUTER_ROOT locates skills/model-router/scripts/route_task.py', () => {
+test('DEEP_MODEL_ROUTER_ROOT locates only an installed/cache plugin root', () => {
   const home = tmpHome('dw-locate-root-');
-  const root = path.join(home, 'plugin-root');
+  const root = path.join(home, '.claude', 'plugins', 'cache', 'mkt', 'deep-model-router', '1.2.0');
   const cli = writeRouteTask(path.join(root, 'skills', 'model-router', 'scripts', 'route_task.py'));
   const found = locateDeepModelRouter({
     env: { DEEP_MODEL_ROUTER_ROOT: root },
     home,
   });
   assert.equal(found, fs.realpathSync(cli));
+});
+
+test('DEEP_MODEL_ROUTER_ROOT rejects a source checkout and a relative sibling', () => {
+  const home = tmpHome('dw-locate-root-src-');
+  const sourceRoot = path.join(home, 'claude-plugins', 'deep-model-router');
+  writeRouteTask(path.join(sourceRoot, 'skills', 'model-router', 'scripts', 'route_task.py'));
+  assert.equal(locateDeepModelRouter({
+    env: { DEEP_MODEL_ROUTER_ROOT: sourceRoot },
+    home,
+  }), null);
+  assert.equal(locateDeepModelRouter({
+    env: { DEEP_MODEL_ROUTER_ROOT: '../deep-model-router' },
+    home,
+    cwd: home,
+  }), null);
+});
+
+test('DEEP_MODEL_ROUTER_ROOT rejects a personal skill tree even via symlink', () => {
+  const home = tmpHome('dw-locate-root-link-');
+  const personal = writeRouteTask(path.join(home, '.claude', 'skills', 'model-router',
+    'scripts', 'route_task.py'));
+  const root = path.join(home, 'alias-root');
+  fs.mkdirSync(path.join(root, 'skills', 'model-router', 'scripts'), { recursive: true });
+  fs.symlinkSync(personal, path.join(root, 'skills', 'model-router', 'scripts', 'route_task.py'));
+  assert.equal(locateDeepModelRouter({
+    env: { DEEP_MODEL_ROUTER_ROOT: root },
+    home,
+  }), null);
 });
 
 test('Claude cache hit prefers the highest semver directory', () => {
@@ -123,10 +151,10 @@ test('python3-unavailable: findPython3 returns the working binary', () => {
   const found = findPython3({
     env: { PYTHON3: '/opt/custom/python3' },
     execFileSync: (bin, args) => {
-      assert.equal(bin, '/opt/custom/python3');
+      assert.equal(bin, 'python3');
       assert.deepEqual(args, ['-c', 'import sys']);
       return '';
     },
   });
-  assert.equal(found, '/opt/custom/python3');
+  assert.equal(found, 'python3');
 });

--- a/scripts/lib/router-adapter.js
+++ b/scripts/lib/router-adapter.js
@@ -1,0 +1,131 @@
+'use strict';
+
+const HIGH_BANDS = new Set(['HIGH', 'CRITICAL']);
+
+function parseDecision(stdout) {
+  if (typeof stdout !== 'string' || !stdout.trim()) return { ok: false, reason: 'empty' };
+  try {
+    const value = JSON.parse(stdout);
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      return { ok: false, reason: 'non-object' };
+    }
+    return { ok: true, value };
+  } catch {
+    return { ok: false, reason: 'non-json' };
+  }
+}
+
+function bandOf(decision, localRiskBand) {
+  const fromDecision = decision && typeof decision.risk_band === 'string'
+    ? decision.risk_band.toUpperCase() : null;
+  if (fromDecision && ['LOW', 'MEDIUM', 'HIGH', 'CRITICAL'].includes(fromDecision)) return fromDecision;
+  if (typeof localRiskBand === 'string') {
+    const local = localRiskBand.toUpperCase();
+    if (['LOW', 'MEDIUM', 'HIGH', 'CRITICAL'].includes(local)) return local;
+  }
+  return null;
+}
+
+function envelope(status, {
+  dispatchAuthorized = false,
+  band = null,
+  reason = null,
+  provenance = 'router',
+  writeRetryAllowed,
+} = {}) {
+  const out = {
+    dispatch_authorized: dispatchAuthorized,
+    status,
+    degrade_reason: reason,
+    risk_band: band,
+    local_floor_applied: {},
+    routing_provenance: provenance,
+  };
+  if (writeRetryAllowed === false) out.write_retry_allowed = false;
+  return out;
+}
+
+function blockedOrFallback(status, band, reason) {
+  if (HIGH_BANDS.has(band)) {
+    return envelope(status, { band, reason, provenance: 'router' });
+  }
+  return envelope(status, { band, reason, provenance: 'local-fallback' });
+}
+
+function translateRouteOutcome({
+  exit, stdout, stderr, processState, localRiskBand, expectedDigest, signal,
+} = {}) {
+  const parsed = parseDecision(stdout);
+  const decision = parsed.ok ? parsed.value : null;
+  const band = bandOf(decision, localRiskBand);
+  const errText = typeof stderr === 'string' && stderr.trim() ? stderr.trim() : null;
+
+  if (processState === 'termination_unconfirmed'
+    || (decision && decision.result && decision.result.state === 'TERMINATION_UNCONFIRMED')) {
+    const out = blockedOrFallback('internal', band, 'TERMINATION_UNCONFIRMED');
+    out.write_retry_allowed = false;
+    return out;
+  }
+
+  if (processState === 'spawn_failed' || processState === 'permission_denied'
+    || processState === 'timeout' || processState === 'missing_cli'
+    || processState === 'python3_unavailable') {
+    const reason = processState === 'python3_unavailable' ? 'python3-unavailable'
+      : (processState === 'missing_cli' ? 'router-cli-missing' : processState);
+    return blockedOrFallback('unavailable', band, reason);
+  }
+
+  if (processState === 'empty_stdout' || processState === 'truncated'
+    || processState === 'out_of_range') {
+    return blockedOrFallback('unavailable', band, processState);
+  }
+
+  if (processState === 'signal') {
+    return blockedOrFallback('invalid', band, signal ? `signal:${signal}` : 'signal');
+  }
+
+  if (processState === 'digest_mismatch'
+    || (decision && expectedDigest && decision.policy_sha256
+      && decision.policy_sha256 !== expectedDigest)) {
+    return blockedOrFallback('invalid', band, 'policy digest mismatch');
+  }
+
+  if (decision && decision.route_schema_version != null
+    && decision.route_schema_version !== 1) {
+    return blockedOrFallback('invalid', band,
+      `unsupported route_schema_version ${decision.route_schema_version}`);
+  }
+
+  const knownExit = typeof exit === 'number' && Number.isInteger(exit) && exit >= 0 && exit <= 5;
+  if (!parsed.ok) {
+    if (knownExit && exit !== 0) {
+      // A documented nonzero exit still classifies the outcome even without JSON.
+    } else if (parsed.reason === 'empty') {
+      return blockedOrFallback('unavailable', band, 'empty_stdout');
+    } else {
+      return blockedOrFallback('invalid', band, parsed.reason);
+    }
+  }
+
+  if (!knownExit) {
+    return blockedOrFallback('unavailable', band, 'out_of_range');
+  }
+
+  if (exit === 0) {
+    return envelope('ok', { dispatchAuthorized: true, band, reason: null, provenance: 'router' });
+  }
+  if (exit === 3) {
+    return envelope('human_gate', { band, reason: null, provenance: 'router' });
+  }
+  if (exit === 4) {
+    return envelope('deferred_confirm', {
+      dispatchAuthorized: true, band, reason: null, provenance: 'router',
+    });
+  }
+  if (exit === 1) return blockedOrFallback('terminal', band, errText || 'terminal');
+  if (exit === 2) return blockedOrFallback('invalid', band, errText || 'invalid');
+  if (exit === 5) return blockedOrFallback('internal', band, errText || 'internal');
+  return blockedOrFallback('unavailable', band, 'out_of_range');
+}
+
+module.exports = { translateRouteOutcome };

--- a/scripts/lib/router-adapter.test.js
+++ b/scripts/lib/router-adapter.test.js
@@ -1,0 +1,258 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { translateRouteOutcome } = require('./router-adapter.js');
+
+const REQUIRED = [
+  'dispatch_authorized', 'status', 'degrade_reason', 'risk_band',
+  'local_floor_applied', 'routing_provenance',
+];
+
+function assertShape(out) {
+  for (const key of REQUIRED) assert.ok(key in out, `missing ${key}`);
+  assert.equal(typeof out.dispatch_authorized, 'boolean');
+  assert.match(out.status, /^(ok|terminal|invalid|human_gate|deferred_confirm|internal|unavailable)$/);
+  assert.match(out.routing_provenance, /^(router|local-fallback)$/);
+}
+
+function decision(overrides = {}) {
+  return JSON.stringify({
+    route_schema_version: 1,
+    router_plugin_version: '1.0.0',
+    policy_sha256: 'a'.repeat(64),
+    risk_band: 'MEDIUM',
+    selected_model: 'gpt-5.6-luna',
+    selected_effort: 'MEDIUM',
+    review: { band: 'MEDIUM', reviewers: ['worker_balanced'] },
+    ...overrides,
+  });
+}
+
+test('exit 0 is dispatchable ok', () => {
+  const out = translateRouteOutcome({
+    exit: 0, stdout: decision(), stderr: '', processState: 'exited',
+  });
+  assertShape(out);
+  assert.equal(out.dispatch_authorized, true);
+  assert.equal(out.status, 'ok');
+  assert.equal(out.degrade_reason, null);
+  assert.equal(out.risk_band, 'MEDIUM');
+  assert.equal(out.routing_provenance, 'router');
+});
+
+test('exit 1 HIGH/CRITICAL is blocked — no local-fallback', () => {
+  const high = translateRouteOutcome({
+    exit: 1, stdout: decision({ risk_band: 'HIGH', terminal: 'HUMAN_REQUIRED' }),
+    stderr: '', processState: 'exited',
+  });
+  assertShape(high);
+  assert.equal(high.dispatch_authorized, false);
+  assert.equal(high.status, 'terminal');
+  assert.equal(high.risk_band, 'HIGH');
+  assert.notEqual(high.routing_provenance, 'local-fallback');
+
+  const critical = translateRouteOutcome({
+    exit: 1, stdout: decision({ risk_band: 'CRITICAL', terminal: 'HUMAN_REQUIRED' }),
+    stderr: '', processState: 'exited', localRiskBand: 'CRITICAL',
+  });
+  assert.equal(critical.dispatch_authorized, false);
+  assert.equal(critical.status, 'terminal');
+  assert.notEqual(critical.routing_provenance, 'local-fallback');
+});
+
+test('exit 1 LOW/MEDIUM may local-fallback', () => {
+  const out = translateRouteOutcome({
+    exit: 1, stdout: decision({ risk_band: 'LOW', terminal: 'SUPPLY_EXHAUSTED' }),
+    stderr: '', processState: 'exited',
+  });
+  assertShape(out);
+  assert.equal(out.dispatch_authorized, false);
+  assert.equal(out.status, 'terminal');
+  assert.equal(out.routing_provenance, 'local-fallback');
+  assert.ok(out.degrade_reason);
+});
+
+test('exit 2 is invalid and follows the same band rule as exit 1', () => {
+  const medium = translateRouteOutcome({
+    exit: 2, stdout: decision({ risk_band: 'MEDIUM' }), stderr: 'error: bad', processState: 'exited',
+  });
+  assert.equal(medium.status, 'invalid');
+  assert.equal(medium.dispatch_authorized, false);
+  assert.equal(medium.routing_provenance, 'local-fallback');
+
+  const high = translateRouteOutcome({
+    exit: 2, stdout: decision({ risk_band: 'HIGH' }), stderr: 'error: bad', processState: 'exited',
+  });
+  assert.equal(high.status, 'invalid');
+  assert.equal(high.dispatch_authorized, false);
+  assert.notEqual(high.routing_provenance, 'local-fallback');
+});
+
+test('exit 3 is human_gate and must not degrade', () => {
+  const out = translateRouteOutcome({
+    exit: 3, stdout: decision({ requires_human_confirmation: true, risk_band: 'LOW' }),
+    stderr: '', processState: 'exited',
+  });
+  assertShape(out);
+  assert.equal(out.status, 'human_gate');
+  assert.equal(out.dispatch_authorized, false);
+  assert.equal(out.routing_provenance, 'router');
+  assert.equal(out.degrade_reason, null);
+});
+
+test('exit 4 is deferred_confirm, dispatchable, no degrade', () => {
+  const out = translateRouteOutcome({
+    exit: 4, stdout: decision({ human_confirmation_deferred: true, risk_band: 'HIGH' }),
+    stderr: '', processState: 'exited',
+  });
+  assertShape(out);
+  assert.equal(out.status, 'deferred_confirm');
+  assert.equal(out.dispatch_authorized, true);
+  assert.equal(out.routing_provenance, 'router');
+  assert.equal(out.degrade_reason, null);
+});
+
+test('exit 5 is internal and follows the same band rule as exit 2', () => {
+  const low = translateRouteOutcome({
+    exit: 5, stdout: '', stderr: 'internal error', processState: 'exited', localRiskBand: 'LOW',
+  });
+  assert.equal(low.status, 'internal');
+  assert.equal(low.dispatch_authorized, false);
+  assert.equal(low.routing_provenance, 'local-fallback');
+
+  const high = translateRouteOutcome({
+    exit: 5, stdout: '', stderr: 'internal error', processState: 'exited', localRiskBand: 'HIGH',
+  });
+  assert.equal(high.status, 'internal');
+  assert.equal(high.dispatch_authorized, false);
+  assert.notEqual(high.routing_provenance, 'local-fallback');
+});
+
+test('spawn failure is unavailable', () => {
+  const out = translateRouteOutcome({
+    exit: null, stdout: '', stderr: 'spawn ENOENT', processState: 'spawn_failed',
+    localRiskBand: 'MEDIUM',
+  });
+  assertShape(out);
+  assert.equal(out.dispatch_authorized, false);
+  assert.equal(out.status, 'unavailable');
+  assert.equal(out.routing_provenance, 'local-fallback');
+});
+
+test('permission denied is unavailable', () => {
+  const out = translateRouteOutcome({
+    exit: null, stdout: '', stderr: 'EACCES', processState: 'permission_denied',
+    localRiskBand: 'LOW',
+  });
+  assert.equal(out.status, 'unavailable');
+  assert.equal(out.dispatch_authorized, false);
+});
+
+test('timeout is unavailable', () => {
+  const out = translateRouteOutcome({
+    exit: null, stdout: '', stderr: 'ETIMEDOUT', processState: 'timeout',
+    localRiskBand: 'MEDIUM',
+  });
+  assert.equal(out.status, 'unavailable');
+  assert.equal(out.dispatch_authorized, false);
+});
+
+test('signal is treated like invalid (same as exit 2)', () => {
+  const out = translateRouteOutcome({
+    exit: null, stdout: '', stderr: '', processState: 'signal', signal: 'SIGTERM',
+    localRiskBand: 'MEDIUM',
+  });
+  assert.equal(out.dispatch_authorized, false);
+  assert.match(out.status, /^(invalid|unavailable)$/);
+});
+
+test('empty stdout is unavailable', () => {
+  const out = translateRouteOutcome({
+    exit: 0, stdout: '', stderr: '', processState: 'empty_stdout', localRiskBand: 'LOW',
+  });
+  assert.equal(out.dispatch_authorized, false);
+  assert.equal(out.status, 'unavailable');
+});
+
+test('truncated stdout is unavailable', () => {
+  const out = translateRouteOutcome({
+    exit: 0, stdout: '{"route_schema_version":1', stderr: '', processState: 'truncated',
+    localRiskBand: 'LOW',
+  });
+  assert.equal(out.dispatch_authorized, false);
+  assert.equal(out.status, 'unavailable');
+});
+
+test('non-JSON stdout is invalid', () => {
+  const out = translateRouteOutcome({
+    exit: 0, stdout: 'not json', stderr: '', processState: 'exited', localRiskBand: 'LOW',
+  });
+  assert.equal(out.dispatch_authorized, false);
+  assert.equal(out.status, 'invalid');
+});
+
+test('unsupported schema is invalid', () => {
+  const out = translateRouteOutcome({
+    exit: 0, stdout: decision({ route_schema_version: 99 }), stderr: '', processState: 'exited',
+  });
+  assert.equal(out.dispatch_authorized, false);
+  assert.equal(out.status, 'invalid');
+  assert.match(String(out.degrade_reason), /schema/i);
+});
+
+test('digest mismatch is invalid', () => {
+  const out = translateRouteOutcome({
+    exit: 0, stdout: decision({ policy_sha256: 'b'.repeat(64) }), stderr: '',
+    processState: 'digest_mismatch', expectedDigest: 'a'.repeat(64),
+  });
+  assert.equal(out.dispatch_authorized, false);
+  assert.equal(out.status, 'invalid');
+  assert.match(String(out.degrade_reason), /digest/i);
+});
+
+test('out-of-range exit is unavailable', () => {
+  const out = translateRouteOutcome({
+    exit: 9, stdout: decision(), stderr: '', processState: 'out_of_range',
+    localRiskBand: 'MEDIUM',
+  });
+  assert.equal(out.dispatch_authorized, false);
+  assert.equal(out.status, 'unavailable');
+});
+
+test('missing executable is unavailable', () => {
+  const out = translateRouteOutcome({
+    exit: null, stdout: '', stderr: '', processState: 'missing_cli', localRiskBand: 'LOW',
+  });
+  assert.equal(out.status, 'unavailable');
+  assert.equal(out.dispatch_authorized, false);
+});
+
+test('python3 unavailable is unavailable', () => {
+  const out = translateRouteOutcome({
+    exit: null, stdout: '', stderr: '', processState: 'python3_unavailable',
+    localRiskBand: 'LOW',
+  });
+  assert.equal(out.status, 'unavailable');
+  assert.equal(out.dispatch_authorized, false);
+});
+
+test('TERMINATION_UNCONFIRMED blocks write-capable retry', () => {
+  const out = translateRouteOutcome({
+    exit: 5, stdout: JSON.stringify({ result: { state: 'TERMINATION_UNCONFIRMED' } }),
+    stderr: '', processState: 'termination_unconfirmed', localRiskBand: 'HIGH',
+  });
+  assertShape(out);
+  assert.equal(out.dispatch_authorized, false);
+  assert.match(out.status, /^(internal|unavailable)$/);
+  assert.equal(out.write_retry_allowed, false);
+  assert.notEqual(out.routing_provenance, 'local-fallback');
+});
+
+test('HIGH local band with empty stdout still does not degrade', () => {
+  const out = translateRouteOutcome({
+    exit: 2, stdout: '', stderr: 'boom', processState: 'exited', localRiskBand: 'HIGH',
+  });
+  assert.equal(out.dispatch_authorized, false);
+  assert.notEqual(out.routing_provenance, 'local-fallback');
+});

--- a/scripts/router-shadow.js
+++ b/scripts/router-shadow.js
@@ -151,7 +151,7 @@ function defaultInvoke({ python, cli, request, env, timeoutMs }) {
   const reqPath = path.join(dir, 'request.json');
   fs.writeFileSync(reqPath, JSON.stringify(request ?? {}));
   try {
-    const result = spawnSync(python, [cli, '--request-json', reqPath, '--format', 'json'], {
+    const result = spawnSync('python3', [cli, '--request-json', reqPath, '--format', 'json'], {
       encoding: 'utf8',
       timeout: timeoutMs || 15_000,
       env,

--- a/scripts/router-shadow.js
+++ b/scripts/router-shadow.js
@@ -1,0 +1,315 @@
+#!/usr/bin/env node
+'use strict';
+
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const { locateDeepModelRouter, findPython3 } = require('./lib/locate-deep-model-router.js');
+const { translateRouteOutcome } = require('./lib/router-adapter.js');
+
+const EFFORT_RANK = Object.freeze({
+  MINIMAL: 0, LOW: 1, MEDIUM: 2, HIGH: 3, VERY_HIGH: 4, MAX: 5,
+  medium: 2, high: 3, xhigh: 4, max: 5,
+});
+
+function cloneJson(value) {
+  return value === undefined ? undefined : JSON.parse(JSON.stringify(value));
+}
+
+function hashRequest(request) {
+  return crypto.createHash('sha256')
+    .update(JSON.stringify(request ?? null))
+    .digest('hex');
+}
+
+function parseJson(text) {
+  try {
+    const value = JSON.parse(text);
+    return value && typeof value === 'object' && !Array.isArray(value) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+function riskBandFromAuthority(mrOut) {
+  const cls = mrOut && mrOut.meta && mrOut.meta.policy && mrOut.meta.policy.risk_class;
+  if (!cls) return null;
+  return String(cls).toUpperCase();
+}
+
+function isDowngrade(mrOut, decision) {
+  if (!decision) return false;
+  const authEffort = mrOut && mrOut.meta && mrOut.meta.efforts
+    && mrOut.meta.efforts.implement && mrOut.meta.efforts.implement.effort;
+  const routerEffort = decision.selected_effort;
+  if (authEffort != null && routerEffort != null
+    && EFFORT_RANK[routerEffort] != null && EFFORT_RANK[authEffort] != null
+    && EFFORT_RANK[routerEffort] < EFFORT_RANK[authEffort]) {
+    return true;
+  }
+  const authModel = mrOut && mrOut.model_routing && mrOut.model_routing.implement;
+  if (authModel && decision.selected_model && authModel !== decision.selected_model) {
+    if (/luna|haiku|fast/i.test(String(decision.selected_model))
+      && /opus|sol|sonnet|terra/i.test(String(authModel))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function compareDecisions(mrOut, decision) {
+  return {
+    authority: {
+      implement: mrOut && mrOut.model_routing ? mrOut.model_routing.implement : null,
+      research: mrOut && mrOut.model_routing ? mrOut.model_routing.research : null,
+      efforts: mrOut && mrOut.meta ? mrOut.meta.efforts || null : null,
+    },
+    router: decision ? {
+      selected_model: decision.selected_model ?? null,
+      selected_effort: decision.selected_effort ?? null,
+      selected_effort_native: decision.selected_effort_native ?? null,
+      review: decision.review ?? null,
+    } : { selected_model: null, selected_effort: null, selected_effort_native: null, review: null },
+    downgrade: isDowngrade(mrOut, decision),
+  };
+}
+
+function mapRuntime(runtime) {
+  if (runtime === 'codex') return 'codex';
+  if (runtime === 'grok') return 'grok';
+  return 'claude_code';
+}
+
+function dimensionsForRisk(riskClass) {
+  const key = String(riskClass || '').toLowerCase();
+  if (key === 'low') return [0, 0, 0, 0];
+  if (key === 'high') return [2, 2, 2, 1];
+  if (key === 'critical') return [3, 3, 3, 2];
+  return [1, 1, 1, 1];
+}
+
+function buildShadowRequest({ runtime, riskClass, taskClass } = {}) {
+  const dims = dimensionsForRisk(riskClass);
+  return {
+    route_schema_version: 1,
+    task_class: taskClass || 'IMPLEMENTATION',
+    complexity: dims[0],
+    uncertainty: dims[1],
+    blast_radius: dims[2],
+    reversibility: dims[3],
+    reasoning_centric: false,
+    flags: [],
+    runtime: mapRuntime(runtime),
+    prior_failures: [],
+  };
+}
+
+function classifySpawn(result) {
+  if (result.error) {
+    if (result.error.code === 'ENOENT') {
+      return { exit: null, stdout: '', stderr: String(result.error.message || result.error), processState: 'spawn_failed' };
+    }
+    if (result.error.code === 'EACCES') {
+      return { exit: null, stdout: '', stderr: String(result.error.message || result.error), processState: 'permission_denied' };
+    }
+    if (result.error.code === 'ETIMEDOUT' || result.error.code === 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER') {
+      const state = result.error.code === 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER' ? 'truncated' : 'timeout';
+      return {
+        exit: result.status,
+        stdout: result.stdout || '',
+        stderr: result.stderr || String(result.error.message || result.error),
+        processState: state,
+      };
+    }
+  }
+  if (result.signal) {
+    return {
+      exit: result.status,
+      stdout: result.stdout || '',
+      stderr: result.stderr || '',
+      processState: 'signal',
+      signal: result.signal,
+    };
+  }
+  const stdout = result.stdout || '';
+  const stderr = result.stderr || '';
+  const exit = result.status;
+  if (typeof exit === 'number' && (exit < 0 || exit > 5)) {
+    return { exit, stdout, stderr, processState: 'out_of_range' };
+  }
+  if (!String(stdout).trim()) {
+    return { exit, stdout, stderr, processState: 'empty_stdout' };
+  }
+  return { exit, stdout, stderr, processState: 'exited' };
+}
+
+function defaultInvoke({ python, cli, request, env, timeoutMs }) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dw-router-shadow-'));
+  const reqPath = path.join(dir, 'request.json');
+  fs.writeFileSync(reqPath, JSON.stringify(request ?? {}));
+  try {
+    const result = spawnSync(python, [cli, '--request-json', reqPath, '--format', 'json'], {
+      encoding: 'utf8',
+      timeout: timeoutMs || 15_000,
+      env,
+      maxBuffer: 2 * 1024 * 1024,
+    });
+    return classifySpawn(result);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function failShadow(mrOut, request, started, extra) {
+  const localRiskBand = extra.localRiskBand || riskBandFromAuthority(mrOut);
+  return {
+    authority: cloneJson(mrOut),
+    shadow: {
+      dispatch_authorized: false,
+      status: extra.status || 'internal',
+      degrade_reason: extra.degrade_reason || 'internal',
+      risk_band: localRiskBand,
+      local_floor_applied: {},
+      routing_provenance: extra.routing_provenance || 'local-fallback',
+      input_hash: hashRequest(request),
+      identity: { route_schema_version: null, router_plugin_version: null, policy_sha256: null },
+      comparison: compareDecisions(mrOut, null),
+      latency_ms: Date.now() - started,
+      exit: extra.exit === undefined ? null : extra.exit,
+      policy_sha256: null,
+      frozen_digest: extra.frozenDigest || null,
+    },
+  };
+}
+
+function recordRouterShadow({
+  mrOut, request, env, home, frozenDigest, localRiskBand, invoke, findPython3: findPy, now,
+} = {}) {
+  const started = typeof now === 'function' ? now() : Date.now();
+  const authority = cloneJson(mrOut);
+  try {
+    const envObj = env || process.env;
+    let outcome;
+    if (typeof invoke === 'function') {
+      outcome = invoke({ request, env: envObj });
+    } else {
+      const cli = locateDeepModelRouter({ env: envObj, home });
+      const pythonFinder = typeof findPy === 'function' ? findPy : findPython3;
+      const python = pythonFinder({ env: envObj });
+      if (!cli) {
+        outcome = { exit: null, stdout: '', stderr: 'router-cli-missing', processState: 'missing_cli' };
+      } else if (!python) {
+        outcome = { exit: null, stdout: '', stderr: 'python3-unavailable', processState: 'python3_unavailable' };
+      } else {
+        outcome = defaultInvoke({ python, cli, request, env: envObj });
+      }
+    }
+
+    const parsed = parseJson(outcome && outcome.stdout);
+    const observedDigest = parsed && typeof parsed.policy_sha256 === 'string' ? parsed.policy_sha256 : null;
+    if (frozenDigest && observedDigest && frozenDigest !== observedDigest) {
+      outcome = { ...outcome, processState: 'digest_mismatch', expectedDigest: frozenDigest };
+    }
+
+    const band = localRiskBand || riskBandFromAuthority(mrOut);
+    const translated = translateRouteOutcome({
+      exit: outcome.exit,
+      stdout: outcome.stdout,
+      stderr: outcome.stderr,
+      processState: outcome.processState,
+      signal: outcome.signal,
+      localRiskBand: band,
+      expectedDigest: frozenDigest,
+    });
+
+    return {
+      authority,
+      shadow: {
+        ...translated,
+        input_hash: hashRequest(request),
+        identity: {
+          route_schema_version: parsed ? parsed.route_schema_version ?? null : null,
+          router_plugin_version: parsed ? parsed.router_plugin_version ?? null : null,
+          policy_sha256: observedDigest,
+        },
+        comparison: compareDecisions(mrOut, parsed),
+        latency_ms: Date.now() - started,
+        exit: outcome.exit === undefined ? null : outcome.exit,
+        policy_sha256: observedDigest,
+        frozen_digest: frozenDigest || observedDigest,
+      },
+    };
+  } catch (err) {
+    return failShadow(mrOut, request, started, {
+      status: 'internal',
+      degrade_reason: err && err.message ? err.message : String(err),
+      localRiskBand,
+      frozenDigest,
+    });
+  }
+}
+
+function parseArgs(argv) {
+  const out = {
+    mrOutFile: null, requestJson: null, frozenDigest: null,
+    runtime: null, riskClass: null, taskClass: null,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === '--mr-out-file') out.mrOutFile = argv[++i] || null;
+    else if (a === '--request-json') out.requestJson = argv[++i] || null;
+    else if (a === '--frozen-digest') out.frozenDigest = argv[++i] || null;
+    else if (a === '--runtime') out.runtime = argv[++i] || null;
+    else if (a === '--risk-class') out.riskClass = argv[++i] || null;
+    else if (a === '--task-class') out.taskClass = argv[++i] || null;
+  }
+  return out;
+}
+
+function readMrOut(args) {
+  if (args.mrOutFile) return fs.readFileSync(args.mrOutFile, 'utf8');
+  return fs.readFileSync(0, 'utf8');
+}
+
+function main(argv = process.argv.slice(2)) {
+  try {
+    const args = parseArgs(argv);
+    const mrRaw = readMrOut(args);
+    const mrOut = parseJson(mrRaw) || { model_routing: {}, meta: {}, warnings: ['shadow: invalid mr-out'] };
+    let request = null;
+    if (args.requestJson) request = parseJson(fs.readFileSync(args.requestJson, 'utf8'));
+    if (!request) {
+      request = buildShadowRequest({
+        runtime: args.runtime,
+        riskClass: args.riskClass,
+        taskClass: args.taskClass,
+      });
+    }
+    const wrap = recordRouterShadow({
+      mrOut,
+      request,
+      env: process.env,
+      frozenDigest: args.frozenDigest || null,
+    });
+    process.stdout.write(JSON.stringify(wrap));
+  } catch (err) {
+    process.stdout.write(JSON.stringify({
+      authority: { model_routing: {}, meta: { error: true }, warnings: [] },
+      shadow: {
+        dispatch_authorized: false,
+        status: 'internal',
+        degrade_reason: err && err.message ? err.message : String(err),
+        risk_band: null,
+        local_floor_applied: {},
+        routing_provenance: 'local-fallback',
+      },
+    }));
+  }
+}
+
+if (require.main === module) main();
+
+module.exports = { recordRouterShadow, buildShadowRequest, hashRequest, compareDecisions, main };

--- a/scripts/router-shadow.test.js
+++ b/scripts/router-shadow.test.js
@@ -1,0 +1,297 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const {
+  recordRouterShadow,
+  buildShadowRequest,
+} = require('./router-shadow.js');
+
+const ROOT = path.resolve(__dirname, '..');
+const REAL_CLI = '/Users/sungmin/Dev/claude-plugins/deep-model-router/skills/model-router/scripts/route_task.py';
+const CLI = path.join(__dirname, 'model-routing-cli.js');
+const SHADOW_CLI = path.join(__dirname, 'router-shadow.js');
+
+function authorityFromCli(args = []) {
+  const out = execFileSync(process.execPath, [
+    CLI, '--root', ROOT, '--task', 'shadow authority probe',
+    '--runtime', 'claude', ...args,
+  ], { encoding: 'utf8' });
+  return { raw: out, parsed: JSON.parse(out) };
+}
+
+function sampleRequest(overrides = {}) {
+  return {
+    route_schema_version: 1,
+    task_class: 'IMPLEMENTATION',
+    complexity: 1,
+    uncertainty: 1,
+    blast_radius: 1,
+    reversibility: 1,
+    reasoning_centric: false,
+    flags: [],
+    runtime: 'claude_code',
+    prior_failures: [],
+    ...overrides,
+  };
+}
+
+function mockInvoke(outcome) {
+  return () => outcome;
+}
+
+test('authority JSON is deepEqual to the input MR_OUT (live router)', () => {
+  assert.ok(fs.existsSync(REAL_CLI), 'P2a tests require the local router checkout');
+  const { raw, parsed } = authorityFromCli();
+  const original = JSON.parse(raw);
+  const result = recordRouterShadow({
+    mrOut: parsed,
+    request: sampleRequest(),
+    env: { ...process.env, DEEP_MODEL_ROUTER_CLI: REAL_CLI },
+  });
+  assert.deepEqual(result.authority, original);
+  assert.deepEqual(result.authority.model_routing, original.model_routing);
+  assert.notEqual(result.authority, parsed);
+  assert.ok(result.shadow);
+  assert.equal(typeof result.shadow.dispatch_authorized, 'boolean');
+  assert.ok(result.shadow.input_hash);
+  assert.ok('latency_ms' in result.shadow);
+  assert.ok('exit' in result.shadow);
+});
+
+test('HIGH/CRITICAL router error does not rewrite model_routing', () => {
+  const { parsed } = authorityFromCli(['--risk-class', 'critical']);
+  const before = JSON.parse(JSON.stringify(parsed.model_routing));
+  const result = recordRouterShadow({
+    mrOut: parsed,
+    request: sampleRequest({
+      complexity: 3, uncertainty: 3, blast_radius: 3, reversibility: 3,
+    }),
+    env: { ...process.env, DEEP_MODEL_ROUTER_CLI: REAL_CLI },
+    localRiskBand: 'CRITICAL',
+    invoke: mockInvoke({
+      exit: 5,
+      stdout: '',
+      stderr: 'internal error: boom',
+      processState: 'exited',
+    }),
+  });
+  assert.deepEqual(result.authority.model_routing, before);
+  assert.deepEqual(result.authority.model_routing, parsed.model_routing);
+  assert.equal(result.shadow.dispatch_authorized, false);
+  assert.equal(result.shadow.status, 'internal');
+  assert.notEqual(result.shadow.routing_provenance, 'local-fallback');
+  assert.ok(result.shadow.degrade_reason);
+});
+
+test('shadow records comparison fields without mutating authority', () => {
+  const mrOut = {
+    model_routing: { brainstorm: 'main', research: 'sonnet', plan: 'main', implement: 'opus', test: 'haiku' },
+    meta: { runtime: 'claude', tiers: { implement: 'deep' }, efforts: { implement: { effort: 'high' } } },
+    warnings: [],
+  };
+  const snapshot = JSON.parse(JSON.stringify(mrOut));
+  const result = recordRouterShadow({
+    mrOut,
+    request: sampleRequest(),
+    env: {},
+    invoke: mockInvoke({
+      exit: 0,
+      stdout: JSON.stringify({
+        route_schema_version: 1,
+        router_plugin_version: '1.0.0',
+        policy_sha256: 'c'.repeat(64),
+        selected_model: 'gpt-5.6-luna',
+        selected_effort: 'LOW',
+        selected_effort_native: 'low',
+        risk_band: 'LOW',
+        review: { band: 'LOW', reviewers: ['worker_fast'] },
+      }),
+      stderr: '',
+      processState: 'exited',
+    }),
+  });
+  assert.deepEqual(mrOut, snapshot);
+  assert.deepEqual(result.authority, snapshot);
+  assert.equal(result.shadow.dispatch_authorized, true);
+  assert.equal(result.shadow.identity.route_schema_version, 1);
+  assert.equal(result.shadow.identity.router_plugin_version, '1.0.0');
+  assert.equal(result.shadow.identity.policy_sha256, 'c'.repeat(64));
+  assert.equal(result.shadow.comparison.router.selected_model, 'gpt-5.6-luna');
+  assert.equal(result.shadow.comparison.authority.implement, 'opus');
+  assert.equal(result.shadow.comparison.downgrade, true);
+});
+
+test('first digest is frozen; a later mismatch is invalid and leaves MR_OUT alone', () => {
+  const mrOut = {
+    model_routing: { implement: 'sonnet', research: 'sonnet', plan: 'main', brainstorm: 'main', test: 'haiku' },
+    meta: { runtime: 'claude', tiers: {} },
+    warnings: [],
+  };
+  const first = recordRouterShadow({
+    mrOut,
+    request: sampleRequest(),
+    env: {},
+    invoke: mockInvoke({
+      exit: 0,
+      stdout: JSON.stringify({
+        route_schema_version: 1,
+        router_plugin_version: '1.0.0',
+        policy_sha256: 'd'.repeat(64),
+        selected_model: 'sonnet',
+        selected_effort: 'HIGH',
+        risk_band: 'MEDIUM',
+        review: { band: 'MEDIUM', reviewers: [] },
+      }),
+      stderr: '',
+      processState: 'exited',
+    }),
+  });
+  assert.equal(first.shadow.status, 'ok');
+  assert.equal(first.shadow.policy_sha256, 'd'.repeat(64));
+  assert.equal(first.shadow.frozen_digest, 'd'.repeat(64));
+
+  const before = JSON.parse(JSON.stringify(mrOut.model_routing));
+  const second = recordRouterShadow({
+    mrOut,
+    request: sampleRequest(),
+    env: {},
+    frozenDigest: first.shadow.frozen_digest,
+    invoke: mockInvoke({
+      exit: 0,
+      stdout: JSON.stringify({
+        route_schema_version: 1,
+        router_plugin_version: '1.0.0',
+        policy_sha256: 'e'.repeat(64),
+        selected_model: 'haiku',
+        selected_effort: 'LOW',
+        risk_band: 'LOW',
+        review: { band: 'LOW', reviewers: [] },
+      }),
+      stderr: '',
+      processState: 'exited',
+    }),
+  });
+  assert.deepEqual(second.authority.model_routing, before);
+  assert.equal(second.shadow.status, 'invalid');
+  assert.equal(second.shadow.dispatch_authorized, false);
+  assert.match(String(second.shadow.degrade_reason), /digest/i);
+  assert.equal(second.shadow.frozen_digest, 'd'.repeat(64));
+});
+
+test('matching frozen digest stays ok', () => {
+  const digest = 'f'.repeat(64);
+  const result = recordRouterShadow({
+    mrOut: { model_routing: { implement: 'sonnet' }, meta: {}, warnings: [] },
+    request: sampleRequest(),
+    env: {},
+    frozenDigest: digest,
+    invoke: mockInvoke({
+      exit: 0,
+      stdout: JSON.stringify({
+        route_schema_version: 1,
+        router_plugin_version: '1.0.0',
+        policy_sha256: digest,
+        selected_model: 'sonnet',
+        selected_effort: 'HIGH',
+        risk_band: 'MEDIUM',
+        review: { reviewers: [] },
+      }),
+      stderr: '',
+      processState: 'exited',
+    }),
+  });
+  assert.equal(result.shadow.status, 'ok');
+  assert.equal(result.shadow.dispatch_authorized, true);
+});
+
+test('recordRouterShadow never throws into the orchestrator', () => {
+  const mrOut = { model_routing: { implement: 'main' }, meta: { error: true }, warnings: ['x'] };
+  const result = recordRouterShadow({
+    mrOut,
+    request: sampleRequest(),
+    env: {},
+    invoke: () => { throw new Error('spawn exploded'); },
+  });
+  assert.deepEqual(result.authority.model_routing, mrOut.model_routing);
+  assert.equal(result.shadow.dispatch_authorized, false);
+  assert.match(result.shadow.status, /^(internal|unavailable)$/);
+});
+
+test('missing router is unavailable shadow, authority intact', () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'dw-shadow-miss-'));
+  const mrOut = { model_routing: { implement: 'opus' }, meta: {}, warnings: [] };
+  const result = recordRouterShadow({
+    mrOut,
+    request: sampleRequest(),
+    env: {},
+    home,
+  });
+  assert.deepEqual(result.authority.model_routing, mrOut.model_routing);
+  assert.equal(result.shadow.status, 'unavailable');
+  assert.equal(result.shadow.dispatch_authorized, false);
+});
+
+test('python3-unavailable is recorded as unavailable, authority intact', () => {
+  const mrOut = { model_routing: { implement: 'opus' }, meta: {}, warnings: [] };
+  const result = recordRouterShadow({
+    mrOut,
+    request: sampleRequest(),
+    env: { DEEP_MODEL_ROUTER_CLI: REAL_CLI, PYTHON3: '/definitely/missing/python3', PATH: '/empty' },
+    findPython3: () => null,
+  });
+  assert.deepEqual(result.authority.model_routing, { implement: 'opus' });
+  assert.equal(result.shadow.status, 'unavailable');
+  assert.match(String(result.shadow.degrade_reason), /python3/i);
+});
+
+test('buildShadowRequest emits RouteRequestV1 with host runtime mapped', () => {
+  const req = buildShadowRequest({
+    runtime: 'claude',
+    riskClass: 'high',
+    taskClass: 'IMPLEMENTATION',
+  });
+  assert.equal(req.route_schema_version, 1);
+  assert.equal(req.task_class, 'IMPLEMENTATION');
+  assert.equal(req.runtime, 'claude_code');
+  assert.equal(typeof req.complexity, 'number');
+  assert.ok(!Object.hasOwn(req, 'extra'));
+});
+
+test('CLI prints shadow JSON and never a rewritten authority', () => {
+  const mrFile = path.join(os.tmpdir(), `dw-shadow-cli-${process.pid}.json`);
+  const reqFile = path.join(os.tmpdir(), `dw-shadow-req-${process.pid}.json`);
+  const mrOut = { model_routing: { implement: 'opus' }, meta: { runtime: 'claude' }, warnings: [] };
+  fs.writeFileSync(mrFile, JSON.stringify(mrOut));
+  fs.writeFileSync(reqFile, JSON.stringify(sampleRequest()));
+  const out = execFileSync(process.execPath, [
+    SHADOW_CLI, '--mr-out-file', mrFile, '--request-json', reqFile,
+  ], {
+    encoding: 'utf8',
+    env: { ...process.env, DEEP_MODEL_ROUTER_CLI: REAL_CLI },
+  });
+  const wrap = JSON.parse(out);
+  assert.deepEqual(wrap.authority.model_routing, mrOut.model_routing);
+  assert.ok(wrap.shadow);
+  fs.unlinkSync(mrFile);
+  fs.unlinkSync(reqFile);
+});
+
+test('orchestrator and research invoke router-shadow immediately after model-routing-cli', () => {
+  const orch = fs.readFileSync(path.join(ROOT, 'skills/deep-work-orchestrator/SKILL.md'), 'utf8');
+  const research = fs.readFileSync(path.join(ROOT, 'skills/deep-research/SKILL.md'), 'utf8');
+  for (const [name, skill] of [['orchestrator', orch], ['research', research]]) {
+    const cli = skill.indexOf('scripts/model-routing-cli.js');
+    const shadow = skill.indexOf('scripts/router-shadow.js');
+    assert.ok(cli >= 0, `${name} must call model-routing-cli.js`);
+    assert.ok(shadow > cli, `${name} must call router-shadow.js after model-routing-cli.js`);
+    const between = skill.slice(cli, shadow);
+    assert.ok(!/current_phase|model_routing_json/.test(between),
+      `${name} must invoke shadow immediately after the CLI, before state write`);
+  }
+});

--- a/scripts/router-shadow.test.js
+++ b/scripts/router-shadow.test.js
@@ -13,7 +13,21 @@ const {
 } = require('./router-shadow.js');
 
 const ROOT = path.resolve(__dirname, '..');
-const REAL_CLI = '/Users/sungmin/Dev/claude-plugins/deep-model-router/skills/model-router/scripts/route_task.py';
+function writeTempRouteTask() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dw-shadow-cli-'));
+  const cli = path.join(dir, 'route_task.py');
+  fs.writeFileSync(cli, '#!/usr/bin/env python3\n');
+  fs.chmodSync(cli, 0o755);
+  return cli;
+}
+
+function existingRouterCli() {
+  const sibling = '/Users/sungmin/Dev/claude-plugins/deep-model-router/skills/model-router/scripts/route_task.py';
+  for (const candidate of [process.env.DEEP_MODEL_ROUTER_CLI, sibling]) {
+    if (candidate && fs.existsSync(candidate)) return candidate;
+  }
+  return null;
+}
 const CLI = path.join(__dirname, 'model-routing-cli.js');
 const SHADOW_CLI = path.join(__dirname, 'router-shadow.js');
 
@@ -45,14 +59,25 @@ function mockInvoke(outcome) {
   return () => outcome;
 }
 
-test('authority JSON is deepEqual to the input MR_OUT (live router)', () => {
-  assert.ok(fs.existsSync(REAL_CLI), 'P2a tests require the local router checkout');
+test('authority JSON is deepEqual to the input MR_OUT', () => {
   const { raw, parsed } = authorityFromCli();
   const original = JSON.parse(raw);
   const result = recordRouterShadow({
     mrOut: parsed,
     request: sampleRequest(),
-    env: { ...process.env, DEEP_MODEL_ROUTER_CLI: REAL_CLI },
+    invoke: mockInvoke({
+      exit: 0,
+      stdout: JSON.stringify({
+        route_schema_version: 1,
+        router_plugin_version: '1.0.0',
+        policy_sha256: 'a'.repeat(64),
+        selected_model: 'claude-sonnet-5',
+        selected_effort_native: 'high',
+        risk_band: 'MEDIUM',
+      }),
+      stderr: '',
+      processState: 'exited',
+    }),
   });
   assert.deepEqual(result.authority, original);
   assert.deepEqual(result.authority.model_routing, original.model_routing);
@@ -64,6 +89,23 @@ test('authority JSON is deepEqual to the input MR_OUT (live router)', () => {
   assert.ok('exit' in result.shadow);
 });
 
+test('live router clones authority when a local checkout exists', (t) => {
+  const cli = existingRouterCli();
+  if (!cli) {
+    t.skip('local deep-model-router checkout is not present');
+    return;
+  }
+  const { raw, parsed } = authorityFromCli();
+  const original = JSON.parse(raw);
+  const result = recordRouterShadow({
+    mrOut: parsed,
+    request: sampleRequest(),
+    env: { ...process.env, DEEP_MODEL_ROUTER_CLI: cli },
+  });
+  assert.deepEqual(result.authority, original);
+  assert.equal(typeof result.shadow.dispatch_authorized, 'boolean');
+});
+
 test('HIGH/CRITICAL router error does not rewrite model_routing', () => {
   const { parsed } = authorityFromCli(['--risk-class', 'critical']);
   const before = JSON.parse(JSON.stringify(parsed.model_routing));
@@ -72,7 +114,6 @@ test('HIGH/CRITICAL router error does not rewrite model_routing', () => {
     request: sampleRequest({
       complexity: 3, uncertainty: 3, blast_radius: 3, reversibility: 3,
     }),
-    env: { ...process.env, DEEP_MODEL_ROUTER_CLI: REAL_CLI },
     localRiskBand: 'CRITICAL',
     invoke: mockInvoke({
       exit: 5,
@@ -242,7 +283,7 @@ test('python3-unavailable is recorded as unavailable, authority intact', () => {
   const result = recordRouterShadow({
     mrOut,
     request: sampleRequest(),
-    env: { DEEP_MODEL_ROUTER_CLI: REAL_CLI, PYTHON3: '/definitely/missing/python3', PATH: '/empty' },
+    env: { DEEP_MODEL_ROUTER_CLI: writeTempRouteTask(), PATH: '/empty' },
     findPython3: () => null,
   });
   assert.deepEqual(result.authority.model_routing, { implement: 'opus' });
@@ -273,7 +314,7 @@ test('CLI prints shadow JSON and never a rewritten authority', () => {
     SHADOW_CLI, '--mr-out-file', mrFile, '--request-json', reqFile,
   ], {
     encoding: 'utf8',
-    env: { ...process.env, DEEP_MODEL_ROUTER_CLI: REAL_CLI },
+    env: { ...process.env, DEEP_MODEL_ROUTER_CLI: writeTempRouteTask() },
   });
   const wrap = JSON.parse(out);
   assert.deepEqual(wrap.authority.model_routing, mrOut.model_routing);

--- a/skills/deep-research/SKILL.md
+++ b/skills/deep-research/SKILL.md
@@ -263,7 +263,19 @@ MR_OUT=$(node "${CLAUDE_PLUGIN_ROOT}/scripts/model-routing-cli.js" \
   --pinned "<decodedRoutingMeta.pinned as phase=value CSV>" \
   --runtime "$ROUTING_RUNTIME" \
   --methodology-policy "$METHODOLOGY_AUTHORITY")
+MR_FILE=$(mktemp)
+printf '%s' "$MR_OUT" > "$MR_FILE"
+SHADOW_WRAP=$(node "${CLAUDE_PLUGIN_ROOT}/scripts/router-shadow.js" \
+  --mr-out-file "$MR_FILE" \
+  --runtime "$ROUTING_RUNTIME" \
+  --risk-class "$AUTH_CLASS" \
+  --task-class INVESTIGATION \
+  --frozen-digest "<decodedRoutingMeta.router_shadow.policy_sha256 or empty>")
+rm -f "$MR_FILE"
 ```
+`$MR_OUT` remains the dispatch authority. Merge only `SHADOW_WRAP.shadow` into
+`model_routing_meta_json.router_shadow`. A later `policy_sha256` mismatch is
+recorded as `status: invalid` and must not rewrite `model_routing`.
 
 4. state를 한 번의 atomic RMW로 갱신한다.
    - `risk_profile_json.authoritative`에 profile/input_ref/evidence_refs를 기록하고 transition은
@@ -272,11 +284,12 @@ MR_OUT=$(node "${CLAUDE_PLUGIN_ROOT}/scripts/model-routing-cli.js" \
      `RISK_OUT.error`도 같은 배열에 기록한다.
    - `policy_shadow_json.authoritative`에 `RISK_OUT.policy_snapshot`을 병합하되 provisional은
      보존한다.
-   - 재라우팅 성공 시 `model_routing_json`과 `model_routing_meta_json`을 각각 MR_OUT의
-     routing/meta JSON-string으로 교체하고, `methodology_policy_json`을
+   - 재라우팅 성공 시 `model_routing_json`은 MR_OUT의 routing JSON-string으로
+     교체하고, `model_routing_meta_json`은 `{ ...MR_OUT.meta, router_shadow: SHADOW_WRAP.shadow }`
+     JSON-string으로 교체한다. `methodology_policy_json`을
      `RISK_OUT.methodology_authority`의 exact JSON으로 교체한다. 저장 전후
      `policy_sha256`를 재검증하며 routing meta의 `methodology_policy_sha256`와
-     동일해야 한다.
+     동일해야 한다. `router_shadow`는 관측 전용이다.
    - high/critical이고 `floor_overridden_by_pin`이 true인 phase마다
      `⚠️ 사용자 pin이 <phase> policy floor보다 낮습니다`를 1회 표시한다.
 5. 요약 1줄: `Risk: <provisional class> → <authoritative class> (policy: <profile>)`.

--- a/skills/deep-work-orchestrator/SKILL.md
+++ b/skills/deep-work-orchestrator/SKILL.md
@@ -155,7 +155,18 @@ MR_OUT=$(node "${CLAUDE_PLUGIN_ROOT}/scripts/model-routing-cli.js" \
   --difficulty "${REC_TASK_DIFFICULTY:-}" --pinned "${FLAGS.model_routing:-}" \
   --runtime "$ROUTING_RUNTIME" \
   --methodology-policy "$METHODOLOGY_AUTHORITY")
+MR_FILE=$(mktemp)
+printf '%s' "$MR_OUT" > "$MR_FILE"
+SHADOW_WRAP=$(node "${CLAUDE_PLUGIN_ROOT}/scripts/router-shadow.js" \
+  --mr-out-file "$MR_FILE" \
+  --runtime "$ROUTING_RUNTIME" \
+  --risk-class "$RISK_CLASS" \
+  --task-class IMPLEMENTATION)
+rm -f "$MR_FILE"
 ```
+`$MR_OUT` remains the dispatch authority. `$SHADOW_WRAP` is observation-only
+(`authority` is a clone; persist only `shadow` under `model_routing_meta_json.router_shadow`).
+The shadow CLI never fails the session: it always exits 0.
 
 프로필의 per-phase concrete pin은 `--pinned`에 병합하되 CLI pin이 우선한다. `MR_OUT.meta.policy.floor_overridden_by_pin`에 true가 있고 risk class가
 `high` 또는 `critical`이면 `⚠️ 사용자 pin이 <phase> policy floor보다 낮습니다`를 phase별
@@ -195,7 +206,7 @@ rm -f "$RISK_IN"
 - session_id, current_phase, task_description, work_dir
 - team_mode, tdd_mode, worktree_*, cross_model_*
 - **`model_routing_json`**: `JSON.stringify(MR_OUT.model_routing)`로 만든 한 줄 JSON-string 스칼라
-- **`model_routing_meta_json`**: `JSON.stringify(MR_OUT.meta)`로 만든 한 줄 JSON-string 스칼라
+- **`model_routing_meta_json`**: `JSON.stringify({ ...MR_OUT.meta, router_shadow: SHADOW_WRAP.shadow })`로 만든 한 줄 JSON-string 스칼라. `router_shadow`는 관측 전용이며 phase-guard/dispatch는 이 키를 읽지 않는다. `MR_OUT` 권위 바이트는 그대로 둔다.
 - **`risk_profile_json`, `policy_shadow_json`, `slice_risk_shadow_json`** (옵셔널, v6.11.0 — frontmatter JSON-string 스칼라, shadow 관찰 전용. phase-guard/gate enforcement에 영향 없음)
 - **`methodology_policy_json`, `review_execution_json`**. v7은 digest-bound
   `methodology-policy-v1` authority를 전자에 기록한다. legacy v6.12 shape는


### PR DESCRIPTION
## Summary

P2a wires `deep-model-router` into deep-work as a **shadow** observer. Authority (`MR_OUT` / `model_routing`) is unchanged; the router result is recorded only on `router_shadow`.

- Call `scripts/router-shadow.js` immediately after `model-routing-cli.js` in orchestrator and research.
- Locator follows §11.5: `DEEP_MODEL_ROUTER_CLI` (dev/CI, including source checkout), then installed/cache `DEEP_MODEL_ROUTER_ROOT`, then Claude/Codex plugin caches. Personal `~/.claude/skills/model-router` and `../deep-model-router` are rejected on every source.
- Adapter translates exits 0–5 plus process failures. HIGH/CRITICAL shadow failures do not rewrite authority.
- Review follow-up: `spawnSync('python3')` is a literal optional probe so the committed release graph stays scannable. `DEEP_MODEL_ROUTER_ROOT` accepts only cache-shaped installed roots.

## Review

Independent dual review vs design §11: gpt-5.6-sol FAIL (accepted findings applied); claude-fable-5 TIMED_OUT. Orchestrator adjudicated from sol + §11 + source.

## Test plan

- [x] `node --test scripts/lib/locate-deep-model-router.test.js scripts/router-shadow.test.js scripts/lib/router-adapter.test.js runtime/release-source-scanner.test.js`
- [x] Full `npm test` before review fixes: 1883 pass / 1 fail (`spawnSync:python`). After the optional-python3 commit, `exact committed production release graph is scannable` is green.
- [ ] CI on this PR