### PR TITLE
fix: record slice model from the current receipt contract

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deep-work",
-  "version": "7.2.2",
+  "version": "7.2.3",
   "description": "Evidence-Driven Development Protocol — 24 command-equivalent skill surfaces plus a skill-native deep-work entry alias (cross-platform: Claude Code skills + Codex / Copilot CLI / Gemini CLI / SDK), 3-layer architecture with Skill-based phase dispatch, computational enforcement (worktree guard + phase transition injection), TDD enforcement, and receipt validation",
   "author": {
     "name": "sungmin"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deep-work",
-  "version": "7.2.2",
+  "version": "7.2.3",
   "description": "Evidence-Driven Development Protocol with skill-based phase dispatch, computational enforcement, TDD discipline, and receipt validation",
   "author": {
     "name": "sungmin"

--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -7,6 +7,12 @@ Deep Work 플러그인의 모든 주요 변경 사항을 이 파일에 기록합
 형식은 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)를 따르며,
 이 프로젝트는 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)을 준수합니다.
 
+## [7.2.3] — 2026-08-20 (세션 종료 모델 추출)
+
+### Fixed
+
+- **envelope 시대 slice receipt의 모델이 세션 기록에 저장됩니다.** session-end.sh가 먼저 harness_metadata.model_id를 읽고 legacy top-level model_used로 fallback하며, 회귀 테스트는 hooks/scripts/session-end-model-extract.test.js에 있습니다.
+
 ## [7.2.2] — 2026-08-18 (따옴표 인식 리다이렉트 판정)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to the Deep Work plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.2.3] — 2026-08-20 (Session-End Model Extraction)
+
+### Fixed
+
+- **Session history now records the model for envelope-era slice receipts.** session-end.sh reads harness_metadata.model_id first and falls back to legacy top-level model_used; regression coverage lives in hooks/scripts/session-end-model-extract.test.js.
+
 ## [7.2.2] — 2026-08-18 (Quote-Aware Redirect Detection)
 
 ### Fixed

--- a/hooks/scripts/session-end-model-extract.test.js
+++ b/hooks/scripts/session-end-model-extract.test.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const FIXTURE = path.join(__dirname, '..', '..', 'tests', 'fixtures',
+  'sample-slice-receipt.json');
+const SCRIPT = path.join(__dirname, 'session-end.sh');
+
+function runSession(receipt) {
+  const project = fs.mkdtempSync(path.join(os.tmpdir(), 'session-end-model-'));
+  const sid = 'model-extract-test';
+  const receipts = path.join(project, '.deep-work', 'test', 'receipts');
+  fs.mkdirSync(path.join(project, '.git'));
+  fs.mkdirSync(path.join(project, '.claude'));
+  fs.mkdirSync(receipts, { recursive: true });
+  fs.writeFileSync(path.join(project, '.claude', 'deep-work.' + sid + '.md'), [
+    '---',
+    'current_phase: implement',
+    'work_dir: .deep-work/test',
+    'started_at: 2026-08-20T00:00:00.000Z',
+    'tdd_mode: strict',
+    'test_retry_count: 0',
+    '---',
+    '',
+  ].join('\n'));
+  fs.writeFileSync(path.join(project, '.claude', 'deep-work-current-session'), sid);
+  fs.writeFileSync(path.join(receipts, 'SLICE-001.json'), JSON.stringify(receipt) + '\n');
+
+  try {
+    const result = spawnSync('bash', [SCRIPT], {
+      cwd: project,
+      env: { ...process.env, DEEP_WORK_SESSION_ID: sid },
+      encoding: 'utf8',
+      timeout: 10000,
+    });
+    assert.equal(result.error, undefined, result.error && result.error.message);
+    assert.equal(result.status, 0, 'session-end.sh failed: ' + result.stderr);
+    const history = path.join(project, '.deep-work', 'harness-history',
+      'harness-sessions.jsonl');
+    assert.ok(fs.existsSync(history), 'history was not written: ' + result.stderr);
+    const lines = fs.readFileSync(history, 'utf8').trim().split('\n');
+    return JSON.parse(lines[lines.length - 1]);
+  } finally {
+    fs.rmSync(project, { recursive: true, force: true });
+  }
+}
+
+test('session-end records the current envelope model_id', () => {
+  const fixture = JSON.parse(fs.readFileSync(FIXTURE, 'utf8'));
+  const history = runSession(fixture);
+  assert.equal(history.slices[0].model, 'claude-sonnet-4-5');
+});
+
+test('session-end falls back to legacy top-level model_used', () => {
+  const history = runSession({
+    slice_id: 'SLICE-001',
+    status: 'complete',
+    tdd_mode: 'strict',
+    model_used: 'legacy-haiku',
+  });
+  assert.equal(history.slices[0].model, 'legacy-haiku');
+});
+
+test('session-end prefers model_id when both model fields exist', () => {
+  const history = runSession({
+    slice_id: 'SLICE-001',
+    status: 'complete',
+    tdd_mode: 'strict',
+    model_id: 'current-sonnet',
+    model_used: 'legacy-haiku',
+  });
+  assert.equal(history.slices[0].model, 'current-sonnet');
+});

