### PR TITLE
fix: stop the PostToolUse cache leak and the phase-guard false positives

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deep-work",
-  "version": "7.2.0",
+  "version": "7.2.1",
   "description": "Evidence-Driven Development Protocol — 24 command-equivalent skill surfaces plus a skill-native deep-work entry alias (cross-platform: Claude Code skills + Codex / Copilot CLI / Gemini CLI / SDK), 3-layer architecture with Skill-based phase dispatch, computational enforcement (worktree guard + phase transition injection), TDD enforcement, and receipt validation",
   "author": {
     "name": "sungmin"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deep-work",
-  "version": "7.2.0",
+  "version": "7.2.1",
   "description": "Evidence-Driven Development Protocol with skill-based phase dispatch, computational enforcement, TDD discipline, and receipt validation",
   "author": {
     "name": "sungmin"

--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -7,6 +7,13 @@ Deep Work 플러그인의 모든 주요 변경 사항을 이 파일에 기록합
 형식은 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)를 따르며,
 이 프로젝트는 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)을 준수합니다.
 
+## [7.2.1] — 2026-08-18 (훅 캐시 및 가드 오탐 수정)
+
+### Fixed
+
+- **PostToolUse 핸드오프 캐시가 툴 호출마다 파일을 남기지 않는다** ([#74](https://github.com/Sungmin-Cho/claude-deep-work/issues/74)). `phase-transition.sh`가 조기 종료 지점들보다 앞에서 `.claude/.hook-tool-input.<PPID>`를 무조건 삭제한다. 캐시를 읽었을 때만 삭제해서는 안 된다 — `hook-shell-adapter.js`가 payload를 `CLAUDE_TOOL_INPUT`으로 직접 넘기므로 프로덕션 경로에서는 폴백 분기가 아예 실행되지 않아, `file-tracker.sh`가 방금 쓴 파일을 아무도 소비하지 않았다. 한 세션 안에서 동시 실행된 호출들이 서로의 payload를 읽지 않도록 키는 `$PPID`를 유지한다. `session-end.sh`는 도달 불가능하던 `$PPID` 삭제 줄을 제거하고, 60분 sweep은 크래시 백스톱으로 남긴다. 회귀 커버리지는 `hooks/scripts/hook-input-cache-lifecycle.test.js`에 있다.
+- **`phase-guard`가 Implement 외 단계에서 읽기 전용 Bash를 막지 않는다** ([#75](https://github.com/Sungmin-Cho/claude-deep-work/issues/75)). `FILE_WRITE_PATTERNS`가 fd 번호 리다이렉트(`cat f 2>/dev/null`), `/dev/null` 및 fd 복제 대상(`ls > /dev/null`, `2>&1`), 따옴표 안 산문에 등장하는 명령어 이름(`git commit -m "patch the bug"`)을 더 이상 쓰기로 보지 않는다. 명령어 패턴은 명령 위치 — fragment 선두, env/권한 접두사 뒤, `sh -c` 페이로드 내부 — 에서만 매칭하므로 `bash -c "mv a b"`는 계속 차단된다. 패키지 매니저 install은 명시적 패턴으로 기존 동작을 유지한다. 양쪽 스트림 리다이렉트 `node app.js &> build.log`는 이제 올바르게 쓰기로 감지된다. 이슈가 제시한 12케이스 매트릭스를 `hooks/scripts/phase-guard-core.test.js`에 고정했다.
+
 ## [7.2.0] — 2026-08-17 (Suite Model-Router Shadow)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable changes to the Deep Work plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.2.1] — 2026-08-18 (Hook Cache & Guard False-Positive Fixes)
+
+### Fixed
+
+- **The PostToolUse handoff cache no longer leaves one file per tool call** ([#74](https://github.com/Sungmin-Cho/claude-deep-work/issues/74)). `phase-transition.sh` deletes `.claude/.hook-tool-input.<PPID>` unconditionally, ahead of its early exits. The delete cannot be conditional on having read the cache: `hook-shell-adapter.js` hands the payload over in `CLAUDE_TOOL_INPUT`, so on the production path the fallback branch never runs and nothing consumed the file `file-tracker.sh` had just written. `$PPID` stays as the key so concurrent invocations in one session cannot read each other's payload. `session-end.sh` drops its unreachable `$PPID` removal and keeps the 60-minute sweep as a crash backstop. Regression coverage lives in `hooks/scripts/hook-input-cache-lifecycle.test.js`.
+- **`phase-guard` no longer blocks read-only Bash outside the Implement phase** ([#75](https://github.com/Sungmin-Cho/claude-deep-work/issues/75)). `FILE_WRITE_PATTERNS` now ignores fd-numbered redirects (`cat f 2>/dev/null`), `/dev/null` and fd-duplication targets (`ls > /dev/null`, `2>&1`), and command names that appear inside quoted prose (`git commit -m "patch the bug"`). Command-name patterns match only in command position — fragment head, after an env or privilege prefix, or inside a `sh -c` payload — so `bash -c "mv a b"` stays blocked. Package-manager installs keep their previous handling through an explicit pattern. The both-streams redirect `node app.js &> build.log` is now correctly detected as a write. The issue's own 12-case matrix is pinned in `hooks/scripts/phase-guard-core.test.js`.
+
 ## [7.2.0] — 2026-08-17 (Suite Model-Router Shadow)
 
 ### Added

--- a/hooks/scripts/hook-input-cache-lifecycle.test.js
+++ b/hooks/scripts/hook-input-cache-lifecycle.test.js
@@ -1,0 +1,171 @@
+// Regression tests for GitHub issue #74 — the PostToolUse stdin-handoff cache
+// (`.claude/.hook-tool-input.<PPID>`) accumulated one file per tool call.
+//
+// Two facts drive these tests:
+//   1. The key is $PPID — the PID of the per-invocation node bootstrap — so the
+//      cache is effectively per tool call, not per session.
+//   2. hook-shell-adapter.js passes CLAUDE_TOOL_INPUT to phase-transition.sh,
+//      so on the production path the cache fallback branch never runs and the
+//      file is written but never consumed.
+//
+// The fix is therefore an *unconditional* delete in phase-transition.sh, which
+// must fire whether or not the cache was the source of TOOL_INPUT.
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const PHASE_TRANSITION = path.resolve(__dirname, 'phase-transition.sh');
+const SESSION_END = path.resolve(__dirname, 'session-end.sh');
+const ADAPTER = path.resolve(__dirname, 'hook-shell-adapter.js');
+
+describe('hook stdin-cache lifecycle (issue #74)', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hook-cache-'));
+    fs.mkdirSync(path.join(tmpDir, '.claude'), { recursive: true });
+  });
+
+  afterEach(() => {
+    if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeStateFile(sid, fields) {
+    const yaml = Object.entries(fields).map(([k, v]) => `${k}: ${v}`).join('\n');
+    const fp = path.join(tmpDir, '.claude', `deep-work.${sid}.md`);
+    fs.writeFileSync(fp, `---\n${yaml}\n---\n`);
+    fs.writeFileSync(path.join(tmpDir, '.claude', 'deep-work-current-session'), sid);
+    return fp;
+  }
+
+  function cacheFiles() {
+    return fs.readdirSync(path.join(tmpDir, '.claude'))
+      .filter((f) => f.startsWith('.hook-tool-input.'));
+  }
+
+  it('phase-transition.sh deletes the cache it consumed (env unset)', () => {
+    const stateFile = writeStateFile('s-del1', {
+      current_phase: 'plan',
+      worktree_enabled: 'true',
+      worktree_path: '"/tmp/wt"',
+      team_mode: 'team',
+    });
+
+    const cacheFile = path.join(tmpDir, '.claude', `.hook-tool-input.${process.pid}`);
+    fs.writeFileSync(cacheFile, JSON.stringify({ file_path: stateFile }));
+
+    const env = { ...process.env };
+    delete env.CLAUDE_TOOL_USE_INPUT;
+    delete env.CLAUDE_TOOL_INPUT;
+
+    const result = spawnSync('bash', [PHASE_TRANSITION], {
+      cwd: tmpDir, env, encoding: 'utf8', timeout: 5000,
+    });
+
+    assert.equal(result.status, 0, `stderr: ${result.stderr}`);
+    assert.match(result.stdout, /Phase Transition/, 'cache must still be consumed');
+    assert.equal(fs.existsSync(cacheFile), false,
+      'phase-transition.sh must remove the cache after reading it');
+  });
+
+  it('phase-transition.sh deletes the cache even when CLAUDE_TOOL_INPUT is set (adapter path)', () => {
+    // This is the production topology: hook-shell-adapter.js hands the tool
+    // input to phase-transition.sh via env, so the cache fallback branch never
+    // runs. Before the fix nothing deleted the file and it leaked on every
+    // single PostToolUse call.
+    const stateFile = writeStateFile('s-del2', {
+      current_phase: 'plan',
+      worktree_enabled: 'true',
+      worktree_path: '"/tmp/wt"',
+      team_mode: 'team',
+    });
+
+    const cacheFile = path.join(tmpDir, '.claude', `.hook-tool-input.${process.pid}`);
+    fs.writeFileSync(cacheFile, JSON.stringify({ file_path: stateFile }));
+
+    const result = spawnSync('bash', [PHASE_TRANSITION], {
+      cwd: tmpDir,
+      env: { ...process.env, CLAUDE_TOOL_INPUT: JSON.stringify({ file_path: stateFile }) },
+      encoding: 'utf8',
+      timeout: 5000,
+    });
+
+    assert.equal(result.status, 0, `stderr: ${result.stderr}`);
+    assert.equal(fs.existsSync(cacheFile), false,
+      'phase-transition.sh must remove the PPID cache regardless of the input source');
+  });
+
+  it('phase-transition.sh deletes the cache before its own early exits', () => {
+    // TOOL_INPUT resolves, but the payload names no file_path, so the script
+    // exits early. The cache must already be gone by then.
+    const stateFile = writeStateFile('s-del3', { current_phase: 'plan' });
+    const cacheFile = path.join(tmpDir, '.claude', `.hook-tool-input.${process.pid}`);
+    fs.writeFileSync(cacheFile, JSON.stringify({ command: 'ls -la' }));
+
+    const env = { ...process.env };
+    delete env.CLAUDE_TOOL_USE_INPUT;
+    delete env.CLAUDE_TOOL_INPUT;
+
+    const result = spawnSync('bash', [PHASE_TRANSITION], {
+      cwd: tmpDir, env, encoding: 'utf8', timeout: 5000,
+    });
+
+    assert.equal(result.status, 0, `stderr: ${result.stderr}`);
+    assert.equal(fs.existsSync(cacheFile), false,
+      'an early exit must not strand the cache file');
+    assert.ok(stateFile);
+  });
+
+  it('repeated post-tool cycles do not accumulate cache files', () => {
+    const stateFile = writeStateFile('s-accum', {
+      current_phase: 'plan',
+      worktree_enabled: 'true',
+      worktree_path: '"/tmp/wt"',
+      team_mode: 'team',
+    });
+    const toolInput = JSON.stringify({ file_path: stateFile });
+
+    // Drive the real entry point rather than the two scripts by hand:
+    // `hook-shell-adapter.js post-tool` spawnSyncs both from one node process,
+    // so they share a $PPID exactly as they do in production. Reproducing that
+    // with a bash wrapper is not portable — bash may exec-optimise the last
+    // command of a `-c` string, which changes the parent of one script only.
+    for (let i = 0; i < 5; i++) {
+      const cycle = spawnSync(process.execPath, [ADAPTER, 'post-tool'], {
+        input: toolInput,
+        cwd: tmpDir,
+        env: { ...process.env, CLAUDE_TOOL_USE_TOOL_NAME: 'Write', DEEP_WORK_SESSION_ID: 's-accum' },
+        encoding: 'utf8',
+        timeout: 15000,
+      });
+      assert.equal(cycle.status, 0, `cycle ${i} failed: ${cycle.stderr}`);
+    }
+
+    assert.deepEqual(cacheFiles(), [],
+      `5 post-tool cycles must leave no cache files, found: ${cacheFiles().join(', ')}`);
+  });
+
+  it('session-end.sh sweeps stale cache files left by crashed invocations', () => {
+    writeStateFile('s-sweep', { current_phase: 'plan' });
+
+    const stale = path.join(tmpDir, '.claude', '.hook-tool-input.999001');
+    fs.writeFileSync(stale, '{}');
+    const twoHoursAgo = Date.now() / 1000 - 7200;
+    fs.utimesSync(stale, twoHoursAgo, twoHoursAgo);
+
+    const result = spawnSync('bash', [SESSION_END], {
+      cwd: tmpDir,
+      env: { ...process.env, DEEP_WORK_SESSION_ID: 's-sweep' },
+      encoding: 'utf8',
+      timeout: 10000,
+    });
+
+    assert.equal(result.status, 0, `stderr: ${result.stderr}`);
+    assert.equal(fs.existsSync(stale), false,
+      'session-end.sh must sweep cache files older than the retention window');
+  });
+});

--- a/hooks/scripts/phase-guard-core.js
+++ b/hooks/scripts/phase-guard-core.js
@@ -130,40 +130,73 @@ function checkTddEnforcement(tddState, filePath, tddMode, exemptPatterns, tddOve
 
 // ─── Bash Command Detection ──────────────────────────────────
 
+// ─── Write-pattern building blocks (issue #75) ────────────────
+//
+// A redirect writes a file only when its target is a real path. `/dev/null`
+// discards output and `&1` duplicates a descriptor; neither creates anything,
+// so `ls > /dev/null` and `make check >/dev/null 2>&1` are read-only.
+const REDIRECT_TARGET = String.raw`\s*(?!/dev/null(?:\s|$)|&\d)\S+`;
+
+// `2>` names a file descriptor, so `cat f 2>/dev/null` is a read. The generic
+// entry below cannot match one because it demands a separator immediately
+// before the operator, and a digit is not a separator. The command-specific
+// entries need the rule spelled out: their `.*` used to swallow the fd digit,
+// which is what blocked `cat pkg.json 2>/dev/null | grep name`.
+const NOT_FD = String.raw`(?<![0-9])`;
+
+// A command name only counts when it sits in command position: at the head of
+// a fragment (splitCommands has already cut on | ; && ||), after env
+// assignments or a privilege/timing prefix, or at the head of a shell-wrapper
+// payload (`sh -c "…"`). Without this anchor a bare `\bmv\s+` matches English
+// prose inside a quoted argument — `gh issue create --body "…then mv on
+// L63-67"` was blocked as a file move, and `git commit -m "patch the bug"` as
+// a patch. The repetition is bounded to keep the alternation from backtracking
+// pathologically on hostile input.
+const CMD_HEAD = String.raw`(?:^|-c\s*["']?)\s*(?:(?:[\w.]+=\S*|sudo|command|time|timeout|env|nohup|exec|xargs|\d+[a-z]?)\s+){0,6}`;
+
+/** Builds a command-position-anchored write pattern. */
+const cmd = (body) => new RegExp(CMD_HEAD + body);
+
 /**
  * File-writing shell patterns that bypass Write/Edit tools.
  * Each pattern has a regex and a description.
  */
 const FILE_WRITE_PATTERNS = [
-  { pattern: /(?:^|[|;]|\s)(?:>{1,2})\s*\S+/, desc: 'output redirection (> or >>)' },
-  { pattern: /\btee\s+(?:-a\s+)?\S+/, desc: 'tee command' },
-  { pattern: /\bsed\s+-i/, desc: 'sed in-place edit' },
-  { pattern: /\bcp\s+/, desc: 'cp (file copy)' },
-  { pattern: /\bmv\s+/, desc: 'mv (file move)' },
-  { pattern: /\binstall\s+-/, desc: 'install command' },
-  { pattern: /\bdd\s+.*of=/, desc: 'dd with output file' },
-  { pattern: /\bcat\s+.*>\s*\S+/, desc: 'cat with redirect' },
-  { pattern: /\becho\s+.*>\s*\S+/, desc: 'echo with redirect' },
-  { pattern: /\bprintf\s+.*>\s*\S+/, desc: 'printf with redirect' },
-  { pattern: /\bpatch\s+/, desc: 'patch command' },
-  { pattern: /\bchmod\s+/, desc: 'chmod (permission change)' },
-  { pattern: /\bchown\s+/, desc: 'chown (ownership change)' },
-  { pattern: /\bperl\s+.*-[^\s]*i/, desc: 'perl in-place edit' },
-  { pattern: /\bnode\s+-e\s+.*(?:writeFile|appendFile|createWriteStream|fs\.)/, desc: 'node -e file system write' },
-  { pattern: /\bawk\s+.*-i\s+inplace\b/, desc: 'awk in-place edit' },
-  { pattern: /\bpython[23]?\s+-c\s+.*(?:open\s*\(|write|\.dump)/, desc: 'python -c file write' },
-  { pattern: /\bruby\s+-e\s+.*(?:File\.|IO\.|open\s*\()/, desc: 'ruby -e file write' },
-  { pattern: /\bswift\s+-e\s+.*(?:write|FileManager|contentsOf)/, desc: 'swift -e file write' },
-  { pattern: /\btruncate\s+/, desc: 'truncate command' },
-  { pattern: /\bsponge\s+/, desc: 'sponge (moreutils) write' },
-  { pattern: /\bgit\s+(push|reset\s+--hard|checkout\s+--\s|clean\s+-f)/, desc: 'destructive git operation' },
-  { pattern: /\bcurl\s+.*-[^\s]*o\s/, desc: 'curl output to file' },
-  { pattern: /\bwget\s+.*-[^\s]*O\s/, desc: 'wget output to file' },
-  { pattern: /\bln\s+(?:-[^\s]*\s+)*\S+\s+\S+/, desc: 'ln (link creation)' },
-  { pattern: /\btar\s+.*x/, desc: 'tar extract (file creation)' },
-  { pattern: /\bunzip\s+/, desc: 'unzip (file extraction)' },
-  { pattern: /\bcpio\s+/, desc: 'cpio archive extraction' },
-  { pattern: /\brsync\s+/, desc: 'rsync (file sync)' },
+  // Redirects are deliberately NOT command-anchored: the operator is what
+  // writes, wherever it appears — including inside `bash -c "echo x > f"`.
+  { pattern: new RegExp(String.raw`(?:^|[|;&]|\s)>{1,2}${REDIRECT_TARGET}`), desc: 'output redirection (> or >>)' },
+  { pattern: new RegExp(String.raw`\bcat\s+[^|;]*${NOT_FD}>{1,2}${REDIRECT_TARGET}`), desc: 'cat with redirect' },
+  { pattern: new RegExp(String.raw`\becho\s+[^|;]*${NOT_FD}>{1,2}${REDIRECT_TARGET}`), desc: 'echo with redirect' },
+  { pattern: new RegExp(String.raw`\bprintf\s+[^|;]*${NOT_FD}>{1,2}${REDIRECT_TARGET}`), desc: 'printf with redirect' },
+  { pattern: cmd(String.raw`tee\s+(?:-a\s+)?\S+`), desc: 'tee command' },
+  { pattern: cmd(String.raw`sed\s+-i`), desc: 'sed in-place edit' },
+  { pattern: cmd(String.raw`cp\s+`), desc: 'cp (file copy)' },
+  { pattern: cmd(String.raw`mv\s+`), desc: 'mv (file move)' },
+  { pattern: cmd(String.raw`install\s+-`), desc: 'install command' },
+  // `\binstall\s+-` used to catch package-manager installs as a side effect of
+  // matching anywhere. Command-anchoring would silently unblock them, which is
+  // outside what issue #75 asked for, so state them explicitly instead.
+  { pattern: cmd(String.raw`(?:npm|yarn|pnpm|bun)\s+(?:install|add)\b`), desc: 'package manager install' },
+  { pattern: cmd(String.raw`dd\s+.*of=`), desc: 'dd with output file' },
+  { pattern: cmd(String.raw`patch\s+`), desc: 'patch command' },
+  { pattern: cmd(String.raw`chmod\s+`), desc: 'chmod (permission change)' },
+  { pattern: cmd(String.raw`chown\s+`), desc: 'chown (ownership change)' },
+  { pattern: cmd(String.raw`perl\s+.*-[^\s]*i`), desc: 'perl in-place edit' },
+  { pattern: cmd(String.raw`node\s+-e\s+.*(?:writeFile|appendFile|createWriteStream|fs\.)`), desc: 'node -e file system write' },
+  { pattern: cmd(String.raw`awk\s+.*-i\s+inplace\b`), desc: 'awk in-place edit' },
+  { pattern: cmd(String.raw`python[23]?\s+-c\s+.*(?:open\s*\(|write|\.dump)`), desc: 'python -c file write' },
+  { pattern: cmd(String.raw`ruby\s+-e\s+.*(?:File\.|IO\.|open\s*\()`), desc: 'ruby -e file write' },
+  { pattern: cmd(String.raw`swift\s+-e\s+.*(?:write|FileManager|contentsOf)`), desc: 'swift -e file write' },
+  { pattern: cmd(String.raw`truncate\s+`), desc: 'truncate command' },
+  { pattern: cmd(String.raw`sponge\s+`), desc: 'sponge (moreutils) write' },
+  { pattern: cmd(String.raw`git\s+(push|reset\s+--hard|checkout\s+--\s|clean\s+-f)`), desc: 'destructive git operation' },
+  { pattern: cmd(String.raw`curl\s+.*-[^\s]*o\s`), desc: 'curl output to file' },
+  { pattern: cmd(String.raw`wget\s+.*-[^\s]*O\s`), desc: 'wget output to file' },
+  { pattern: cmd(String.raw`ln\s+(?:-[^\s]*\s+)*\S+\s+\S+`), desc: 'ln (link creation)' },
+  { pattern: cmd(String.raw`tar\s+.*x`), desc: 'tar extract (file creation)' },
+  { pattern: cmd(String.raw`unzip\s+`), desc: 'unzip (file extraction)' },
+  { pattern: cmd(String.raw`cpio\s+`), desc: 'cpio archive extraction' },
+  { pattern: cmd(String.raw`rsync\s+`), desc: 'rsync (file sync)' },
   { pattern: /\bwriteFile\b/, desc: 'Node.js writeFile API call' },
 ];
 

--- a/hooks/scripts/phase-guard-core.test.js
+++ b/hooks/scripts/phase-guard-core.test.js
@@ -868,3 +868,97 @@ describe('artifacts-only fork phase restriction', () => {
     assert.equal(result.decision, 'allow');
   });
 });
+
+// ─── FILE_WRITE_PATTERNS false positives / negatives (issue #75) ──────────
+//
+// The guard blocked ordinary read-only Bash during non-implement phases.
+// SAFE_COMMAND_PATTERNS cannot rescue these: detectBashFileWrite checks the
+// write patterns first and returns immediately.
+
+describe('detectBashFileWrite — fd-numbered redirects are not file writes (issue #75.1)', () => {
+  it('allows a stderr redirect to /dev/null on cat', () => {
+    assert.equal(detectBashFileWrite('cat pkg.json 2>/dev/null | grep name').isFileWrite, false);
+  });
+
+  it('allows a stderr redirect inside command substitution on echo', () => {
+    assert.equal(detectBashFileWrite('echo "n=$(ls a* 2>/dev/null | wc -l)"').isFileWrite, false);
+  });
+
+  it('allows a stderr redirect on printf', () => {
+    assert.equal(detectBashFileWrite('printf "%s" "$x" 2>/dev/null').isFileWrite, false);
+  });
+
+  it('allows an fd duplication', () => {
+    assert.equal(detectBashFileWrite('ls -la 2>&1 | head').isFileWrite, false);
+  });
+});
+
+describe('detectBashFileWrite — /dev/null is not a file write (issue #75.2)', () => {
+  it('allows discarding stdout to /dev/null', () => {
+    assert.equal(detectBashFileWrite('ls > /dev/null').isFileWrite, false);
+  });
+
+  it('allows discarding both streams to /dev/null', () => {
+    assert.equal(detectBashFileWrite('make check >/dev/null 2>&1').isFileWrite, false);
+  });
+});
+
+describe('detectBashFileWrite — command tokens in prose are not commands (issue #75.3)', () => {
+  it('allows an issue body that mentions mv in English prose', () => {
+    assert.equal(
+      detectBashFileWrite('gh issue create --body "atomic temp write then mv on L63-67"').isFileWrite,
+      false,
+    );
+  });
+
+  it('allows a commit message containing the word patch', () => {
+    assert.equal(detectBashFileWrite('git commit -m "patch the bug"').isFileWrite, false);
+  });
+
+  it('allows a commit message containing the word install', () => {
+    assert.equal(detectBashFileWrite('git commit -m "install the plugin first"').isFileWrite, false);
+  });
+
+  it('still blocks mv in command position', () => {
+    assert.equal(detectBashFileWrite('mv a.txt b.txt').isFileWrite, true);
+  });
+
+  it('still blocks mv after a privilege prefix', () => {
+    assert.equal(detectBashFileWrite('sudo mv a.txt b.txt').isFileWrite, true);
+  });
+
+  it('still blocks mv in a shell-wrapper payload', () => {
+    assert.equal(detectBashFileWrite('bash -c "mv a.txt b.txt"').isFileWrite, true);
+  });
+
+  it('still blocks cp after a chained safe command', () => {
+    assert.equal(detectBashFileWrite('npm test && cp a.txt b.txt').isFileWrite, true);
+  });
+});
+
+describe('detectBashFileWrite — ampersand redirect is a file write (issue #75.4)', () => {
+  it('blocks the both-streams redirect form', () => {
+    assert.equal(detectBashFileWrite('node app.js &> build.log').isFileWrite, true);
+  });
+
+  it('blocks the both-streams append form', () => {
+    assert.equal(detectBashFileWrite('node app.js &>> build.log').isFileWrite, true);
+  });
+});
+
+describe('detectBashFileWrite — real writes stay blocked (issue #75 regression guard)', () => {
+  const blocked = [
+    'echo hi > out.txt',
+    'echo hi>out.txt',
+    'echo hi >> out.txt',
+    'cat a.txt > b.txt',
+    'printf x > f',
+    'tee out.txt',
+    "sed -i 's/a/b/' f.txt",
+  ];
+  for (const cmd of blocked) {
+    it(`blocks: ${cmd}`, () => {
+      assert.equal(detectBashFileWrite(cmd).isFileWrite, true);
+    });
+  }
+});

--- a/hooks/scripts/phase-transition.sh
+++ b/hooks/scripts/phase-transition.sh
@@ -22,10 +22,19 @@ init_deep_work_state
 # $PPID 키로 캐시해 두고, 우리가 그 캐시 파일을 읽는다. 환경변수도
 # 혹시 미래 버전에서 설정될 가능성을 고려해 우선 확인한다.
 TOOL_INPUT="${CLAUDE_TOOL_USE_INPUT:-${CLAUDE_TOOL_INPUT:-}}"
-if [[ -z "$TOOL_INPUT" ]]; then
-  _HOOK_INPUT_CACHE="$PROJECT_ROOT/.claude/.hook-tool-input.${PPID}"
-  [[ -f "$_HOOK_INPUT_CACHE" ]] && TOOL_INPUT="$(cat "$_HOOK_INPUT_CACHE" 2>/dev/null || printf '')"
+_HOOK_INPUT_CACHE="$PROJECT_ROOT/.claude/.hook-tool-input.${PPID}"
+if [[ -z "$TOOL_INPUT" && -f "$_HOOK_INPUT_CACHE" ]]; then
+  TOOL_INPUT="$(cat "$_HOOK_INPUT_CACHE" 2>/dev/null || printf '')"
 fi
+# v7.2.1 (issue #74): we are the cache's only consumer, so the handoff is over
+# the moment the read above has had its chance — drop the file here, ahead of
+# every early exit below. This must NOT be conditional on having read it:
+# hook-shell-adapter.js passes the payload in CLAUDE_TOOL_INPUT, so on the
+# production path the branch above never runs and nothing else would ever
+# remove what file-tracker.sh just wrote. That is why the files piled up one
+# per tool call. $PPID stays as the key so two hook invocations racing inside
+# one session cannot read each other's payload.
+rm -f "$_HOOK_INPUT_CACHE" 2>/dev/null || true
 [[ -z "$TOOL_INPUT" ]] && exit 0
 
 # v6.9.4 (deep-review D-2): env 미설정(wrapper) 하네스 방어 — 받은 입력이

--- a/hooks/scripts/session-end.sh
+++ b/hooks/scripts/session-end.sh
@@ -421,9 +421,11 @@ append_session_history() {
 (append_session_history) 2>>"$PROJECT_ROOT/.claude/deep-work-guard-errors.log" || true
 
 # v6.2.4 post-review: cleanup stale PostToolUse stdin-cache files.
-# Remove our own PPID cache (no longer needed after session close) and any
-# orphaned .hook-tool-input.* files older than 60 minutes. Best-effort.
-rm -f "$PROJECT_ROOT/.claude/.hook-tool-input.$PPID" 2>/dev/null
+# v7.2.1 (issue #74): phase-transition.sh now deletes each cache as soon as the
+# handoff is done, so this sweep is only a backstop for invocations that died
+# between the write and the read. The former `rm -f …$PPID` line was dropped:
+# $PPID here is this Stop hook's own node bootstrap, never the PostToolUse one
+# that created a cache, so it could not match a real file. Best-effort.
 find "$PROJECT_ROOT/.claude" -maxdepth 1 -name '.hook-tool-input.*' -type f -mmin +60 -delete 2>/dev/null || true
 
 # v5.4: Update last_activity on CLI stop (do NOT unregister)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-deep-work/deep-work",
-  "version": "7.2.0",
+  "version": "7.2.1",
   "engines": {
     "node": ">=22"
   },

--- a/tests/integration/v6.4.0-smoke.test.js
+++ b/tests/integration/v6.4.0-smoke.test.js
@@ -211,8 +211,8 @@ describe('v6.4.0 integration — Health Engine command contracts', () => {
 });
 
 describe('release metadata', () => {
-  it('active release metadata is bumped to 7.2.0 with evergreen usage docs', () => {
-    const version = '7.2.0';
+  it('active release metadata is bumped to 7.2.1 with evergreen usage docs', () => {
+    const version = '7.2.1';
     const featureVersion = '6.9.0';
     const root = path.join(__dirname, '..', '..');
     const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
@@ -227,13 +227,27 @@ describe('release metadata', () => {
     assert.equal(claudePlugin.version, version);
     assert.equal(codexPlugin.version, version);
 
-    // Current release (7.2.0) — suite model-router shadow comparison.
+    // Current release (7.2.1) — hook cache lifecycle and guard false positives.
     const changelogCurrent = releaseSection(changelog, version);
     const changelogKoCurrent = releaseSection(changelogKo, version);
-    assert.match(changelogCurrent,/Model-router shadow comparison/);
-    assert.match(changelogKoCurrent,/Model-router 섀도 비교/);
-    assert.match(changelogCurrent,/Dispatch authority stays the existing CLI JSON/);
-    assert.match(changelogKoCurrent,/dispatch 권위는 기존 CLI JSON입니다/);
+    assert.match(changelogCurrent,/PostToolUse handoff cache no longer leaves one file per tool call/);
+    assert.match(changelogKoCurrent,/PostToolUse 핸드오프 캐시가 툴 호출마다 파일을 남기지 않는다/);
+    assert.match(changelogCurrent,/no longer blocks read-only Bash outside the Implement phase/);
+    assert.match(changelogKoCurrent,/Implement 외 단계에서 읽기 전용 Bash를 막지 않는다/);
+    assert.ok(changelogCurrent.includes('hooks/scripts/hook-input-cache-lifecycle.test.js'),
+      'CHANGELOG.md 7.2.1 section must cite the cache-lifecycle regression test');
+    assert.ok(changelogKoCurrent.includes('hooks/scripts/hook-input-cache-lifecycle.test.js'),
+      'CHANGELOG.ko.md 7.2.1 section must cite the cache-lifecycle regression test');
+    // The prior release (7.2.0) keeps its own model-router shadow headline; this
+    // patch release must not absorb it.
+    assert.match(releaseSection(changelog, '7.2.0'),/Model-router shadow comparison/);
+    assert.match(releaseSection(changelogKo, '7.2.0'),/Model-router 섀도 비교/);
+    assert.match(releaseSection(changelog, '7.2.0'),/Dispatch authority stays the existing CLI JSON/);
+    assert.match(releaseSection(changelogKo, '7.2.0'),/dispatch 권위는 기존 CLI JSON입니다/);
+    assert.equal(changelogCurrent.includes('Model-router shadow comparison'), false,
+      'CHANGELOG.md 7.2.1 section must not absorb the 7.2.0 model-router note');
+    assert.equal(changelogKoCurrent.includes('Model-router 섀도 비교'), false,
+      'CHANGELOG.ko.md 7.2.1 section must not absorb the 7.2.0 model-router note');
     assert.match(releaseSection(changelog, '7.1.5'),/Strict recovery evidence now fails closed across rollback and retry transitions/);
     assert.match(releaseSection(changelogKo, '7.1.5'),/Strict recovery evidence가 rollback·retry 전환에서 fail-closed로 동작합니다/);
     assert.match(releaseSection(changelog, '7.1.4'),/terminal reviewed no-go/);


### PR DESCRIPTION
Fixes two independent bugs reported in #74 and #75. Released as 7.2.1.

## #74 — PostToolUse handoff cache leaked one file per tool call

`file-tracker.sh` keys its stdin handoff on `$PPID`, which is the PID of the per-invocation node bootstrap, so the cache is effectively per tool call. Nothing consumed it either: `hook-shell-adapter.js` hands the payload to `phase-transition.sh` in `CLAUDE_TOOL_INPUT`, so the cache fallback branch never runs in production. The file was written on every Write/Edit/MultiEdit/Bash and never read — a busy hour left several hundred unredacted payload files (full Bash command lines, complete `file_path` + `content` of every Write) in the project working tree, with no ignore rule covering them.

This is why the fix is an **unconditional** delete rather than the delete-after-read the issue proposed: a conditional delete would sit in the branch that production never reaches.

- `phase-transition.sh` deletes the cache ahead of all its early exits.
- `$PPID` stays as the key. Re-keying on the session id (issue suggestion 1) would let two hook invocations racing inside one session read each other's payload.
- `session-end.sh` drops its `rm -f …$PPID` line — that `$PPID` is the Stop hook's own bootstrap, never the PostToolUse one that created a cache, so it could never match a file. The 60-minute sweep stays as a crash backstop.

## #75 — phase-guard blocked read-only Bash outside Implement

`SAFE_COMMAND_PATTERNS` cannot rescue these: `detectBashFileWrite` returns on the first write-pattern match.

| Defect | Example | Now |
|---|---|---|
| fd-numbered redirect | `cat pkg.json 2>/dev/null \| grep name` | passes |
| `/dev/null` target | `ls > /dev/null` | passes |
| command token in prose | `git commit -m "patch the bug"` | passes |
| missed `&>` form | `node app.js &> build.log` | blocked |

Command-name patterns now match only in **command position** — fragment head, after an env/privilege prefix, or inside a `sh -c` payload — so `bash -c "mv a b"` stays blocked. Redirect patterns are deliberately left unanchored, since the operator writes wherever it appears.

One out-of-scope behaviour change was deliberately prevented: `\binstall\s+-` was incidentally blocking `npm install -g` by matching anywhere. Anchoring would have silently unblocked it, so package-manager installs keep their previous handling through an explicit pattern. Whether to relax that is a separate decision.

## Verification

- The issue's own 12-case matrix: **5 failures → 0**.
- New `hooks/scripts/hook-input-cache-lifecycle.test.js` (5 tests). The accumulation test left 5 distinct PID-keyed files before the fix, 0 after.
- The #75 matrix is pinned in `hooks/scripts/phase-guard-core.test.js`.
- Adversarial input against the new patterns stays under 3 ms — no backtracking blowup.
- Full suite: **1915 pass, 0 fail** (17 pre-existing skips), unchanged from baseline.

## Known gap, not a regression

`cmd 2> err.log` is a real file write that still passes. It passed before this change too — it follows from allowing fd-numbered redirects, per the issue's proposal.

## Not included

The deep-suite marketplace pin (`npm run release:bump -- deep-work <sha40>`) is the post-merge suite-side step per `AGENTS.md` §Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQsFL5iHcmdHg4o3wVCNH1