### PR TITLE
fix: make redirect detection quote-aware in phase-guard

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deep-work",
-  "version": "7.2.1",
+  "version": "7.2.2",
   "description": "Evidence-Driven Development Protocol — 24 command-equivalent skill surfaces plus a skill-native deep-work entry alias (cross-platform: Claude Code skills + Codex / Copilot CLI / Gemini CLI / SDK), 3-layer architecture with Skill-based phase dispatch, computational enforcement (worktree guard + phase transition injection), TDD enforcement, and receipt validation",
   "author": {
     "name": "sungmin"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deep-work",
-  "version": "7.2.1",
+  "version": "7.2.2",
   "description": "Evidence-Driven Development Protocol with skill-based phase dispatch, computational enforcement, TDD discipline, and receipt validation",
   "author": {
     "name": "sungmin"

--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -7,6 +7,13 @@ Deep Work 플러그인의 모든 주요 변경 사항을 이 파일에 기록합
 형식은 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)를 따르며,
 이 프로젝트는 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)을 준수합니다.
 
+## [7.2.2] — 2026-08-18 (따옴표 인식 리다이렉트 판정)
+
+### Fixed
+
+- **`phase-guard`가 리다이렉트 문자를 양방향 모두 오판하지 않는다.** v7.2.1은 이슈 [#75](https://github.com/Sungmin-Cho/claude-deep-work/issues/75)가 나열한 사례를 닫았지만, 전제 하나가 두 가지 일을 겸하고 있었다 — 산문의 `->`가 매칭되지 않도록 `>` 앞에 구분자를 요구했고, 그 조건이 동시에 공백 없는 리다이렉트를 전부 놓치게 하면서 커밋 메시지 안의 `>=`는 여전히 쓰기로 읽었다. 이제 리다이렉트는 따옴표가 마스킹된 사본을 대상으로 매칭하므로 셸이 데이터로만 넘기는 텍스트는 아예 매칭될 수 없고, 산문이 구조적으로 처리되면서 구분자 요구는 제거됐다. 이 변경을 촉발한 19개 명령으로 측정: 놓치는 쓰기 8/12 → 0/12 (`git diff>patch.diff`, `cmd 2> err.log`, `make 2>build-errors.txt`가 이제 잡힌다), 오탐 3/7 → 0/7 (`git commit -m "require node >= 22"`, `echo "map: x => y"`가 이제 통과한다).
+- **셸이 실제로 실행하는 구간은 살아 있다.** `scanShellFragment`가 각 fragment를 한 번 훑으며 따옴표 리터럴을 지우되, 명령 치환과 `sh -c` 페이로드는 그 자체로 명령으로 남겨 깊이 제한 하에 재귀 분석한다. `bash -c "echo x > f"`와 `echo "$(cat x > f)"`는 계속 차단되고, 작은따옴표라 리터럴인 `echo '$(cat x > f)'`는 차단되지 않는다. 명령어 패턴은 원본 fragment를 계속 대상으로 삼아 `node -e "…writeFileSync…"`가 영향받지 않는다. 중복이 된 `cat`/`echo`/`printf` 전용 리다이렉트 항목은 제거했다. 커버리지는 `hooks/scripts/phase-guard-redirect-detection.test.js`에 있다.
+
 ## [7.2.1] — 2026-08-18 (훅 캐시 및 가드 오탐 수정)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable changes to the Deep Work plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.2.2] — 2026-08-18 (Quote-Aware Redirect Detection)
+
+### Fixed
+
+- **`phase-guard` no longer misreads redirect characters, in either direction.** v7.2.1 closed the cases issue [#75](https://github.com/Sungmin-Cho/claude-deep-work/issues/75) listed but left one precondition doing two jobs: the redirect pattern demanded a separator before `>` so that `->` in prose would not match, which also made every no-space redirect invisible and still let `>=` inside a commit message read as a write. Redirects are now matched against a quote-masked copy of the fragment, so text the shell only carries as data cannot match at all — and with prose handled structurally, the separator requirement is gone. Measured on the 19 commands that motivated the change: missed writes went 8/12 → 0/12 (`git diff>patch.diff`, `cmd 2> err.log`, `make 2>build-errors.txt` are now caught) and false positives 3/7 → 0/7 (`git commit -m "require node >= 22"`, `echo "map: x => y"` now pass).
+- **Spans the shell really executes stay live.** `scanShellFragment` walks each fragment once, blanking quoted literals while keeping command substitutions and `sh -c` payloads as commands in their own right, analysed recursively to a bounded depth. `bash -c "echo x > f"` and `echo "$(cat x > f)"` stay blocked; `echo '$(cat x > f)'`, single-quoted and therefore literal, does not. Command-name patterns keep matching the raw fragment so that `node -e "…writeFileSync…"` is unaffected. The per-command `cat`/`echo`/`printf` redirect entries were removed as redundant. Coverage lives in `hooks/scripts/phase-guard-redirect-detection.test.js`.
+
 ## [7.2.1] — 2026-08-18 (Hook Cache & Guard False-Positive Fixes)
 
 ### Fixed

--- a/hooks/scripts/phase-guard-core.js
+++ b/hooks/scripts/phase-guard-core.js
@@ -133,16 +133,142 @@ function checkTddEnforcement(tddState, filePath, tddMode, exemptPatterns, tddOve
 // ─── Write-pattern building blocks (issue #75) ────────────────
 //
 // A redirect writes a file only when its target is a real path. `/dev/null`
-// discards output and `&1` duplicates a descriptor; neither creates anything,
-// so `ls > /dev/null` and `make check >/dev/null 2>&1` are read-only.
-const REDIRECT_TARGET = String.raw`\s*(?!/dev/null(?:\s|$)|&\d)\S+`;
+// discards output, `&1` duplicates a descriptor, and `=` means the `>` was
+// part of `>=`; none of them create anything, so `ls > /dev/null` and
+// `make check >/dev/null 2>&1` are read-only.
+//
+// The operator may carry a leading fd digit (`2> err.log` does write a file),
+// and needs no separator before it (`git diff>patch.diff` writes one too).
+// What it must not do is match an arrow: `->` and `=>` are excluded by the
+// lookbehind. Prose is handled upstream — `scanShellFragment` blanks quoted
+// literals before this pattern ever sees them, which is what lets the
+// separator requirement go without `git commit -m "a > b"` matching.
+const REDIRECT_WRITE = /(?<![-=<>])\d?>{1,2}\s*(?!\/dev\/null(?:\s|$)|&\d|=)\S+/;
 
-// `2>` names a file descriptor, so `cat f 2>/dev/null` is a read. The generic
-// entry below cannot match one because it demands a separator immediately
-// before the operator, and a digit is not a separator. The command-specific
-// entries need the rule spelled out: their `.*` used to swallow the fd digit,
-// which is what blocked `cat pkg.json 2>/dev/null | grep name`.
-const NOT_FD = String.raw`(?<![0-9])`;
+// Placeholder for a character the shell will not interpret. Non-whitespace on
+// purpose: a quoted redirect target (`> "my file.txt"`) must still look like a
+// target to `\S+`, while a quoted `>` must not look like an operator.
+const INERT_CHAR = '\u0001';
+
+// How deep to follow nested command substitutions before giving up.
+const MAX_SHELL_NESTING = 3;
+
+/**
+ * Walks a command fragment once, separating text the shell executes from text
+ * it merely carries as data.
+ *
+ * @param {string} fragment - one command fragment from splitCommands
+ * @returns {{ masked: string, liveSpans: string[] }}
+ *   masked    - same-length copy with every inert character replaced by
+ *               INERT_CHAR, so offsets still line up
+ *   liveSpans - contents the shell runs as commands in their own right:
+ *               command substitutions and `sh -c` payloads. They are blanked
+ *               in `masked` and handed back for analysis as commands.
+ */
+function scanShellFragment(fragment) {
+  const out = fragment.split('');
+  const liveSpans = [];
+  const frames = [];
+  let singleQuoted = false;
+  let doubleQuoted = false;
+  let quoteOpenAt = -1;
+  let i = 0;
+
+  const blank = (idx) => { out[idx] = INERT_CHAR; };
+
+  // A quoted span that directly follows `-c` is a shell payload, not data.
+  const closeQuote = (contentStart, contentEnd) => {
+    const before = fragment.slice(0, quoteOpenAt).trimEnd();
+    if (before.endsWith('-c')) liveSpans.push(fragment.slice(contentStart, contentEnd));
+    quoteOpenAt = -1;
+  };
+
+  while (i < fragment.length) {
+    const ch = fragment[i];
+    const inSubstitution = frames.length > 0;
+
+    // A backslash escapes the next character everywhere except single quotes.
+    if (ch === '\\' && !singleQuoted && i + 1 < fragment.length) {
+      if (singleQuoted || doubleQuoted || inSubstitution) { blank(i); blank(i + 1); }
+      i += 2;
+      continue;
+    }
+
+    if (singleQuoted) {
+      blank(i);
+      if (ch === "'") {
+        singleQuoted = false;
+        if (!inSubstitution) closeQuote(quoteOpenAt + 1, i);
+      }
+      i++;
+      continue;
+    }
+
+    // `$(` opens a substitution even inside double quotes — the shell runs it.
+    if (ch === '$' && fragment[i + 1] === '(') {
+      frames.push({ kind: 'paren', contentStart: i + 2, singleQuoted, doubleQuoted });
+      blank(i); blank(i + 1);
+      singleQuoted = false;
+      doubleQuoted = false;
+      i += 2;
+      continue;
+    }
+
+    if (ch === ')' && frames.length > 0 && frames[frames.length - 1].kind === 'paren') {
+      const frame = frames.pop();
+      blank(i);
+      if (frames.length === 0) liveSpans.push(fragment.slice(frame.contentStart, i));
+      singleQuoted = frame.singleQuoted;
+      doubleQuoted = frame.doubleQuoted;
+      i++;
+      continue;
+    }
+
+    if (ch === '`') {
+      const top = frames[frames.length - 1];
+      if (top && top.kind === 'tick') {
+        frames.pop();
+        blank(i);
+        if (frames.length === 0) liveSpans.push(fragment.slice(top.contentStart, i));
+        singleQuoted = top.singleQuoted;
+        doubleQuoted = top.doubleQuoted;
+      } else {
+        frames.push({ kind: 'tick', contentStart: i + 1, singleQuoted, doubleQuoted });
+        blank(i);
+        singleQuoted = false;
+        doubleQuoted = false;
+      }
+      i++;
+      continue;
+    }
+
+    if (ch === "'" && !doubleQuoted) {
+      singleQuoted = true;
+      if (!inSubstitution) quoteOpenAt = i;
+      blank(i);
+      i++;
+      continue;
+    }
+
+    if (ch === '"') {
+      blank(i);
+      if (doubleQuoted) {
+        doubleQuoted = false;
+        if (!inSubstitution) closeQuote(quoteOpenAt + 1, i);
+      } else {
+        doubleQuoted = true;
+        if (!inSubstitution) quoteOpenAt = i;
+      }
+      i++;
+      continue;
+    }
+
+    if (doubleQuoted || inSubstitution) blank(i);
+    i++;
+  }
+
+  return { masked: out.join(''), liveSpans };
+}
 
 // A command name only counts when it sits in command position: at the head of
 // a fragment (splitCommands has already cut on | ; && ||), after env
@@ -162,12 +288,12 @@ const cmd = (body) => new RegExp(CMD_HEAD + body);
  * Each pattern has a regex and a description.
  */
 const FILE_WRITE_PATTERNS = [
-  // Redirects are deliberately NOT command-anchored: the operator is what
-  // writes, wherever it appears — including inside `bash -c "echo x > f"`.
-  { pattern: new RegExp(String.raw`(?:^|[|;&]|\s)>{1,2}${REDIRECT_TARGET}`), desc: 'output redirection (> or >>)' },
-  { pattern: new RegExp(String.raw`\bcat\s+[^|;]*${NOT_FD}>{1,2}${REDIRECT_TARGET}`), desc: 'cat with redirect' },
-  { pattern: new RegExp(String.raw`\becho\s+[^|;]*${NOT_FD}>{1,2}${REDIRECT_TARGET}`), desc: 'echo with redirect' },
-  { pattern: new RegExp(String.raw`\bprintf\s+[^|;]*${NOT_FD}>{1,2}${REDIRECT_TARGET}`), desc: 'printf with redirect' },
+  // Redirects are NOT in this list: they are matched by detectRedirectWrite
+  // against the quote-masked fragment, because the operator is a character the
+  // shell interprets rather than a command name, and prose is full of `>`.
+  // The per-command `cat`/`echo`/`printf` redirect entries are gone with them —
+  // they existed only to catch the no-space form, which the generic redirect
+  // pattern now handles for every command.
   { pattern: cmd(String.raw`tee\s+(?:-a\s+)?\S+`), desc: 'tee command' },
   { pattern: cmd(String.raw`sed\s+-i`), desc: 'sed in-place edit' },
   { pattern: cmd(String.raw`cp\s+`), desc: 'cp (file copy)' },
@@ -478,6 +604,39 @@ function splitCommands(command) {
  * @param {string} command - The bash command string
  * @returns {{ isFileWrite: boolean, pattern?: string }}
  */
+/**
+ * Decides whether one command fragment writes a file, following the spans the
+ * shell actually executes.
+ *
+ * Redirects are matched against the quote-masked fragment so that `>` inside a
+ * commit message or issue body is inert. Command-name patterns keep matching
+ * the raw fragment, because several of them deliberately inspect a quoted
+ * argument — `node -e "…writeFileSync…"` would vanish under masking.
+ *
+ * @param {string} fragment - a single command fragment
+ * @param {number} depth - current substitution nesting level
+ * @returns {string|null} the matched pattern description, or null
+ */
+function matchFileWrite(fragment, depth) {
+  const { masked, liveSpans } = scanShellFragment(fragment);
+
+  if (REDIRECT_WRITE.test(masked)) return 'output redirection (> or >>)';
+
+  for (const { pattern, desc } of FILE_WRITE_PATTERNS) {
+    if (pattern.test(fragment)) return desc;
+  }
+
+  if (depth >= MAX_SHELL_NESTING) return null;
+  for (const span of liveSpans) {
+    for (const inner of splitCommands(span)) {
+      const nested = matchFileWrite(inner, depth + 1);
+      if (nested) return nested;
+    }
+  }
+
+  return null;
+}
+
 function detectBashFileWrite(command) {
   if (!command || typeof command !== 'string') {
     return { isFileWrite: false };
@@ -487,13 +646,7 @@ function detectBashFileWrite(command) {
 
   for (const sub of subCommands) {
     // Check file-write patterns FIRST (security-critical)
-    let writeMatch = null;
-    for (const { pattern, desc } of FILE_WRITE_PATTERNS) {
-      if (pattern.test(sub)) {
-        writeMatch = desc;
-        break;
-      }
-    }
+    let writeMatch = matchFileWrite(sub, 0);
 
     // If file-write detected, return immediately (safe patterns cannot override)
     if (writeMatch) {

--- a/hooks/scripts/phase-guard-redirect-detection.test.js
+++ b/hooks/scripts/phase-guard-redirect-detection.test.js
@@ -1,0 +1,82 @@
+// Quote-aware redirect detection.
+//
+// v7.2.1 fixed the reported #75 cases but left the redirect family leaking in
+// both directions, because one precondition served two jobs: the generic
+// pattern demanded a separator immediately before `>` so that `->` in prose
+// would not match. That same demand made every no-space redirect invisible
+// (`git diff>patch.diff`) and, since prose lives in the raw string, `>=` and
+// `=>` inside a commit message still read as writes.
+//
+// Splitting the two jobs resolves the tension: quoted literals are masked out
+// before redirect matching (so prose cannot match at all), which in turn makes
+// the separator demand unnecessary (so no-space and fd-numbered redirects are
+// caught). Spans the shell really executes — command substitutions and
+// `sh -c` payloads — stay live and are analysed as commands.
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { detectBashFileWrite } = require('./phase-guard-core.js');
+
+const blocks = (cmd) => assert.equal(detectBashFileWrite(cmd).isFileWrite, true, `must block: ${cmd}`);
+const allows = (cmd) => assert.equal(detectBashFileWrite(cmd).isFileWrite, false, `must allow: ${cmd}`);
+
+describe('redirect detection — no-space redirects are writes', () => {
+  const cases = [
+    'node app.js>out.log',
+    'python gen.py>result.txt',
+    'git diff>patch.diff',
+    'jq . in.json>out.json',
+    'curl https://example.com/a>a.html',
+    'echo hi>out.txt',
+    'node app.js>>out.log',
+  ];
+  for (const cmd of cases) {
+    it(`blocks: ${cmd}`, () => blocks(cmd));
+  }
+});
+
+describe('redirect detection — fd-numbered redirects to a real file are writes', () => {
+  it('blocks a stderr redirect to a named file', () => blocks('cmd 2> err.log'));
+  it('blocks a stderr append to a named file', () => blocks('node app.js 2>> err.log'));
+  it('blocks a no-space stderr redirect', () => blocks('make 2>build-errors.txt'));
+});
+
+describe('redirect detection — discards and fd duplication stay read-only', () => {
+  it('allows stdout discard', () => allows('ls > /dev/null'));
+  it('allows both-stream discard', () => allows('make check >/dev/null 2>&1'));
+  it('allows fd duplication', () => allows('ls -la 2>&1 | head'));
+  it('allows stderr discard on cat', () => allows('cat pkg.json 2>/dev/null | grep name'));
+  it('allows a redirect to stderr', () => allows('printf oops >&2'));
+});
+
+describe('redirect detection — redirect characters inside prose are inert', () => {
+  it('allows a comparison in a commit message', () => allows('git commit -m "a > b 순서로 정렬"'));
+  it('allows a version constraint in a commit message', () => allows('git commit -m "require node >= 22"'));
+  it('allows a fat arrow in an echoed string', () => allows('echo "map: x => y"'));
+  it('allows an arrow in an issue body', () => allows('gh issue create --body "foo -> bar 로 바뀐다"'));
+  it('allows an arrow inside a search pattern', () => allows('grep -n "a->b" src/*.c'));
+  it('allows a redirect character quoted as documentation', () => allows('git commit -m "use cmd > file to save"'));
+});
+
+describe('redirect detection — spans the shell executes stay live', () => {
+  it('blocks a redirect inside a shell wrapper payload', () => blocks('bash -c "echo x > f"'));
+  it('blocks a redirect inside a single-quoted shell wrapper payload', () => blocks("sh -c 'echo x > f'"));
+  it('blocks a redirect inside a command substitution', () => blocks('echo "$(cat x > f)"'));
+  it('blocks a redirect inside a backtick substitution', () => blocks('echo `cat x > f`'));
+  it('allows a substitution that only discards', () => allows('echo "n=$(ls a* 2>/dev/null | wc -l)"'));
+  it('allows a substitution spelled literally in single quotes', () => allows("echo '$(cat x > f)'"));
+});
+
+describe('redirect detection — 7.2.1 behaviour is preserved', () => {
+  it('still blocks a spaced redirect', () => blocks('echo x > f'));
+  it('still blocks an append', () => blocks('echo hi >> out.txt'));
+  it('still blocks the both-streams form', () => blocks('node app.js &> build.log'));
+  it('still blocks cat into a file', () => blocks('cat a.txt > b.txt'));
+  it('still allows a plain pipe', () => allows('grep -rn foo . | head -20'));
+  it('still allows prose naming a command token', () =>
+    allows('gh issue create --body "atomic temp write then mv on L63-67"'));
+  it('still blocks mv in command position', () => blocks('mv a.txt b.txt'));
+  it('still blocks mv in a wrapper payload', () => blocks('bash -c "mv a b"'));
+  it('still blocks an interpreter write in a quoted argument', () =>
+    blocks('node -e "require(\'fs\').writeFileSync(\'f\',\'x\')"'));
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-deep-work/deep-work",
-  "version": "7.2.1",
+  "version": "7.2.2",
   "engines": {
     "node": ">=22"
   },

--- a/tests/integration/v6.4.0-smoke.test.js
+++ b/tests/integration/v6.4.0-smoke.test.js
@@ -211,8 +211,8 @@ describe('v6.4.0 integration — Health Engine command contracts', () => {
 });
 
 describe('release metadata', () => {
-  it('active release metadata is bumped to 7.2.1 with evergreen usage docs', () => {
-    const version = '7.2.1';
+  it('active release metadata is bumped to 7.2.2 with evergreen usage docs', () => {
+    const version = '7.2.2';
     const featureVersion = '6.9.0';
     const root = path.join(__dirname, '..', '..');
     const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
@@ -227,17 +227,29 @@ describe('release metadata', () => {
     assert.equal(claudePlugin.version, version);
     assert.equal(codexPlugin.version, version);
 
-    // Current release (7.2.1) — hook cache lifecycle and guard false positives.
+    // Current release (7.2.2) — quote-aware redirect detection.
     const changelogCurrent = releaseSection(changelog, version);
     const changelogKoCurrent = releaseSection(changelogKo, version);
-    assert.match(changelogCurrent,/PostToolUse handoff cache no longer leaves one file per tool call/);
-    assert.match(changelogKoCurrent,/PostToolUse 핸드오프 캐시가 툴 호출마다 파일을 남기지 않는다/);
-    assert.match(changelogCurrent,/no longer blocks read-only Bash outside the Implement phase/);
-    assert.match(changelogKoCurrent,/Implement 외 단계에서 읽기 전용 Bash를 막지 않는다/);
-    assert.ok(changelogCurrent.includes('hooks/scripts/hook-input-cache-lifecycle.test.js'),
-      'CHANGELOG.md 7.2.1 section must cite the cache-lifecycle regression test');
-    assert.ok(changelogKoCurrent.includes('hooks/scripts/hook-input-cache-lifecycle.test.js'),
-      'CHANGELOG.ko.md 7.2.1 section must cite the cache-lifecycle regression test');
+    assert.match(changelogCurrent,/no longer misreads redirect characters, in either direction/);
+    assert.match(changelogKoCurrent,/리다이렉트 문자를 양방향 모두 오판하지 않는다/);
+    assert.match(changelogCurrent,/Spans the shell really executes stay live/);
+    assert.match(changelogKoCurrent,/셸이 실제로 실행하는 구간은 살아 있다/);
+    assert.ok(changelogCurrent.includes('hooks/scripts/phase-guard-redirect-detection.test.js'),
+      'CHANGELOG.md 7.2.2 section must cite the redirect-detection regression test');
+    assert.ok(changelogKoCurrent.includes('hooks/scripts/phase-guard-redirect-detection.test.js'),
+      'CHANGELOG.ko.md 7.2.2 section must cite the redirect-detection regression test');
+    // The prior release (7.2.1) keeps its own hook-cache headline; this patch
+    // release must not absorb it.
+    assert.match(releaseSection(changelog, '7.2.1'),/PostToolUse handoff cache no longer leaves one file per tool call/);
+    assert.match(releaseSection(changelogKo, '7.2.1'),/PostToolUse 핸드오프 캐시가 툴 호출마다 파일을 남기지 않는다/);
+    assert.ok(releaseSection(changelog, '7.2.1').includes('hooks/scripts/hook-input-cache-lifecycle.test.js'),
+      'CHANGELOG.md 7.2.1 section must retain the cache-lifecycle regression test');
+    assert.ok(releaseSection(changelogKo, '7.2.1').includes('hooks/scripts/hook-input-cache-lifecycle.test.js'),
+      'CHANGELOG.ko.md 7.2.1 section must retain the cache-lifecycle regression test');
+    assert.equal(changelogCurrent.includes('PostToolUse handoff cache'), false,
+      'CHANGELOG.md 7.2.2 section must not absorb the 7.2.1 hook-cache note');
+    assert.equal(changelogKoCurrent.includes('PostToolUse 핸드오프 캐시'), false,
+      'CHANGELOG.ko.md 7.2.2 section must not absorb the 7.2.1 hook-cache note');
     // The prior release (7.2.0) keeps its own model-router shadow headline; this
     // patch release must not absorb it.
     assert.match(releaseSection(changelog, '7.2.0'),/Model-router shadow comparison/);


### PR DESCRIPTION
Follow-up to #76. Released as 7.2.2.

## Why this exists

v7.2.1 closed the exact cases issue #75 listed. Measuring the redirect family afterwards showed it was still leaking **in both directions**, because one precondition was doing two jobs: the generic pattern demanded a separator immediately before `>` so that `->` in prose would not match. That same demand made every no-space redirect invisible, and since prose lives in the raw string, `>=` and `=>` inside a commit message still read as writes.

Measured over the 19 commands that motivated the change:

| | before | after |
|---|---|---|
| missed writes | 8/12 | **0/12** |
| false positives | 3/7 | **0/7** |

Newly caught: `git diff>patch.diff`, `node app.js>out.log`, `jq . in.json>out.json`, `cmd 2> err.log`, `make 2>build-errors.txt`.
Newly allowed: `git commit -m "require node >= 22"`, `git commit -m "a > b 순서로 정렬"`, `echo "map: x => y"`.

## Approach

Patching the regex further would only move the error from one side to the other — the two directions pull against each other under a single pattern. Splitting the two jobs resolves it:

- `scanShellFragment` walks each fragment once and blanks the spans the shell only carries as data. Redirects match against that quote-masked copy, so prose cannot match at all — which in turn makes the separator requirement unnecessary, so no-space and fd-numbered redirects are caught.
- Spans the shell **really executes** stay live: command substitutions and `sh -c` payloads are handed back as commands and analysed recursively to a bounded depth. `bash -c "echo x > f"` and `echo "$(cat x > f)"` stay blocked; `echo '$(cat x > f)'` is single-quoted and therefore literal, so it does not.
- Command-name patterns keep matching the raw fragment. Several deliberately inspect a quoted argument — `node -e "…writeFileSync…"` would vanish under masking. Their command-position anchoring from 7.2.1 is unchanged.
- The per-command `cat`/`echo`/`printf` redirect entries are removed as redundant: they existed only to catch the no-space form, which the generic pattern now handles for every command.

## Scope

This is **protocol discipline, not a security boundary.** Command-string inspection is always bypassable via `eval`, variable indirection, or `$(printf '\076')`. Chasing that would buy nothing and cost false positives, which is the failure mode #75 was filed about.

## Verification

- New `hooks/scripts/phase-guard-redirect-detection.test.js` — 36 tests covering both directions plus the live/inert span distinction. 14 failed before the change.
- Guard suites (`phase-guard-core`, `phase-guard-hardening`, denylist, golden fixtures, `file-tracker-fixes`): 253 pass, 0 fail.
- Full suite: **1951 pass, 0 fail** (17 pre-existing skips), up from 1915 with the 36 new tests.
- Adversarial input (unbalanced quotes, 400-deep substitutions, 20 KB no-space write, 5000 arrows) stays under 4 ms — the scanner is a single O(n) pass and recursion is depth-bounded.

## Not included

The deep-suite marketplace pin is the post-merge suite-side step per `AGENTS.md` §Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQsFL5iHcmdHg4o3wVCNH1