### PR TITLE
chore: release deep-work v7.2.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deep-work",
-  "version": "7.1.5",
+  "version": "7.2.0",
   "description": "Evidence-Driven Development Protocol — 24 command-equivalent skill surfaces plus a skill-native deep-work entry alias (cross-platform: Claude Code skills + Codex / Copilot CLI / Gemini CLI / SDK), 3-layer architecture with Skill-based phase dispatch, computational enforcement (worktree guard + phase transition injection), TDD enforcement, and receipt validation",
   "author": {
     "name": "sungmin"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deep-work",
-  "version": "7.1.5",
+  "version": "7.2.0",
   "description": "Evidence-Driven Development Protocol with skill-based phase dispatch, computational enforcement, TDD discipline, and receipt validation",
   "author": {
     "name": "sungmin"

--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -7,7 +7,7 @@ Deep Work 플러그인의 모든 주요 변경 사항을 이 파일에 기록합
 형식은 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)를 따르며,
 이 프로젝트는 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)을 준수합니다.
 
-## [Unreleased]
+## [7.2.0] — 2026-08-17 (Suite Model-Router Shadow)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to the Deep Work plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [7.2.0] — 2026-08-17 (Suite Model-Router Shadow)
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-deep-work/deep-work",
-  "version": "7.1.5",
+  "version": "7.2.0",
   "engines": {
     "node": ">=22"
   },

--- a/tests/integration/v6.4.0-smoke.test.js
+++ b/tests/integration/v6.4.0-smoke.test.js
@@ -211,8 +211,8 @@ describe('v6.4.0 integration — Health Engine command contracts', () => {
 });
 
 describe('release metadata', () => {
-  it('active release metadata is bumped to 7.1.5 with evergreen usage docs', () => {
-    const version = '7.1.5';
+  it('active release metadata is bumped to 7.2.0 with evergreen usage docs', () => {
+    const version = '7.2.0';
     const featureVersion = '6.9.0';
     const root = path.join(__dirname, '..', '..');
     const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
@@ -227,13 +227,15 @@ describe('release metadata', () => {
     assert.equal(claudePlugin.version, version);
     assert.equal(codexPlugin.version, version);
 
-    // Current release (7.1.5) — strict recovery evidence closure.
+    // Current release (7.2.0) — suite model-router shadow comparison.
     const changelogCurrent = releaseSection(changelog, version);
     const changelogKoCurrent = releaseSection(changelogKo, version);
-    assert.match(changelogCurrent,/Strict recovery evidence now fails closed across rollback and retry transitions/);
-    assert.match(changelogKoCurrent,/Strict recovery evidence가 rollback·retry 전환에서 fail-closed로 동작합니다/);
-    assert.match(changelogCurrent,/Recovery and receipt contracts now preserve identity and ordering guarantees/);
-    assert.match(changelogKoCurrent,/Recovery·receipt 계약이 identity와 ordering 보장을 유지합니다/);
+    assert.match(changelogCurrent,/Model-router shadow comparison/);
+    assert.match(changelogKoCurrent,/Model-router 섀도 비교/);
+    assert.match(changelogCurrent,/Dispatch authority stays the existing CLI JSON/);
+    assert.match(changelogKoCurrent,/dispatch 권위는 기존 CLI JSON입니다/);
+    assert.match(releaseSection(changelog, '7.1.5'),/Strict recovery evidence now fails closed across rollback and retry transitions/);
+    assert.match(releaseSection(changelogKo, '7.1.5'),/Strict recovery evidence가 rollback·retry 전환에서 fail-closed로 동작합니다/);
     assert.match(releaseSection(changelog, '7.1.4'),/terminal reviewed no-go/);
     assert.match(releaseSection(changelogKo, '7.1.4'),/terminal no-go/);
     assert.match(releaseSection(changelog, '7.1.4'),/existing inline policy pipeline therefore remains authoritative/);


### PR DESCRIPTION
## Summary
- Publish **v7.2.0** after the merged P2a shadow comparison (`#72`).
- Promote the Unreleased changelog (en/ko) to `[7.2.0] — 2026-08-17`.
- Synchronize `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, `package.json`, and the release smoke oracle.

## Test plan
- [x] `node --test tests/integration/v6.4.0-smoke.test.js`
- [ ] CI green on this PR