--- a/hooks/scripts/session-end.sh
+++ b/hooks/scripts/session-end.sh
@@ -276,7 +276,7 @@ append_session_history() {
       # Per-field grep extraction below works on either shape because
       # envelope keys (producer, producer_version, artifact_kind, run_id,
       # generated_at, schema, git, provenance) do not collide with payload
-      # keys (slice_id, status, tdd_mode, model_used, etc.).
+      # keys (slice_id, status, tdd_mode, harness_metadata.model_id, etc.).
       if grep -q '"envelope"[[:space:]]*:' "$receipt_file" 2>/dev/null \
          && grep -q '"schema_version"[[:space:]]*:[[:space:]]*"1\.0"' "$receipt_file" 2>/dev/null; then
         # Envelope-shaped — verify producer + artifact_kind + schema.name.
@@ -297,7 +297,13 @@ append_session_history() {
       slice_id=$(grep -o '"slice_id"[[:space:]]*:[[:space:]]*"[^"]*"' "$receipt_file" 2>/dev/null | head -1 | sed 's/.*:.*"\([^"]*\)".*/\1/' || echo "")
       slice_status=$(grep -o '"status"[[:space:]]*:[[:space:]]*"[^"]*"' "$receipt_file" 2>/dev/null | head -1 | sed 's/.*:.*"\([^"]*\)".*/\1/' || echo "")
       slice_tdd_mode=$(grep -o '"tdd_mode"[[:space:]]*:[[:space:]]*"[^"]*"' "$receipt_file" 2>/dev/null | head -1 | sed 's/.*:.*"\([^"]*\)".*/\1/' || echo "")
-      slice_model=$(grep -o '"model_used"[[:space:]]*:[[:space:]]*"[^"]*"' "$receipt_file" 2>/dev/null | head -1 | sed 's/.*:.*"\([^"]*\)".*/\1/' || echo "")
+      # harness_metadata.model_id is the current receipt contract
+      # (agents/implement-slice-worker.md); top-level "model_used" survives
+      # only in legacy pre-envelope receipts (receipt-migration.js).
+      slice_model=$(grep -o '"model_id"[[:space:]]*:[[:space:]]*"[^"]*"' "$receipt_file" 2>/dev/null | head -1 | sed 's/.*:.*"\([^"]*\)".*/\1/' || echo "")
+      if [[ -z "$slice_model" ]]; then
+        slice_model=$(grep -o '"model_used"[[:space:]]*:[[:space:]]*"[^"]*"' "$receipt_file" 2>/dev/null | head -1 | sed 's/.*:.*"\([^"]*\)".*/\1/' || echo "")
+      fi
 
       # harness_metadata fields (may not exist in older receipts)
       local hm_block

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deep-work/deep-work",
-  "version": "7.2.2",
+  "version": "7.2.3",
   "engines": {
     "node": ">=22"
   },

--- a/tests/integration/v6.4.0-smoke.test.js
+++ b/tests/integration/v6.4.0-smoke.test.js
@@ -211,8 +211,8 @@ describe('v6.4.0 integration — Health Engine command contracts', () => {
 });
 
 describe('release metadata', () => {
-  it('active release metadata is bumped to 7.2.2 with evergreen usage docs', () => {
-    const version = '7.2.2';
+  it('active release metadata is bumped to 7.2.3 with evergreen usage docs', () => {
+    const version = '7.2.3';
     const featureVersion = '6.9.0';
     const root = path.join(__dirname, '..', '..');
     const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
@@ -227,17 +227,15 @@ describe('release metadata', () => {
     assert.equal(claudePlugin.version, version);
     assert.equal(codexPlugin.version, version);
 
-    // Current release (7.2.2) — quote-aware redirect detection.
+    // Current release (7.2.3) — session-end model extraction.
     const changelogCurrent = releaseSection(changelog, version);
     const changelogKoCurrent = releaseSection(changelogKo, version);
-    assert.match(changelogCurrent,/no longer misreads redirect characters, in either direction/);
-    assert.match(changelogKoCurrent,/리다이렉트 문자를 양방향 모두 오판하지 않는다/);
-    assert.match(changelogCurrent,/Spans the shell really executes stay live/);
-    assert.match(changelogKoCurrent,/셸이 실제로 실행하는 구간은 살아 있다/);
-    assert.ok(changelogCurrent.includes('hooks/scripts/phase-guard-redirect-detection.test.js'),
-      'CHANGELOG.md 7.2.2 section must cite the redirect-detection regression test');
-    assert.ok(changelogKoCurrent.includes('hooks/scripts/phase-guard-redirect-detection.test.js'),
-      'CHANGELOG.ko.md 7.2.2 section must cite the redirect-detection regression test');
+    assert.match(changelogCurrent,/session-end/);
+    assert.match(changelogKoCurrent,/session-end/);
+    assert.ok(changelogCurrent.includes('hooks/scripts/session-end-model-extract.test.js'),
+      'CHANGELOG.md 7.2.3 section must cite the model-extraction regression test');
+    assert.ok(changelogKoCurrent.includes('hooks/scripts/session-end-model-extract.test.js'),
+      'CHANGELOG.ko.md 7.2.3 section must cite the model-extraction regression test');
     // The prior release (7.2.1) keeps its own hook-cache headline; this patch
     // release must not absorb it.
     assert.match(releaseSection(changelog, '7.2.1'),/PostToolUse handoff cache no longer leaves one file per tool call/);
@@ -247,9 +245,9 @@ describe('release metadata', () => {
     assert.ok(releaseSection(changelogKo, '7.2.1').includes('hooks/scripts/hook-input-cache-lifecycle.test.js'),
       'CHANGELOG.ko.md 7.2.1 section must retain the cache-lifecycle regression test');
     assert.equal(changelogCurrent.includes('PostToolUse handoff cache'), false,
-      'CHANGELOG.md 7.2.2 section must not absorb the 7.2.1 hook-cache note');
+      'CHANGELOG.md 7.2.3 section must not absorb the 7.2.1 hook-cache note');
     assert.equal(changelogKoCurrent.includes('PostToolUse 핸드오프 캐시'), false,
-      'CHANGELOG.ko.md 7.2.2 section must not absorb the 7.2.1 hook-cache note');
+      'CHANGELOG.ko.md 7.2.3 section must not absorb the 7.2.1 hook-cache note');
     // The prior release (7.2.0) keeps its own model-router shadow headline; this
     // patch release must not absorb it.
     assert.match(releaseSection(changelog, '7.2.0'),/Model-router shadow comparison/);


### PR DESCRIPTION
## Summary

- read `payload.harness_metadata.model_id` when session-end records slice history
- retain top-level `model_used` as the legacy pre-envelope fallback
- exercise the real Stop-hook history path for current, legacy-only, and both-field receipts
- release the fix as deep-work 7.2.3 with version triple-sync and bilingual changelogs

## Validation

- `PATH=/opt/homebrew/opt/node@22/bin:$PATH npm run test:all`
  - 1,910 passed, 0 failed, 35 skipped
- `node --test hooks/scripts/session-end-model-extract.test.js`
  - 3 passed, covering current envelope, legacy fallback, and current-key precedence
- temporary old-code mutation
  - current-envelope and both-field cases failed as expected; legacy-only remained green
- `claude plugin validate .`
  - passed with the two existing informational warnings
- `git diff --check`

## Model routing and review

- implementation: `gpt-5.6-luna`, medium effort
- independent GPT-only review: `gpt-5.6-terra`, high effort
- final review verdict: `PASS` (confidence 0.99)

The merge-following deep-suite marketplace pin update remains a separate suite-side step.
